### PR TITLE
Add PyTorch & FlashInfer as community project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       drifted: ${{ steps.sync.outputs.drifted }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check skill directories in source repos
         id: sync
@@ -40,6 +40,8 @@ jobs:
             "Nemotron Voice Agent|NVIDIA-AI-Blueprints/nemotron-voice-agent|main|.agents/skills|1"
             "NeMo Gym|NVIDIA-NeMo/Gym|main|.claude/skills|1"
             "NeMo Evaluator|NVIDIA-NeMo/Evaluator|main|packages/nemo-evaluator-launcher/.claude/skills+packages/nemo-evaluator/.claude/skills|4"
+            "PyTorch|pytorch/pytorch|main|.claude/skills|12"
+            "FlashInfer|flashinfer-ai/flashinfer|main|.claude/skills|3"
           )
 
           REPORT="## Skill Catalog Sync Report\n\n"
@@ -104,7 +106,7 @@ jobs:
 
       - name: Upload sync artifacts
         if: steps.sync.outputs.drifted == '1'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sync-data
           path: |
@@ -124,10 +126,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download sync artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: sync-data
           path: /tmp
@@ -152,7 +154,7 @@ jobs:
           git diff README.md
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "fix: update skill counts to match source repos"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ That's it — the skill activates automatically the next time your agent encount
 
 ---
 
+## Community Projects with NVIDIA Contribution
+
+The following open-source projects are not maintained by NVIDIA but include agent skills with active contributions from NVIDIA engineering teams.
+
+| Project | Description | Skills | Skills Location |
+|---------|-------------|:------:|-----------------|
+| **PyTorch** | Deep learning framework — code contribution, debugging, type coverage, issue triage, kernel development, and documentation. | 12 | [`pytorch/pytorch/.claude/skills/`](https://github.com/pytorch/pytorch/tree/main/.claude/skills) |
+| **FlashInfer** | GPU kernel library for LLM serving — CUDA kernel development, benchmarking, and crash debugging. | 3 | [`flashinfer-ai/flashinfer/.claude/skills/`](https://github.com/flashinfer-ai/flashinfer/tree/main/.claude/skills) |
+
+---
+
 ## Getting Help & Contributing
 
 For skill-related issues, feature requests, new skill ideas, discussions, and contributions — use the source repo for the relevant product:


### PR DESCRIPTION
- Add PyTorch (12 skills) and FlashInfer (3 skills) to CI sync check as community projects with active NVIDIA contribution
- Add "Community Projects with NVIDIA Contribution" section to README


Wondering what your thought are on this @mosheabr? These are public open-source repos but we have active NVIDIA engineers & PMs contributing to them. 