### PR TITLE
Add @sayalinvidia as co-CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 
 # Default owners for all files in the repo
-* @mosheabr
+* @mosheabr @sayalinvidia


### PR DESCRIPTION
## Summary

Adds @sayalinvidia to `.github/CODEOWNERS` alongside @mosheabr.

## Why

Sayali is the de-facto infrastructure owner of this repo (sync pipeline, CI work, DCO enforcement now in flight). The repo's merge ruleset requires code-owner review; with only @mosheabr listed today, every PR review depends on a single person.

After this change, Sayali's approval will satisfy the code-owner-review gate, enabling her to review and merge PRs (including the auto-sync PR) without admin override or waiting on a parallel @mosheabr approval.

She already has `admin` permissions on the repo — this only changes the CODEOWNERS-based review gate.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context

Single-line change to one file. No `components.yml` change, no skill content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)