### PR TITLE
Fix silent total failure in sync-skills workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -255,6 +255,13 @@ jobs:
       - name: Clean up temp checkouts
         run: rm -rf .tmp
 
+      - name: Fail if nothing synced
+        run: |
+          if [ ! -s /tmp/synced-products.txt ]; then
+            echo "::error::All product checkouts failed — no skills were synced"
+            exit 1
+          fi
+
       - name: Build sync summary
         id: summary
         run: |


### PR DESCRIPTION
## Summary
- When all product checkouts fail (e.g. missing `SKILLS_SYNC_PAT`), `continue-on-error: true` masks the failures and the job reports success
- The `if: failure()` gate on the issue-creation step never triggers, so nobody gets notified
- Adds an explicit check: if `/tmp/synced-products.txt` is empty after all sync steps, fail the job so the existing issue-creation step fires

## Test plan
- [ ] Trigger `sync-skills` workflow manually without `SKILLS_SYNC_PAT` configured — verify a GitHub issue is created
- [ ] Trigger with valid PAT — verify normal PR creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)