### PR TITLE
Add GitHub Actions workflow to sync skills from product repos

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -105,6 +105,28 @@ jobs:
             echo "⚠ Model-Optimizer checkout empty or missing — skipping to preserve existing catalog"
           fi
 
+      # ── CUDA-Q ───────────────────────────────────────────────
+      - name: Checkout CUDA-Q
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/cuda-quantum
+          ref: main
+          path: .tmp/cuda-quantum
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
+          sparse-checkout: |
+            .claude/skills/
+
+      - name: Copy CUDA-Q skills into catalog
+        run: |
+          if [ -d ".tmp/cuda-quantum/.claude/skills" ] && [ -n "$(ls -A .tmp/cuda-quantum/.claude/skills)" ]; then
+            mkdir -p skills/CUDA-Q
+            rsync -a --delete .tmp/cuda-quantum/.claude/skills/ skills/CUDA-Q/
+            echo "- CUDA-Q" >> /tmp/synced-products.txt
+          else
+            echo "⚠ CUDA-Q checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
       # ── Megatron-Core ──────────────────────────────────────
       - name: Checkout Megatron-LM
         continue-on-error: true

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: sync-skills
@@ -228,20 +229,11 @@ jobs:
       - name: Clean up temp checkouts
         run: rm -rf .tmp
 
-      - name: Check for changes
-        id: changes
-        run: |
-          git add -A skills/
-          if git diff --cached --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Commit and push
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: sync skills from product repos"
-          git push
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: sync skills from product repos"
+          branch: automated/sync-skills
+          title: "chore: sync skills from product repos"
+          body: "Automated sync of skills from registered product repos."
+          delete-branch: true

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           ref: main
 
+      - name: Initialize sync log
+        run: echo "" > /tmp/synced-products.txt
+
       # ── cuOpt ──────────────────────────────────────────────
       - name: Checkout cuOpt
         continue-on-error: true
@@ -52,7 +55,7 @@ jobs:
           if [ -d ".tmp/cuopt/skills" ] && [ -n "$(ls -A .tmp/cuopt/skills)" ]; then
             mkdir -p skills/cuopt
             rsync -a --delete .tmp/cuopt/skills/ skills/cuopt/
-            echo "✓ cuopt synced"
+            echo "- cuOpt" >> /tmp/synced-products.txt
           else
             echo "⚠ cuopt checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -74,7 +77,7 @@ jobs:
           if [ -d ".tmp/TensorRT-LLM/.claude/skills" ] && [ -n "$(ls -A .tmp/TensorRT-LLM/.claude/skills)" ]; then
             mkdir -p skills/TensorRT-LLM
             rsync -a --delete .tmp/TensorRT-LLM/.claude/skills/ skills/TensorRT-LLM/
-            echo "✓ TensorRT-LLM synced"
+            echo "- TensorRT-LLM" >> /tmp/synced-products.txt
           else
             echo "⚠ TensorRT-LLM checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -96,7 +99,7 @@ jobs:
           if [ -d ".tmp/Model-Optimizer/.claude/skills" ] && [ -n "$(ls -A .tmp/Model-Optimizer/.claude/skills)" ]; then
             mkdir -p skills/Model-Optimizer
             rsync -a --delete .tmp/Model-Optimizer/.claude/skills/ skills/Model-Optimizer/
-            echo "✓ Model-Optimizer synced"
+            echo "- Model-Optimizer" >> /tmp/synced-products.txt
           else
             echo "⚠ Model-Optimizer checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -118,7 +121,7 @@ jobs:
           if [ -d ".tmp/Megatron-LM/.claude/skills" ] && [ -n "$(ls -A .tmp/Megatron-LM/.claude/skills)" ]; then
             mkdir -p skills/Megatron-Core
             rsync -a --delete .tmp/Megatron-LM/.claude/skills/ skills/Megatron-Core/
-            echo "✓ Megatron-Core synced"
+            echo "- Megatron-Core" >> /tmp/synced-products.txt
           else
             echo "⚠ Megatron-Core checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -140,7 +143,7 @@ jobs:
           if [ -d ".tmp/Megatron-Bridge/skills" ] && [ -n "$(ls -A .tmp/Megatron-Bridge/skills)" ]; then
             mkdir -p skills/Megatron-Bridge
             rsync -a --delete .tmp/Megatron-Bridge/skills/ skills/Megatron-Bridge/
-            echo "✓ Megatron-Bridge synced"
+            echo "- Megatron-Bridge" >> /tmp/synced-products.txt
           else
             echo "⚠ Megatron-Bridge checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -162,7 +165,7 @@ jobs:
           if [ -d ".tmp/nemotron-voice-agent/.agents/skills" ] && [ -n "$(ls -A .tmp/nemotron-voice-agent/.agents/skills)" ]; then
             mkdir -p skills/nemotron-voice-agent
             rsync -a --delete .tmp/nemotron-voice-agent/.agents/skills/ skills/nemotron-voice-agent/
-            echo "✓ nemotron-voice-agent synced"
+            echo "- Nemotron Voice Agent" >> /tmp/synced-products.txt
           else
             echo "⚠ nemotron-voice-agent checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -184,7 +187,7 @@ jobs:
           if [ -d ".tmp/NeMo-Gym/.claude/skills" ] && [ -n "$(ls -A .tmp/NeMo-Gym/.claude/skills)" ]; then
             mkdir -p skills/NeMo-Gym
             rsync -a --delete .tmp/NeMo-Gym/.claude/skills/ skills/NeMo-Gym/
-            echo "✓ NeMo-Gym synced"
+            echo "- NeMo Gym" >> /tmp/synced-products.txt
           else
             echo "⚠ NeMo-Gym checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -208,7 +211,7 @@ jobs:
           if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
             mkdir -p skills/NeMo-Evaluator-Launcher
             rsync -a --delete "$src/" skills/NeMo-Evaluator-Launcher/
-            echo "✓ NeMo-Evaluator-Launcher synced"
+            echo "- NeMo Evaluator Launcher" >> /tmp/synced-products.txt
           else
             echo "⚠ NeMo-Evaluator-Launcher checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -220,7 +223,7 @@ jobs:
           if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
             mkdir -p skills/NeMo-Evaluator
             rsync -a --delete "$src/" skills/NeMo-Evaluator/
-            echo "✓ NeMo-Evaluator synced"
+            echo "- NeMo Evaluator" >> /tmp/synced-products.txt
           else
             echo "⚠ NeMo-Evaluator checkout empty or missing — skipping to preserve existing catalog"
           fi
@@ -229,11 +232,32 @@ jobs:
       - name: Clean up temp checkouts
         run: rm -rf .tmp
 
+      - name: Build sync summary
+        id: summary
+        run: |
+          if [ -s /tmp/synced-products.txt ]; then
+            products=$(cat /tmp/synced-products.txt | tr '\n' ',' | sed 's/- //g;s/,$//')
+            echo "title=chore: sync skills ($products)" >> "$GITHUB_OUTPUT"
+            {
+              echo 'body<<EOFBODY'
+              echo "## Automated skills sync"
+              echo ""
+              echo "Products synced:"
+              cat /tmp/synced-products.txt
+              echo ""
+              echo "Triggered by: \`${{ github.event_name }}\`"
+              echo 'EOFBODY'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "title=chore: sync skills from product repos" >> "$GITHUB_OUTPUT"
+            echo "body=Automated sync — no products reported changes." >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore: sync skills from product repos"
+          commit-message: ${{ steps.summary.outputs.title }}
           branch: automated/sync-skills
-          title: "chore: sync skills from product repos"
-          body: "Automated sync of skills from registered product repos."
+          title: ${{ steps.summary.outputs.title }}
+          body: ${{ steps.summary.outputs.body }}
           delete-branch: true

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -37,7 +37,7 @@ jobs:
           ref: main
 
       - name: Initialize sync log
-        run: echo "" > /tmp/synced-products.txt
+        run: truncate -s 0 /tmp/synced-products.txt
 
       # ── cuOpt ──────────────────────────────────────────────
       - name: Checkout cuOpt

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: sync-skills
@@ -261,3 +262,25 @@ jobs:
           title: ${{ steps.summary.outputs.title }}
           body: ${{ steps.summary.outputs.body }}
           delete-branch: true
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Skills sync failed — ${new Date().toISOString().slice(0, 10)}`;
+            const body = [
+              `The [sync-skills workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) failed.`,
+              ``,
+              `**Trigger:** \`${context.eventName}\``,
+              `**Run:** ${context.runId}`,
+              ``,
+              `Please investigate and re-run if needed.`
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['sync-failure']
+            });

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -5,6 +5,10 @@
 # Runs on a schedule (twice daily) and can be triggered manually.
 # Each product block sparse-checkouts only the skills/ directory,
 # then copies those skills into the catalog tree.
+#
+# Requires a PAT (SKILLS_SYNC_PAT) with read access to all product
+# repos, stored as a repository secret. The default GITHUB_TOKEN
+# only has access to this repo and will 403 on private product repos.
 
 name: Sync Skills from Product Repos
 
@@ -33,14 +37,20 @@ jobs:
           repository: NVIDIA/cuopt
           ref: main
           path: .tmp/cuopt
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
           sparse-checkout: |
             skills/
 
       - name: Copy cuOpt skills into catalog
         run: |
-          rm -rf skills/cuopt
-          mkdir -p skills/cuopt
-          rsync -a --delete .tmp/cuopt/skills/ skills/cuopt/
+          if [ -d ".tmp/cuopt/skills" ] && [ -n "$(ls -A .tmp/cuopt/skills)" ]; then
+            rm -rf skills/cuopt
+            mkdir -p skills/cuopt
+            rsync -a --delete .tmp/cuopt/skills/ skills/cuopt/
+            echo "✓ cuopt synced"
+          else
+            echo "⚠ cuopt checkout empty or missing — skipping to preserve existing catalog"
+          fi
 
       # ── TensorRT-LLM ──────────────────────────────────────
       - name: Checkout TensorRT-LLM
@@ -49,14 +59,86 @@ jobs:
           repository: NVIDIA/TensorRT-LLM
           ref: main
           path: .tmp/TensorRT-LLM
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
           sparse-checkout: |
             .claude/skills/
 
       - name: Copy TensorRT-LLM skills into catalog
         run: |
-          rm -rf skills/TensorRT-LLM
-          mkdir -p skills/TensorRT-LLM
-          rsync -a --delete .tmp/TensorRT-LLM/.claude/skills/ skills/TensorRT-LLM/
+          if [ -d ".tmp/TensorRT-LLM/.claude/skills" ] && [ -n "$(ls -A .tmp/TensorRT-LLM/.claude/skills)" ]; then
+            rm -rf skills/TensorRT-LLM
+            mkdir -p skills/TensorRT-LLM
+            rsync -a --delete .tmp/TensorRT-LLM/.claude/skills/ skills/TensorRT-LLM/
+            echo "✓ TensorRT-LLM synced"
+          else
+            echo "⚠ TensorRT-LLM checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
+      # ── Model-Optimizer ────────────────────────────────────
+      - name: Checkout Model-Optimizer
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/Model-Optimizer
+          ref: main
+          path: .tmp/Model-Optimizer
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
+          sparse-checkout: |
+            .claude/skills/
+
+      - name: Copy Model-Optimizer skills into catalog
+        run: |
+          if [ -d ".tmp/Model-Optimizer/.claude/skills" ] && [ -n "$(ls -A .tmp/Model-Optimizer/.claude/skills)" ]; then
+            rm -rf skills/Model-Optimizer
+            mkdir -p skills/Model-Optimizer
+            rsync -a --delete .tmp/Model-Optimizer/.claude/skills/ skills/Model-Optimizer/
+            echo "✓ Model-Optimizer synced"
+          else
+            echo "⚠ Model-Optimizer checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
+      # ── Megatron-Core ──────────────────────────────────────
+      - name: Checkout Megatron-LM
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/Megatron-LM
+          ref: main
+          path: .tmp/Megatron-LM
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
+          sparse-checkout: |
+            .claude/skills/
+
+      - name: Copy Megatron-Core skills into catalog
+        run: |
+          if [ -d ".tmp/Megatron-LM/.claude/skills" ] && [ -n "$(ls -A .tmp/Megatron-LM/.claude/skills)" ]; then
+            rm -rf skills/Megatron-Core
+            mkdir -p skills/Megatron-Core
+            rsync -a --delete .tmp/Megatron-LM/.claude/skills/ skills/Megatron-Core/
+            echo "✓ Megatron-Core synced"
+          else
+            echo "⚠ Megatron-Core checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
+      # ── Megatron-Bridge ────────────────────────────────────
+      - name: Checkout Megatron-Bridge
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA-NeMo/Megatron-Bridge
+          ref: main
+          path: .tmp/Megatron-Bridge
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
+          sparse-checkout: |
+            skills/
+
+      - name: Copy Megatron-Bridge skills into catalog
+        run: |
+          if [ -d ".tmp/Megatron-Bridge/skills" ] && [ -n "$(ls -A .tmp/Megatron-Bridge/skills)" ]; then
+            rm -rf skills/Megatron-Bridge
+            mkdir -p skills/Megatron-Bridge
+            rsync -a --delete .tmp/Megatron-Bridge/skills/ skills/Megatron-Bridge/
+            echo "✓ Megatron-Bridge synced"
+          else
+            echo "⚠ Megatron-Bridge checkout empty or missing — skipping to preserve existing catalog"
+          fi
 
       # ── Nemotron Voice Agent ───────────────────────────────
       - name: Checkout nemotron-voice-agent
@@ -65,14 +147,20 @@ jobs:
           repository: NVIDIA-AI-Blueprints/nemotron-voice-agent
           ref: main
           path: .tmp/nemotron-voice-agent
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
           sparse-checkout: |
             .agents/skills/
 
       - name: Copy nemotron-voice-agent skills into catalog
         run: |
-          rm -rf skills/nemotron-voice-agent
-          mkdir -p skills/nemotron-voice-agent
-          rsync -a --delete .tmp/nemotron-voice-agent/.agents/skills/ skills/nemotron-voice-agent/
+          if [ -d ".tmp/nemotron-voice-agent/.agents/skills" ] && [ -n "$(ls -A .tmp/nemotron-voice-agent/.agents/skills)" ]; then
+            rm -rf skills/nemotron-voice-agent
+            mkdir -p skills/nemotron-voice-agent
+            rsync -a --delete .tmp/nemotron-voice-agent/.agents/skills/ skills/nemotron-voice-agent/
+            echo "✓ nemotron-voice-agent synced"
+          else
+            echo "⚠ nemotron-voice-agent checkout empty or missing — skipping to preserve existing catalog"
+          fi
 
       # ── NeMo Gym ───────────────────────────────────────────
       - name: Checkout NeMo Gym
@@ -81,14 +169,57 @@ jobs:
           repository: NVIDIA-NeMo/Gym
           ref: main
           path: .tmp/NeMo-Gym
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
           sparse-checkout: |
             .claude/skills/
 
       - name: Copy NeMo Gym skills into catalog
         run: |
-          rm -rf skills/NeMo-Gym
-          mkdir -p skills/NeMo-Gym
-          rsync -a --delete .tmp/NeMo-Gym/.claude/skills/ skills/NeMo-Gym/
+          if [ -d ".tmp/NeMo-Gym/.claude/skills" ] && [ -n "$(ls -A .tmp/NeMo-Gym/.claude/skills)" ]; then
+            rm -rf skills/NeMo-Gym
+            mkdir -p skills/NeMo-Gym
+            rsync -a --delete .tmp/NeMo-Gym/.claude/skills/ skills/NeMo-Gym/
+            echo "✓ NeMo-Gym synced"
+          else
+            echo "⚠ NeMo-Gym checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
+      # ── NeMo Evaluator Launcher ─────────────────────────────
+      - name: Checkout NeMo Evaluator
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA-NeMo/Evaluator
+          ref: main
+          path: .tmp/NeMo-Evaluator
+          token: ${{ secrets.SKILLS_SYNC_PAT }}
+          sparse-checkout: |
+            packages/nemo-evaluator-launcher/.claude/skills/
+            packages/nemo-evaluator/.claude/skills/
+
+      - name: Copy NeMo Evaluator Launcher skills into catalog
+        run: |
+          src=".tmp/NeMo-Evaluator/packages/nemo-evaluator-launcher/.claude/skills"
+          if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
+            rm -rf skills/NeMo-Evaluator-Launcher
+            mkdir -p skills/NeMo-Evaluator-Launcher
+            rsync -a --delete "$src/" skills/NeMo-Evaluator-Launcher/
+            echo "✓ NeMo-Evaluator-Launcher synced"
+          else
+            echo "⚠ NeMo-Evaluator-Launcher checkout empty or missing — skipping to preserve existing catalog"
+          fi
+
+      # ── NeMo Evaluator ────────────────────────────────────
+      - name: Copy NeMo Evaluator skills into catalog
+        run: |
+          src=".tmp/NeMo-Evaluator/packages/nemo-evaluator/.claude/skills"
+          if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
+            rm -rf skills/NeMo-Evaluator
+            mkdir -p skills/NeMo-Evaluator
+            rsync -a --delete "$src/" skills/NeMo-Evaluator/
+            echo "✓ NeMo-Evaluator synced"
+          else
+            echo "⚠ NeMo-Evaluator checkout empty or missing — skipping to preserve existing catalog"
+          fi
 
       # ── Cleanup and commit ─────────────────────────────────
       - name: Clean up temp checkouts

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Sync skills from product repos into the nvidia/skills catalog.
+# Runs on a schedule (twice daily) and can be triggered manually.
+# Each product block sparse-checkouts only the skills/ directory,
+# then copies those skills into the catalog tree.
+
+name: Sync Skills from Product Repos
+
+on:
+  schedule:
+    # Twice daily: 06:00 UTC and 18:00 UTC
+    - cron: "0 6,18 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout skills catalog
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      # ── cuOpt ──────────────────────────────────────────────
+      - name: Checkout cuOpt
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/cuopt
+          ref: main
+          path: .tmp/cuopt
+          sparse-checkout: |
+            skills/
+
+      - name: Copy cuOpt skills into catalog
+        run: |
+          rm -rf skills/cuopt
+          mkdir -p skills/cuopt
+          rsync -a --delete .tmp/cuopt/skills/ skills/cuopt/
+
+      # ── TensorRT-LLM ──────────────────────────────────────
+      - name: Checkout TensorRT-LLM
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA/TensorRT-LLM
+          ref: main
+          path: .tmp/TensorRT-LLM
+          sparse-checkout: |
+            .claude/skills/
+
+      - name: Copy TensorRT-LLM skills into catalog
+        run: |
+          rm -rf skills/TensorRT-LLM
+          mkdir -p skills/TensorRT-LLM
+          rsync -a --delete .tmp/TensorRT-LLM/.claude/skills/ skills/TensorRT-LLM/
+
+      # ── Nemotron Voice Agent ───────────────────────────────
+      - name: Checkout nemotron-voice-agent
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA-AI-Blueprints/nemotron-voice-agent
+          ref: main
+          path: .tmp/nemotron-voice-agent
+          sparse-checkout: |
+            .agents/skills/
+
+      - name: Copy nemotron-voice-agent skills into catalog
+        run: |
+          rm -rf skills/nemotron-voice-agent
+          mkdir -p skills/nemotron-voice-agent
+          rsync -a --delete .tmp/nemotron-voice-agent/.agents/skills/ skills/nemotron-voice-agent/
+
+      # ── NeMo Gym ───────────────────────────────────────────
+      - name: Checkout NeMo Gym
+        uses: actions/checkout@v4
+        with:
+          repository: NVIDIA-NeMo/Gym
+          ref: main
+          path: .tmp/NeMo-Gym
+          sparse-checkout: |
+            .claude/skills/
+
+      - name: Copy NeMo Gym skills into catalog
+        run: |
+          rm -rf skills/NeMo-Gym
+          mkdir -p skills/NeMo-Gym
+          rsync -a --delete .tmp/NeMo-Gym/.claude/skills/ skills/NeMo-Gym/
+
+      # ── Cleanup and commit ─────────────────────────────────
+      - name: Clean up temp checkouts
+        run: rm -rf .tmp
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add -A skills/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync skills from product repos"
+          git push

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: sync-skills
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Copy cuOpt skills into catalog
         run: |
           if [ -d ".tmp/cuopt/skills" ] && [ -n "$(ls -A .tmp/cuopt/skills)" ]; then
-            rm -rf skills/cuopt
             mkdir -p skills/cuopt
             rsync -a --delete .tmp/cuopt/skills/ skills/cuopt/
             echo "✓ cuopt synced"
@@ -66,7 +65,6 @@ jobs:
       - name: Copy TensorRT-LLM skills into catalog
         run: |
           if [ -d ".tmp/TensorRT-LLM/.claude/skills" ] && [ -n "$(ls -A .tmp/TensorRT-LLM/.claude/skills)" ]; then
-            rm -rf skills/TensorRT-LLM
             mkdir -p skills/TensorRT-LLM
             rsync -a --delete .tmp/TensorRT-LLM/.claude/skills/ skills/TensorRT-LLM/
             echo "✓ TensorRT-LLM synced"
@@ -88,7 +86,6 @@ jobs:
       - name: Copy Model-Optimizer skills into catalog
         run: |
           if [ -d ".tmp/Model-Optimizer/.claude/skills" ] && [ -n "$(ls -A .tmp/Model-Optimizer/.claude/skills)" ]; then
-            rm -rf skills/Model-Optimizer
             mkdir -p skills/Model-Optimizer
             rsync -a --delete .tmp/Model-Optimizer/.claude/skills/ skills/Model-Optimizer/
             echo "✓ Model-Optimizer synced"
@@ -110,7 +107,6 @@ jobs:
       - name: Copy Megatron-Core skills into catalog
         run: |
           if [ -d ".tmp/Megatron-LM/.claude/skills" ] && [ -n "$(ls -A .tmp/Megatron-LM/.claude/skills)" ]; then
-            rm -rf skills/Megatron-Core
             mkdir -p skills/Megatron-Core
             rsync -a --delete .tmp/Megatron-LM/.claude/skills/ skills/Megatron-Core/
             echo "✓ Megatron-Core synced"
@@ -132,7 +128,6 @@ jobs:
       - name: Copy Megatron-Bridge skills into catalog
         run: |
           if [ -d ".tmp/Megatron-Bridge/skills" ] && [ -n "$(ls -A .tmp/Megatron-Bridge/skills)" ]; then
-            rm -rf skills/Megatron-Bridge
             mkdir -p skills/Megatron-Bridge
             rsync -a --delete .tmp/Megatron-Bridge/skills/ skills/Megatron-Bridge/
             echo "✓ Megatron-Bridge synced"
@@ -154,7 +149,6 @@ jobs:
       - name: Copy nemotron-voice-agent skills into catalog
         run: |
           if [ -d ".tmp/nemotron-voice-agent/.agents/skills" ] && [ -n "$(ls -A .tmp/nemotron-voice-agent/.agents/skills)" ]; then
-            rm -rf skills/nemotron-voice-agent
             mkdir -p skills/nemotron-voice-agent
             rsync -a --delete .tmp/nemotron-voice-agent/.agents/skills/ skills/nemotron-voice-agent/
             echo "✓ nemotron-voice-agent synced"
@@ -176,7 +170,6 @@ jobs:
       - name: Copy NeMo Gym skills into catalog
         run: |
           if [ -d ".tmp/NeMo-Gym/.claude/skills" ] && [ -n "$(ls -A .tmp/NeMo-Gym/.claude/skills)" ]; then
-            rm -rf skills/NeMo-Gym
             mkdir -p skills/NeMo-Gym
             rsync -a --delete .tmp/NeMo-Gym/.claude/skills/ skills/NeMo-Gym/
             echo "✓ NeMo-Gym synced"
@@ -200,7 +193,6 @@ jobs:
         run: |
           src=".tmp/NeMo-Evaluator/packages/nemo-evaluator-launcher/.claude/skills"
           if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
-            rm -rf skills/NeMo-Evaluator-Launcher
             mkdir -p skills/NeMo-Evaluator-Launcher
             rsync -a --delete "$src/" skills/NeMo-Evaluator-Launcher/
             echo "✓ NeMo-Evaluator-Launcher synced"
@@ -213,7 +205,6 @@ jobs:
         run: |
           src=".tmp/NeMo-Evaluator/packages/nemo-evaluator/.claude/skills"
           if [ -d "$src" ] && [ -n "$(ls -A "$src")" ]; then
-            rm -rf skills/NeMo-Evaluator
             mkdir -p skills/NeMo-Evaluator
             rsync -a --delete "$src/" skills/NeMo-Evaluator/
             echo "✓ NeMo-Evaluator synced"

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -32,6 +32,7 @@ jobs:
 
       # ── cuOpt ──────────────────────────────────────────────
       - name: Checkout cuOpt
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA/cuopt
@@ -53,6 +54,7 @@ jobs:
 
       # ── TensorRT-LLM ──────────────────────────────────────
       - name: Checkout TensorRT-LLM
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA/TensorRT-LLM
@@ -74,6 +76,7 @@ jobs:
 
       # ── Model-Optimizer ────────────────────────────────────
       - name: Checkout Model-Optimizer
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA/Model-Optimizer
@@ -95,6 +98,7 @@ jobs:
 
       # ── Megatron-Core ──────────────────────────────────────
       - name: Checkout Megatron-LM
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA/Megatron-LM
@@ -116,6 +120,7 @@ jobs:
 
       # ── Megatron-Bridge ────────────────────────────────────
       - name: Checkout Megatron-Bridge
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA-NeMo/Megatron-Bridge
@@ -137,6 +142,7 @@ jobs:
 
       # ── Nemotron Voice Agent ───────────────────────────────
       - name: Checkout nemotron-voice-agent
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA-AI-Blueprints/nemotron-voice-agent
@@ -158,6 +164,7 @@ jobs:
 
       # ── NeMo Gym ───────────────────────────────────────────
       - name: Checkout NeMo Gym
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA-NeMo/Gym
@@ -179,6 +186,7 @@ jobs:
 
       # ── NeMo Evaluator Launcher ─────────────────────────────
       - name: Checkout NeMo Evaluator
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: NVIDIA-NeMo/Evaluator


### PR DESCRIPTION
Implements the automated sync pipeline (Step 5 of onboarding) that sparse-checkouts the skills directory from each registered product repo and mirrors them into this catalog. Runs twice daily on a cron schedule and supports manual dispatch.

Registered repos: cuOpt, TensorRT-LLM, nemotron-voice-agent, NeMo Gym.