### PR TITLE
Update CONTRIBUTING.md + PR template for DCO and path standardization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,11 @@ By submitting this PR, I confirm on behalf of my team:
 - [ ] README rows added (Available Skills + Getting Help & Contributing)
 - [ ] No new license or third-party dependency requiring OSRB filing
 
+## All PRs
+
+- [ ] All commits signed off with DCO (`git commit -s`).
+      If you forgot, run `git rebase --signoff origin/main && git push -f` to retroactively sign all commits in your branch.
+
 ## Other context (for non-onboarding PRs)
 
 <!-- Brief description of the change -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ By submitting this PR, I confirm on behalf of my team:
 ## All PRs
 
 - [ ] All commits signed off with DCO (`git commit -s`).
-      If you forgot, run `git rebase --signoff origin/main && git push -f` to retroactively sign all commits in your branch.
+      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.
 
 ## Other context (for non-onboarding PRs)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,39 @@ To contribute to a skill or propose a new one, use the contributing guidelines i
 
 For changes to the catalog itself (fixing links, adding a new product listing), open a [pull request](../../pulls) or [issue](../../issues).
 
+## Recommended Skill Directory Path
+
+When publishing skills in your product repo, use one of these canonical paths so agents can discover them consistently:
+
+- **`.agents/skills/`** — recommended default; agent-agnostic (matches the [agentskills.io](https://agentskills.io/specification) spec; recognized by Claude Code, Cursor, Codex, Windsurf, and other compatible agents).
+- **`skills/`** at repo root — acceptable for OSS product repos where skills are a first-class product artifact.
+
+Avoid agent-specific paths (`.claude/skills/`, `.codex/skills/`, `.cursor/skills/`) for new entries — they create duplication. Existing products on those paths can keep them; `components.yml` handles per-repo paths via the `skills[].path` field.
+
+## IP Review and License (External Skills)
+
+For skills published to `github.com/nvidia/skills`, NVIDIA contributors confirm three things per onboarding PR:
+
+1. The skills have been cleared for open source release per NVIDIA's internal IP review process (six-question check).
+2. The skill is licensed under Apache 2.0, CC-BY 4.0, or dual-license (Apache 2.0 + CC-BY 4.0).
+3. No new license or new third-party component has been introduced beyond what the source repo already carries.
+
+NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection. The [pull request template](.github/PULL_REQUEST_TEMPLATE.md) prompts for these affirmations on every onboarding PR.
+
 ## Signing Your Work
 
-All pull requests require a DCO sign-off. This certifies that the contribution is your original work or you have rights to submit it under the same license.
+All pull requests require a DCO sign-off on every commit. This certifies that the contribution is your original work or you have rights to submit it under the same license.
 
 ```bash
 git commit -s -m "Fix broken link"
 ```
 
-This appends `Signed-off-by: Your Name <your@email.com>` to the commit. Unsigned commits will not be accepted. See the full [Developer Certificate of Origin](https://developercertificate.org/) for details.
+This appends `Signed-off-by: Your Name <your@email.com>` to the commit. Unsigned commits will not be accepted.
+
+If you forgot to sign off (existing commits without the trailer), retroactively sign all commits in your branch with:
+
+```bash
+git rebase --signoff origin/main && git push -f
+```
+
+See the full [Developer Certificate of Origin](https://developercertificate.org/) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ This appends `Signed-off-by: Your Name <your@email.com>` to the commit. Unsigned
 If you forgot to sign off (existing commits without the trailer), retroactively sign all commits in your branch with:
 
 ```bash
-git rebase --signoff origin/main && git push -f
+git rebase --signoff origin/main && git push --force-with-lease
 ```
 
 See the full [Developer Certificate of Origin](https://developercertificate.org/) for details.


### PR DESCRIPTION
## Summary

Two human-facing additions ahead of @sayalinvidia's upcoming DCO CI enforcement:

**`CONTRIBUTING.md`** — three new sections:
1. **Recommended Skill Directory Path** — `.agents/skills/` canonical default, `skills/` at root acceptable, avoid agent-specific paths. Closes the path standardization gap surfaced by @shljessie in the onboarding guide review.
2. **IP Review and License (External Skills)** — summarizes the three affirmations every onboarding PR requires (six-question IP review, license menu, no-new-component check). Points to the internal onboarding guide for process details.
3. **Signing Your Work (expanded)** — adds the rebase-signoff recovery command for commits that were pushed without DCO trailers.

**`.github/PULL_REQUEST_TEMPLATE.md`** — adds an "All PRs" section with a DCO sign-off checkbox and the same recovery command, so every PR (not just onboarding) prompts the author to confirm sign-off.

## Why now

Sayali is preparing the CI DCO check + bot-branch exemption. If her enforcement lands first, contributors hit a hard fail with only the existing minimal CONTRIBUTING.md as reference. Landing this PR first means the recovery instructions and the checkbox prompt are visible before the gate exists — contributors self-serve, no support burden.

## Test plan

- [ ] Confirm `CONTRIBUTING.md` renders correctly on GitHub
- [ ] Confirm the new "All PRs" section appears in the PR template when a new PR is opened
- [ ] Confirm the rebase command in the doc and template are identical (no drift)

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).
      If you forgot, run \`git rebase --signoff origin/main && git push -f\` to retroactively sign all commits in your branch.

## Other context

Not a new product onboarding — meta-PR updating contribution docs. No \`components.yml\` change, no new license, no new third-party content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)