### PR TITLE
Add pull request template for onboarding PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
+
+## Onboarding type
+
+- [ ] New product onboarding (`components.yml` entry)
+- [ ] Other (catalog change, README fix, infrastructure, etc.)
+
+## For new product onboarding — author affirmations
+
+By submitting this PR, I confirm on behalf of my team:
+
+- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
+- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
+- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
+- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
+- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.yml`)
+
+> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.
+
+## Reviewer checklist (OSS Skills PIC)
+
+- [ ] Author confirmations above are checked
+- [ ] `components.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo)
+- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
+- [ ] README rows added (Available Skills + Getting Help & Contributing)
+- [ ] No new license or third-party dependency requiring OSRB filing
+
+## Other context (for non-onboarding PRs)
+
+<!-- Brief description of the change -->


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md` so future onboarding PRs auto-populate with author affirmations + reviewer checklist.

Encodes the IP-review-upstream model from Step 3 of the internal onboarding guide:

- Author confirms IP review completed (six-question check), license selected, and that no new license / 3rd-party component is being introduced
- Reviewer (OSS Skills PIC) verifies the affirmations + the standard catalog checks (components.yml validity, path exists, SKILL.md spec compliance, README updates)

## Why now

PR #30 (NemoClaw, Miyoung Choi) introduced this pattern organically in the PR description without a template existing. Miyoung's structure is the gold standard and now becomes the default for everyone.

## Public-safe

Template references \"NVIDIA's internal IP review process\" by name only — no internal Confluence URLs. NVIDIA contributors find process details in the internal onboarding guide; external readers see a clean OSS contribution flow.

## Test plan

- [ ] Confirm the template renders correctly in the GitHub UI when a new PR is opened against this repo
- [ ] Confirm checkboxes are interactive and the headings render as expected

## Onboarding self-affirmation (IP-review-upstream model)

Not a new product onboarding — meta-PR adding the template itself. No source-repo changes, no new license, no new third-party content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)