### PR TITLE
Add TileGym to the NVIDIA Agent Skills catalog

### DIFF
--- a/components.d/tilegym.yml
+++ b/components.d/tilegym.yml
@@ -1,0 +1,8 @@
+name: TileGym
+repo: NVIDIA/TileGym
+description: Tile-based GPU programming — adding new kernels, cross-framework conversion, and performance optimization.
+skills:
+  - path: .agents/skills/
+    catalog_dir: TileGym
+links:
+  discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/tilegym.yml` for [NVIDIA/TileGym](https://github.com/NVIDIA/TileGym))

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Dual (Apache 2.0 + CC-BY 4.0)
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org** (`NVIDIA/TileGym`)
- [x] `.agents/skills/` path used (TileGym is on the canonical layout; `.claude/skills` is a symlink → `../.agents/skills`)

## What this PR adds

`components.d/tilegym.yml` registering `NVIDIA/TileGym` for catalog sync under the new components.d schema. TileGym ships 6 skills under `.agents/skills/`:

- `adding-cutile-kernel` — guides adding a new cuTile kernel op to TileGym
- `converting-cutile-to-julia` — port a cuTile Python kernel to Julia
- `converting-cutile-to-triton` — port a cuTile kernel to Triton
- `cutile-python` — author and orchestrate cuTile Python kernels
- `improve-cutile-kernel-perf` — iteratively optimize cuTile kernel performance
- `monkey-patch-kernels-to-transformers` — integrate TileGym kernels into HuggingFace Transformers

`links.discussions: false` — TileGym has Issues but no Discussions tab. [CONTRIBUTING.md](https://github.com/NVIDIA/TileGym/blob/main/CONTRIBUTING.md) and [SECURITY.md](https://github.com/NVIDIA/TileGym/blob/main/SECURITY.md) are present at default paths.

The commit history of this branch was rebased to the new schema: a merge commit drops the obsolete `components.yml`/`README.md` edits (both superseded — `components.yml` is gone, README.md is now auto-generated), and a follow-up commit adds the single `components.d/tilegym.yml` entry.

## All PRs

- [x] All commits signed off with DCO (`Signed-off-by: Hannah Li <hanli@nvidia.com>`)
