### PR TITLE
Add DCO check workflow for pull requests

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Verify every commit in a pull request carries a Signed-off-by
+# trailer per the project's DCO requirement (see CONTRIBUTING.md).
+#
+# The automated/sync-skills branch is exempt — it's the daily mirror
+# bot, not a contributor. The legal anchor for synced content lives
+# on the human onboarding PR that registered the component in
+# components.yml; the daily sync is downstream plumbing.
+
+name: DCO Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify DCO sign-off on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Bot-managed sync branch is exempt — see header comment.
+          if [ "$HEAD_REF" = "automated/sync-skills" ]; then
+            echo "DCO check exempt for bot-managed branch '$HEAD_REF'."
+            exit 0
+          fi
+
+          unsigned=()
+          while read -r sha; do
+            if ! git show --format='%(trailers:key=Signed-off-by,valueonly)' -s "$sha" | grep -q .; then
+              subject=$(git show --format='%s' -s "$sha")
+              unsigned+=("$sha $subject")
+            fi
+          done < <(git log --no-merges --format='%H' "$BASE_SHA..$HEAD_SHA")
+
+          if [ ${#unsigned[@]} -gt 0 ]; then
+            echo "::error::Some commits in this PR are missing a Signed-off-by trailer."
+            echo ""
+            echo "Unsigned commits:"
+            printf '  %s\n' "${unsigned[@]}"
+            echo ""
+            echo "To fix, run on your branch:"
+            echo ""
+            echo "  git rebase --signoff origin/main && git push --force-with-lease"
+            echo ""
+            echo "See CONTRIBUTING.md for the full DCO requirement."
+            exit 1
+          fi
+
+          echo "All commits signed off."


### PR DESCRIPTION
CONTRIBUTING.md requires every commit to carry a Signed-off-by trailer, but enforcement was honor-system — recent PRs (#29, #30, #32) merged via --admin override because contributors forgot the sign-off and there was no automated check.

This workflow runs on every pull_request open/synchronize/reopen, walks each commit in base..head, and fails if any commit lacks a Signed-off-by trailer. The failure log surfaces the recovery command (git rebase --signoff origin/main && git push --force-with-lease) so contributors can self-serve.

The automated/sync-skills branch is exempt — it's the daily mirror bot, not a contributor; the legal anchor for synced content lives on the human onboarding PR that registered the component in components.yml.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (`components.yml` entry)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] README rows added (Available Skills + Getting Help & Contributing)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
