### PR TITLE
Drop stale skill counts from Repository Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ For issues with **this catalog repo itself** (README, structure, listing a new p
 ```
 NVIDIA/skills/
 ├── skills/                  # All skills, mirrored daily from product repos
-│   ├── CUDA-Q/               # CUDA-Q skills (1)
-│   ├── cuopt/                # cuOpt skills (19)
-│   ├── Megatron-Bridge/      # Megatron-Bridge skills (9)
-│   ├── Megatron-Core/        # Megatron-Core skills (6)
-│   ├── Model-Optimizer/      # Model-Optimizer skills (5)
+│   ├── CUDA-Q/               # CUDA-Q skills
+│   ├── cuopt/                # cuOpt skills
+│   ├── Megatron-Bridge/      # Megatron-Bridge skills
+│   ├── Megatron-Core/        # Megatron-Core skills
+│   ├── Model-Optimizer/      # Model-Optimizer skills
 │   ├── NeMo-Evaluator/       # NeMo Evaluator skills
 │   ├── NeMo-Evaluator-Launcher/
-│   ├── NeMo-Gym/             # NeMo Gym skills (1)
-│   ├── NemoClaw/             # NemoClaw skills (21)
-│   ├── nemotron-voice-agent/ # Nemotron Voice Agent skills (1)
-│   ├── TensorRT-LLM/         # TensorRT-LLM skills (20)
+│   ├── NeMo-Gym/             # NeMo Gym skills 
+│   ├── NemoClaw/             # NemoClaw skills 
+│   ├── nemotron-voice-agent/ # Nemotron Voice Agent skills
+│   ├── TensorRT-LLM/         # TensorRT-LLM skills 
 │   └── ...
 ├── components.d/            # Product registry — one file per component, teams onboard here
 │   ├── cuda-q.yml


### PR DESCRIPTION
Hardcoded counts in this block were drifting from reality (e.g. TensorRT-LLM listed as 20 vs actual 24, Megatron-Bridge 9 vs 25). The Available Skills table is the canonical source for counts; keeping them in two places was a maintenance trap.

Reviewer follow-up from #40.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
