### PR TITLE
Update Repository Structure to reflect components.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,13 @@ NVIDIA/skills/
 │   ├── nemotron-voice-agent/ # Nemotron Voice Agent skills (1)
 │   ├── TensorRT-LLM/         # TensorRT-LLM skills (20)
 │   └── ...
-├── components.yml           # Product registry — teams onboard here
+├── components.d/            # Product registry — one file per component, teams onboard here
+│   ├── cuda-q.yml
+│   ├── cuopt.yml
+│   ├── megatron-bridge.yml
+│   ├── ...
+│   ├── tensorrt-llm.yml
+│   └── README.md             # Schema and onboarding instructions
 ├── .github/workflows/       # Automated sync pipeline
 ├── CONTRIBUTING.md          # Contribution guidelines
 ├── SECURITY.md              # Security reporting policy


### PR DESCRIPTION
components.yml was split into per-component files under components.d/ in #40. The repo-structure diagram in README.md still showed the old filename; this commit updates it.

No functional change — pure documentation sync.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
