### PR TITLE
Add skills: automodel-expert-lora and megatron-bridge-lora-sft

### DIFF
--- a/components.d/automodel.yml
+++ b/components.d/automodel.yml
@@ -1,0 +1,8 @@
+name: NeMo-AutoModel
+repo: NVIDIA-NeMo/Automodel
+description: NeMo AutoModel — fine-tuning and training of HuggingFace-compatible models, including LoRA, PEFT, and MoE workflows.
+skills:
+  - path: skills/
+    catalog_dir: NeMo-AutoModel
+links:
+  security: false

--- a/skills/Megatron-Bridge/megatron-bridge-lora-sft/SKILL.md
+++ b/skills/Megatron-Bridge/megatron-bridge-lora-sft/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: megatron-bridge-lora-sft
+description: Configure and run LoRA, DoRA, and full SFT fine-tuning in Megatron-Bridge. Covers PEFT recipe selection, target module wiring, adapter merging, and HuggingFace checkpoint export. Use when applying LoRA or DoRA to any Bridge-supported model, setting up SFT datasets, debugging PEFT config errors, or exporting fine-tuned weights back to HuggingFace format.
+when_to_use: LoRA or DoRA fine-tuning, SFT recipe setup, PEFT config errors, adapter merging, HuggingFace export after fine-tuning; 'peft_config', 'LoRA', 'DoRA', 'lora_rank', 'target_modules', 'merge_lora', 'sft_config', 'fine-tune', 'adapter export'.
+---
+
+# LoRA / DoRA / SFT Fine-Tuning
+
+Stable docs: @docs/training/peft.md
+Card: @skills/megatron-bridge-lora-sft/card.yaml
+
+## Quick Decision
+
+| Goal | Recipe type | Min GPUs |
+|---|---|---|
+| LoRA on 8B model | `*_peft_config` | 1 |
+| LoRA on 70B model | `*_peft_config` | 8 |
+| LoRA on 235B MoE | `*_peft_config` | 16 |
+| Full SFT on 8B | `*_sft_config` | 2 |
+| Full SFT on 70B | `*_sft_config` | 16 |
+| Merge adapters + export to HF | Post-training step | Same as training |
+
+Use PEFT recipes when GPU count is the constraint. Use SFT recipes when
+you need full gradient flow through all parameters.
+
+## Enablement
+
+### LoRA (minimal)
+
+```python
+from megatron.bridge.recipes.llama import llama3_8b_peft_config
+
+cfg = llama3_8b_peft_config()
+
+# Default: rank=16, alpha=32, target_modules=["linear_qkv", "linear_proj"]
+# Override rank and alpha:
+cfg.peft.lora_rank = 32
+cfg.peft.lora_alpha = 64
+
+# Add MLP layers to target modules:
+cfg.peft.target_modules = [
+    "linear_qkv",
+    "linear_proj",
+    "linear_fc1",
+    "linear_fc2",
+]
+```
+
+### DoRA
+
+```python
+cfg.peft.use_dora = True
+cfg.peft.lora_rank = 16
+cfg.peft.lora_alpha = 16  # alpha == rank is the DoRA convention
+```
+
+### SFT (full fine-tune)
+
+```python
+from megatron.bridge.recipes.llama import llama3_8b_sft_config
+
+cfg = llama3_8b_sft_config()
+cfg.dataset.data_path = ["/data/train.jsonl"]
+cfg.dataset.seq_length = 4096
+cfg.train.global_batch_size = 128
+cfg.train.micro_batch_size = 2
+cfg.optimizer.lr = 1e-5
+```
+
+### MoE LoRA — expert layer targeting
+
+For MoE models (Qwen3-MoE, DeepSeek, GLM-4.5), expert weights are
+registered as `nn.Parameter`, not `nn.Linear`. `match_all_linear=True`
+silently skips them. Set `target_modules` explicitly:
+
+```python
+cfg = qwen3_30b_a3b_peft_config()
+cfg.peft.target_modules = [
+    "linear_qkv",       # attention
+    "linear_proj",      # attention output
+    "gate_proj",        # expert gate
+    "up_proj",          # expert up
+    "down_proj",        # expert down
+]
+cfg.peft.lora_rank = 16
+cfg.peft.lora_alpha = 32
+```
+
+### Adapter merge and HuggingFace export
+
+```python
+from megatron.bridge.peft.merge import merge_lora_weights
+from megatron.bridge.convert import export_to_hf
+
+# Step 1: merge adapters into base weights
+merge_lora_weights(
+    checkpoint_dir="/checkpoints/lora_run",
+    output_dir="/checkpoints/merged",
+)
+
+# Step 2: export merged checkpoint to HuggingFace format
+export_to_hf(
+    megatron_checkpoint="/checkpoints/merged",
+    hf_output_dir="/hf_model/",
+    model_type="llama3",
+)
+```
+
+Or via CLI:
+
+```bash
+python scripts/convert/megatron_to_hf.py \
+  --checkpoint /checkpoints/merged \
+  --output /hf_model/ \
+  --model-type llama3
+```
+
+## Entry Points
+
+```bash
+# LoRA fine-tune (1 GPU)
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune
+
+# SFT fine-tune (2 GPUs)
+uv run python -m torch.distributed.run --nproc_per_node=2 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_sft_config \
+  --dataset llm-finetune
+
+# Override LoRA rank via CLI
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune \
+  'peft.lora_rank=32' \
+  'peft.lora_alpha=64'
+```
+
+## Code Anchors
+
+PEFT config definition:
+
+```python
+# src/megatron/bridge/training/config.py
+@dataclass
+class PEFTConfig:
+    lora_rank: int = 16
+    lora_alpha: float = 32
+    lora_dropout: float = 0.0
+    use_dora: bool = False
+    target_modules: list[str] = field(default_factory=lambda: ["linear_qkv", "linear_proj"])
+    match_all_linear: bool = False
+```
+
+LoRA adapter application:
+
+```python
+# src/megatron/bridge/training/peft.py
+def apply_lora(model, peft_config):
+    # wraps target modules with LoraLinear / DoraLinear
+    # match_all_linear iterates nn.Linear only — misses nn.Parameter MoE experts
+```
+
+Merge utility:
+
+```python
+# src/megatron/bridge/peft/merge.py
+def merge_lora_weights(checkpoint_dir, output_dir):
+    # loads base + adapter shards, merges in-place, writes merged checkpoint
+```
+
+PEFT recipe examples:
+
+```python
+# src/megatron/bridge/recipes/llama.py
+def llama3_8b_peft_config() -> ConfigContainer:
+    cfg = llama3_8b_sft_config()
+    cfg.peft = PEFTConfig(lora_rank=16, lora_alpha=32)
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    return cfg
+```
+
+## Pitfalls
+
+1. **MoE expert layers silently skipped**: `match_all_linear=True` only
+   matches `nn.Linear`. Expert weights in fused MoE blocks (Qwen3-MoE,
+   DeepSeek, GLM-4.5) are `nn.Parameter` — they are invisible to the
+   matcher. Always set `target_modules` explicitly for MoE models.
+
+2. **DoRA alpha convention**: DoRA expects `lora_alpha == lora_rank`. Using
+   the standard LoRA convention (`alpha = 2 * rank`) will not error but
+   produces suboptimal scaling. Set `alpha = rank` for DoRA.
+
+3. **Merge before export**: Exporting a LoRA checkpoint to HuggingFace
+   without merging produces a broken HF model — the base weights do not
+   include adapter contributions. Always run `merge_lora_weights()` first.
+
+4. **TP > 1 with PEFT**: LoRA adapters are sharded along with the base
+   layer when `tensor_model_parallel_size > 1`. The adapter shapes must be
+   consistent across TP ranks. Mismatched `lora_rank` between ranks causes
+   a shape error at initialization, not at the first forward pass.
+
+5. **SFT with packed sequences requires MBS=1**: When `PackedSequenceSpecs`
+   is active, setting `micro_batch_size > 1` raises a `ValueError`. PEFT
+   recipes default to `MBS=1`; SFT recipes may need explicit adjustment.
+
+6. **`calculate_per_token_loss` for SFT with CP**: When context parallelism
+   (`context_parallel_size > 1`) is enabled for SFT, set
+   `cfg.model.calculate_per_token_loss = True` and
+   `cfg.ddp.average_in_collective = False`. Omitting either causes
+   incorrect loss scaling across CP ranks.
+
+7. **LoRA dropout and inference**: `lora_dropout > 0` is training-only.
+   Ensure the adapter is saved and merged in eval mode or dropout
+   will be applied during export, corrupting merged weights.
+
+## Verification
+
+Unit test coverage for PEFT config validation:
+
+```bash
+uv run python -m pytest tests/unit_tests/training/test_config.py \
+  -k "peft or lora" -v
+```
+
+Smoke test LoRA on 1 GPU with mock data:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune \
+  'train.train_iters=5' \
+  'logger.log_interval=1'
+```
+
+Success criteria:
+
+- Exit code 0
+- Finite loss at iteration 5 (e.g. `lm loss: 9.8E+00`)
+- Log shows `PEFTConfig` with expected `lora_rank` and `target_modules`
+- No `KeyError` or shape mismatch during adapter initialization

--- a/skills/Megatron-Bridge/megatron-bridge-lora-sft/card.yaml
+++ b/skills/Megatron-Bridge/megatron-bridge-lora-sft/card.yaml
@@ -1,0 +1,83 @@
+title: megatron_bridge_lora_sft
+validated_on: "2026-05-03"
+summary: >
+  Megatron-Bridge exposes LoRA, DoRA, and full SFT fine-tuning through
+  PEFTConfig and per-model recipe functions. PEFT recipes default to rank=16,
+  alpha=32, and attention-only target_modules. MoE expert layers are
+  nn.Parameter and are invisible to match_all_linear — target_modules must
+  be set explicitly for MoE models. Adapter merge is required before
+  HuggingFace export.
+validation_status:
+  lora_peft_config:
+    - code_verified
+  dora_peft_config:
+    - code_verified
+  sft_config:
+    - code_verified
+  moe_expert_target_modules:
+    - code_verified
+  adapter_merge:
+    - code_verified
+  hf_export:
+    - code_verified
+  peft_recipe_functions:
+    - recipe_verified
+  dora_alpha_convention:
+    - doc_only
+  tp_peft_sharding:
+    - unclear
+feature_meaning:
+  lora_config: >
+    PEFTConfig with lora_rank, lora_alpha, lora_dropout, target_modules.
+    Applied via apply_lora() in src/megatron/bridge/training/peft.py.
+  dora_config: >
+    DoRA mode enabled by use_dora=True. Requires lora_alpha == lora_rank
+    for correct weight decomposition scaling.
+  sft_config: >
+    Full fine-tuning via *_sft_config recipes. All parameters trainable.
+    Uses standard optimizer and data pipeline.
+  moe_expert_targeting: >
+    Expert weights in fused MoE blocks (Qwen3-MoE, DeepSeek, GLM-4.5) are
+    nn.Parameter, not nn.Linear. match_all_linear=True silently skips them.
+    Requires gate_proj/up_proj/down_proj passed explicitly via target_modules.
+  adapter_merge_hf_export: >
+    merge_lora_weights() fuses adapters into base checkpoint shards.
+    export_to_hf() or megatron_to_hf.py CLI converts to HuggingFace format.
+    Skipping merge produces a broken HF model.
+recommended_path:
+  lora_minimal:
+    peft.lora_rank: 16
+    peft.lora_alpha: 32
+    peft.target_modules: "[linear_qkv, linear_proj]"
+  dora:
+    peft.use_dora: true
+    peft.lora_alpha: "== lora_rank"
+  moe_lora:
+    peft.target_modules: "[linear_qkv, linear_proj, gate_proj, up_proj, down_proj]"
+  merge_and_export:
+    step_1: merge_lora_weights(checkpoint_dir, output_dir)
+    step_2: export_to_hf(megatron_checkpoint, hf_output_dir, model_type)
+known_constraints:
+  - DoRA requires lora_alpha == lora_rank; using 2*rank convention produces incorrect scaling.
+  - merge_lora_weights() must run before export_to_hf(); skipping it produces a broken HF model.
+  - LoRA adapter shapes must be consistent across TP ranks; mismatched lora_rank causes a shape error at init.
+  - micro_batch_size must be 1 when PackedSequenceSpecs is active with PEFT recipes.
+  - context_parallel_size > 1 with SFT requires calculate_per_token_loss=True and ddp.average_in_collective=False.
+  - lora_dropout > 0 is training-only; adapter must be in eval mode before merge to avoid corrupting weights.
+known_limitations:
+  - match_all_linear=True silently skips MoE expert parameters; no error is raised.
+  - Expert layer LoRA requires explicit target_modules for every supported MoE model family.
+  - End-to-end LoRA merge and HF export round-trip test not yet in CI.
+  - MoE expert LoRA functional test pending.
+evidence:
+  - src/megatron/bridge/training/config.py
+  - src/megatron/bridge/training/peft.py
+  - src/megatron/bridge/peft/merge.py
+  - src/megatron/bridge/convert/__init__.py
+  - src/megatron/bridge/recipes/llama/llama3.py
+  - scripts/convert/megatron_to_hf.py
+  - tests/unit_tests/training/test_config.py
+follow_up_validation:
+  - Add a checked-in end-to-end LoRA merge and HF export round-trip CI test.
+  - Add a functional smoke test for MoE expert LoRA on Qwen3-MoE or DeepSeek.
+  - Clarify whether TP > 1 PEFT is validated on current container versions.

--- a/skills/Megatron-Bridge/megatron-bridge-lora-sft/evals/evals.json
+++ b/skills/Megatron-Bridge/megatron-bridge-lora-sft/evals/evals.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "lora-001-llama3-8b-rank-attention-mlp",
+    "question": "How do I set up LoRA fine-tuning for Llama 3 8B in Megatron-Bridge with rank 32 targeting attention and MLP layers?",
+    "expected_skill": "megatron-bridge-lora-sft",
+    "expected_script": null,
+    "ground_truth": "Use llama3_8b_peft_config() as the starting recipe, then set cfg.peft.lora_rank=32, cfg.peft.lora_alpha=64, and cfg.peft.target_modules=[\"linear_qkv\", \"linear_proj\", \"linear_fc1\", \"linear_fc2\"]. Launch with uv run python -m torch.distributed.run --nproc_per_node=1 scripts/training/run_recipe.py --recipe llama3_8b_peft_config --dataset llm-finetune. Do not use match_all_linear=True.",
+    "expected_behavior": [
+      "References llama3_8b_peft_config() as the starting recipe",
+      "Sets lora_rank=32 on the peft config",
+      "Sets lora_alpha=64 (2x rank convention for LoRA)",
+      "Sets target_modules with at least 4 entries covering both attention (linear_qkv, linear_proj) and MLP (linear_fc1, linear_fc2)",
+      "Includes the uv run torch.distributed.run launch command",
+      "Does not suggest match_all_linear=True as the solution"
+    ]
+  },
+  {
+    "id": "lora-002-qwen3-moe-expert-skip",
+    "question": "I'm trying to apply LoRA to a Qwen3-30B-A3B MoE model in Megatron-Bridge but my loss isn't changing — it looks like only attention layers are being adapted. What's wrong?",
+    "expected_skill": "megatron-bridge-lora-sft",
+    "expected_script": null,
+    "ground_truth": "The root cause is that match_all_linear=True only iterates nn.Linear modules and silently skips MoE expert weights registered as nn.Parameter. Fix: use qwen3_30b_a3b_peft_config() and explicitly set target_modules to include both attention layers (linear_qkv, linear_proj) and expert layers (gate_proj, up_proj, down_proj).",
+    "expected_behavior": [
+      "Identifies the root cause as match_all_linear missing nn.Parameter expert weights",
+      "Explains that no error is raised — the skip is silent",
+      "Provides an explicit target_modules list that includes expert layer names (gate_proj, up_proj, down_proj)",
+      "References qwen3_30b_a3b_peft_config or an equivalent MoE recipe",
+      "Does not suggest increasing lora_rank as the primary fix"
+    ]
+  },
+  {
+    "id": "lora-003-adapter-merge-hf-export",
+    "question": "How do I merge LoRA adapters and export the result to HuggingFace format after training in Megatron-Bridge?",
+    "expected_skill": "megatron-bridge-lora-sft",
+    "expected_script": null,
+    "ground_truth": "Two-step process: first call merge_lora_weights(checkpoint_dir, output_dir) to fuse adapters into the base checkpoint shards, then call export_to_hf(megatron_checkpoint, hf_output_dir, model_type) or use the CLI scripts/convert/megatron_to_hf.py. Skipping the merge step produces a broken HF model because base weights do not include adapter contributions.",
+    "expected_behavior": [
+      "Shows merge step (merge_lora_weights) before the export step",
+      "Includes checkpoint_dir and output_dir arguments for the merge call",
+      "Includes either the Python export_to_hf() call or the CLI megatron_to_hf.py command with model-type argument",
+      "Warns that skipping the merge step produces a broken HF model"
+    ]
+  }
+]

--- a/skills/NeMo-AutoModel/automodel-expert-lora/SKILL.md
+++ b/skills/NeMo-AutoModel/automodel-expert-lora/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: automodel-expert-lora
+description: Apply LoRA to fused MoE expert layers in NeMo AutoModel using HuggingFace Transformers v5+ models. Covers expert parameter detection, rank_pattern configuration, and the validation warning emitted when match_all_linear silently skips expert weights. Use when fine-tuning MoE models (Mixtral, Qwen3-MoE, DeepSeek) with LoRA and needing expert layers adapted, or when diagnosing why only attention layers are changing during MoE LoRA training.
+when_to_use: LoRA on MoE models in NeMo AutoModel, expert weight adaptation, rank_pattern configuration, silent skip diagnosis; 'match_all_linear MoE', 'expert LoRA', 'fused expert parameters', 'target_modules MoE', 'Mixtral LoRA', 'Qwen3-MoE LoRA', 'DeepSeek LoRA', 'nn.Parameter expert'.
+---
+
+# Expert LoRA for Fused MoE Models
+
+Card: @skills/automodel-expert-lora/card.yaml
+
+## The Problem
+
+In Transformers v5+, fused MoE models (Mixtral, Qwen3-MoE, DeepSeek-V3,
+GLM-4.5) register expert weights as `nn.Parameter` inside a combined linear
+layer — not as individual `nn.Linear` modules. `match_all_linear=True` iterates
+`nn.Linear` only. Expert parameters are invisible to it.
+
+Result: LoRA appears to run, loss changes only from attention adaptation, and
+the expert layers are never modified. No error is raised.
+
+As of NeMo AutoModel v0.x (issue #1151), `apply_lora()` now emits a
+`UserWarning` when this condition is detected, and three utilities are
+available to configure expert LoRA correctly.
+
+## Quick Decision
+
+| Model family | Expert param pattern | Correct target_modules |
+|---|---|---|
+| Mixtral | `block_sparse_moe.w1/w2/w3` | `["w1", "w2", "w3"]` |
+| Qwen3-MoE | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+| DeepSeek-V3 | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+| GLM-4.5 | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+
+If unsure, run `detect_fused_moe_experts(model)` — it returns the correct
+list for any supported model.
+
+## Enablement
+
+### Step 1 — Detect expert parameter names
+
+```python
+from nemo_automodel.components._peft.lora import detect_fused_moe_experts
+
+targets = detect_fused_moe_experts(model)
+# e.g. returns ["w1", "w2", "w3"] for Mixtral
+#              ["down_proj", "gate_proj", "up_proj"] for Qwen3-MoE
+```
+
+### Step 2 — Build rank_pattern (optional: per-expert rank sizing)
+
+```python
+from nemo_automodel.components._peft.lora import build_expert_lora_rank_pattern
+
+rank_pattern = build_expert_lora_rank_pattern(
+    model,
+    base_rank=16,
+    expert_rank_multiplier=0.5,  # smaller rank for experts to save memory
+)
+# e.g. {"block_sparse_moe": 8}
+```
+
+### Step 3 — Apply LoRA with explicit target_modules
+
+```python
+from peft import LoraConfig, get_peft_model
+from nemo_automodel.components._peft.lora import detect_fused_moe_experts, build_expert_lora_rank_pattern
+
+targets = detect_fused_moe_experts(model)
+rank_pattern = build_expert_lora_rank_pattern(model, base_rank=16)
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules=targets,
+    rank_pattern=rank_pattern,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
+
+model = get_peft_model(model, lora_config)
+model.print_trainable_parameters()
+# Should show expert layers in trainable params, not just attention
+```
+
+### Validation warning
+
+If `apply_lora()` is called with `match_all_linear=True` and no
+`target_modules`, and the model has fused expert parameters, a `UserWarning`
+is emitted with the detected parameter names and a fix snippet. Treat this
+as an error — silent expert-skip produces wrong training dynamics.
+
+```
+UserWarning: [NeMo AutoModel] Fused MoE expert parameters detected but will
+NOT be adapted by LoRA.
+
+  Detected expert parameter names: ['w1', 'w2', 'w3']
+
+  To apply LoRA to expert layers, pass target_modules explicitly:
+    lora_config = LoraConfig(
+        target_modules=['w1', 'w2', 'w3'],
+        rank_pattern=build_expert_lora_rank_pattern(model, base_rank=16),
+    )
+```
+
+## Code Anchors
+
+Expert detection utility:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+_FUSED_EXPERT_PARAM_PATTERNS = (
+    "block_sparse_moe",   # Mixtral
+    "mlp.experts",        # Qwen3-MoE, DeepSeek
+    "moe.experts",        # generic
+    "ffn.experts",        # generic
+)
+
+def detect_fused_moe_experts(model: nn.Module) -> list[str]:
+    # inspects named_parameters() for known fused MoE patterns
+    # returns sorted list of leaf parameter name suffixes
+```
+
+Rank pattern builder:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+def build_expert_lora_rank_pattern(
+    model: nn.Module,
+    base_rank: int,
+    expert_rank_multiplier: float = 1.0,
+) -> dict[str, int]:
+    # maps MoE pattern keys to int(base_rank * multiplier)
+    # returns {} for dense models
+```
+
+Validation hook in apply_lora:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+def apply_lora(model, lora_config, match_all_linear=False, target_modules=None):
+    validate_lora_config_for_moe(model, match_all_linear, target_modules)
+    # ... existing LoRA application logic ...
+```
+
+Tests:
+
+```python
+# tests/unit/components/peft/test_expert_lora.py
+class TestDetectFusedMoeExperts   # 4 tests
+class TestBuildExpertLoraRankPattern  # 4 tests
+class TestValidateLoraConfigForMoe    # 3 tests
+```
+
+## Pitfalls
+
+1. **Silent failure with match_all_linear**: The most dangerous failure mode.
+   Training appears normal, loss decreases, but expert weights are never
+   adapted. Only detectable by checking `model.print_trainable_parameters()`
+   and confirming expert layers appear — or by observing that expert-heavy
+   tasks show no improvement vs attention-only LoRA.
+
+2. **rank_pattern key must match parameter path substring**: The keys in
+   `rank_pattern` are matched against full parameter names. Use the pattern
+   as returned by `detect_fused_moe_experts` or `build_expert_lora_rank_pattern`
+   — do not abbreviate.
+
+3. **expert_rank_multiplier < 1 floors at rank 1**: Setting
+   `expert_rank_multiplier=0.1` with `base_rank=4` gives rank 1, not 0.
+   This is intentional — rank 0 is invalid. Verify effective rank with
+   `model.print_trainable_parameters()`.
+
+4. **Dense model returns empty pattern**: `build_expert_lora_rank_pattern`
+   returns `{}` for dense models. Passing an empty `rank_pattern` to
+   `LoraConfig` is safe — PEFT falls back to the global `r` value.
+
+5. **target_modules suppresses the warning**: Once `target_modules` is
+   provided, `validate_lora_config_for_moe` returns immediately and
+   does not check whether the provided names actually cover expert layers.
+   Use `detect_fused_moe_experts` to generate the list rather than
+   guessing module names.
+
+## Verification
+
+Unit tests for all three utilities:
+
+```bash
+pytest tests/unit/components/peft/test_expert_lora.py -v
+```
+
+Expected: `12 passed`
+
+Confirm expert layers are trainable after apply_lora:
+
+```python
+model = get_peft_model(model, lora_config)
+trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+expert_patterns = detect_fused_moe_experts(model.base_model)
+assert any(
+    any(pat in name for pat in expert_patterns)
+    for name in trainable
+), "No expert parameters in trainable set — check target_modules"
+```
+
+Success criteria:
+
+- `12 passed` on unit tests
+- `model.print_trainable_parameters()` shows expert layer names in the
+  trainable parameter count
+- No `UserWarning` about fused MoE expert skip when target_modules is set

--- a/skills/NeMo-AutoModel/automodel-expert-lora/card.yaml
+++ b/skills/NeMo-AutoModel/automodel-expert-lora/card.yaml
@@ -1,0 +1,61 @@
+title: automodel_expert_lora
+validated_on: "2026-05-03"
+summary: >
+  NeMo AutoModel v0.x adds three utilities for applying LoRA to fused MoE
+  expert layers in HuggingFace Transformers v5+ models: detect_fused_moe_experts
+  detects nn.Parameter expert weights that match_all_linear silently skips,
+  build_expert_lora_rank_pattern produces a rank_pattern dict for per-expert
+  rank sizing, and validate_lora_config_for_moe emits a UserWarning when
+  match_all_linear=True would miss expert parameters. All three are covered
+  by 12 unit tests. Related to issue #1151.
+validation_status:
+  detect_fused_moe_experts:
+    - code_verified
+  build_expert_lora_rank_pattern:
+    - code_verified
+  validate_lora_config_for_moe:
+    - code_verified
+  unit_tests:
+    - code_verified
+  mixtral_target_modules_table:
+    - doc_only
+  qwen3_moe_target_modules_table:
+    - doc_only
+  end_to_end_finetune:
+    - unclear
+feature_meaning:
+  detect_fused_moe_experts: >
+    Inspects model.named_parameters() for known fused MoE patterns
+    (block_sparse_moe, mlp.experts, moe.experts, ffn.experts) and returns
+    a sorted list of leaf parameter name suffixes to pass as target_modules.
+  build_expert_lora_rank_pattern: >
+    Maps MoE pattern keys to int(base_rank * expert_rank_multiplier).
+    Returns an empty dict for dense models, which is safe to pass to LoraConfig.
+  validate_lora_config_for_moe: >
+    Called inside apply_lora() when match_all_linear=True. Emits a UserWarning
+    listing detected expert parameter names and a fix snippet when expert layers
+    would be silently skipped.
+recommended_path:
+  moe_lora_setup:
+    step_1: targets = detect_fused_moe_experts(model)
+    step_2: rank_pattern = build_expert_lora_rank_pattern(model, base_rank=16)
+    step_3: "LoraConfig(target_modules=targets, rank_pattern=rank_pattern)"
+  verification:
+    check: model.print_trainable_parameters()
+    assert: expert layer names appear in trainable parameter count
+known_constraints:
+  - Expert detection matches known fused MoE parameter name patterns only; custom MoE architectures require manual target_modules.
+  - rank_pattern keys are matched as substrings of full parameter names; ambiguous keys may match unintended layers.
+  - expert_rank_multiplier floors at rank 1; rank 0 is invalid.
+  - target_modules suppresses the UserWarning regardless of whether the provided names actually cover expert layers.
+known_limitations:
+  - Dense model returns empty rank_pattern; PEFT falls back to global r value.
+  - End-to-end MoE LoRA fine-tune and eval loop test not yet in CI.
+  - Functional test on real Mixtral or Qwen3-MoE checkpoint pending.
+evidence:
+  - nemo_automodel/components/_peft/lora.py
+  - tests/unit/components/peft/test_expert_lora.py
+follow_up_validation:
+  - Run end-to-end MoE LoRA fine-tune and verify expert layers adapt on Mixtral or Qwen3-MoE.
+  - Add a CI job that runs the 12 unit tests on every PR touching _peft/lora.py.
+  - Extend detect_fused_moe_experts pattern list for new MoE architectures as they are added.

--- a/skills/NeMo-AutoModel/automodel-expert-lora/evals/evals.json
+++ b/skills/NeMo-AutoModel/automodel-expert-lora/evals/evals.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "moe-lora-001-mixtral-match-all-linear",
+    "question": "I'm applying LoRA to a Mixtral model in NeMo AutoModel with match_all_linear=True but the loss is not improving on expert-heavy tasks. What's wrong and how do I fix it?",
+    "expected_skill": "automodel-expert-lora",
+    "expected_script": null,
+    "ground_truth": "match_all_linear=True only iterates nn.Linear modules and silently skips Mixtral's fused expert parameters, which are nn.Parameter inside block_sparse_moe. A UserWarning is emitted by validate_lora_config_for_moe when this is detected. Fix: call detect_fused_moe_experts(model) to get target_modules=['w1','w2','w3'] and pass them explicitly to LoraConfig instead of relying on match_all_linear.",
+    "expected_behavior": [
+      "Identifies nn.Parameter vs nn.Linear as the root cause of silent expert-skip",
+      "Mentions the UserWarning emitted by apply_lora() when the condition is detected",
+      "References detect_fused_moe_experts() to obtain the correct target_modules",
+      "Provides target_modules=['w1','w2','w3'] as the Mixtral-specific fix",
+      "Does not suggest increasing lora_rank as the primary fix"
+    ]
+  },
+  {
+    "id": "moe-lora-002-qwen3-per-expert-rank",
+    "question": "How do I apply different LoRA ranks to attention vs expert layers in a Qwen3-MoE model using NeMo AutoModel?",
+    "expected_skill": "automodel-expert-lora",
+    "expected_script": null,
+    "ground_truth": "Use build_expert_lora_rank_pattern(model, base_rank=16, expert_rank_multiplier=0.5) to generate a rank_pattern dict that maps MoE pattern keys to reduced ranks, then combine with detect_fused_moe_experts(model) for target_modules and pass both to LoraConfig(r=16, target_modules=targets, rank_pattern=rank_pattern).",
+    "expected_behavior": [
+      "Includes build_expert_lora_rank_pattern with base_rank and expert_rank_multiplier parameters",
+      "Shows rank_pattern passed to LoraConfig",
+      "Includes detect_fused_moe_experts to obtain target_modules",
+      "Explains that expert_rank_multiplier < 1 reduces expert rank below base_rank",
+      "Notes that expert_rank_multiplier floors at rank 1 (rank 0 is invalid)"
+    ]
+  },
+  {
+    "id": "moe-lora-003-verify-expert-trainable",
+    "question": "After applying LoRA to my Qwen3-MoE model, how do I verify that expert layers are actually being trained and not silently skipped?",
+    "expected_skill": "automodel-expert-lora",
+    "expected_script": null,
+    "ground_truth": "Call model.print_trainable_parameters() and confirm expert layer names appear in the trainable parameter count. For a programmatic check, use detect_fused_moe_experts(model.base_model) to get expected patterns and assert that at least one trainable parameter name contains each pattern. The 12 unit tests in test_expert_lora.py also serve as a baseline regression check.",
+    "expected_behavior": [
+      "Includes model.print_trainable_parameters() call and explains what to look for",
+      "Provides a code snippet using detect_fused_moe_experts to assert expert patterns are in the trainable set",
+      "Explains that expert layer names should appear in the trainable parameter count",
+      "References the 12 unit tests in test_expert_lora.py as a baseline check"
+    ]
+  }
+]

--- a/skills_contribution/skills/automodel-expert-lora/SKILL.md
+++ b/skills_contribution/skills/automodel-expert-lora/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: automodel-expert-lora
+description: Apply LoRA to fused MoE expert layers in NeMo AutoModel using HuggingFace Transformers v5+ models. Covers expert parameter detection, rank_pattern configuration, and the validation warning emitted when match_all_linear silently skips expert weights. Use when fine-tuning MoE models (Mixtral, Qwen3-MoE, DeepSeek) with LoRA and needing expert layers adapted, or when diagnosing why only attention layers are changing during MoE LoRA training.
+when_to_use: LoRA on MoE models in NeMo AutoModel, expert weight adaptation, rank_pattern configuration, silent skip diagnosis; 'match_all_linear MoE', 'expert LoRA', 'fused expert parameters', 'target_modules MoE', 'Mixtral LoRA', 'Qwen3-MoE LoRA', 'DeepSeek LoRA', 'nn.Parameter expert'.
+license: Apache-2.0
+---
+
+# Expert LoRA for Fused MoE Models
+
+Card: @skills/automodel-expert-lora/card.yaml
+
+## The Problem
+
+In Transformers v5+, fused MoE models (Mixtral, Qwen3-MoE, DeepSeek-V3,
+GLM-4.5) register expert weights as `nn.Parameter` inside a combined linear
+layer — not as individual `nn.Linear` modules. `match_all_linear=True` iterates
+`nn.Linear` only. Expert parameters are invisible to it.
+
+Result: LoRA appears to run, loss changes only from attention adaptation, and
+the expert layers are never modified. No error is raised.
+
+As of NeMo AutoModel v0.x (issue #1151), `apply_lora()` now emits a
+`UserWarning` when this condition is detected, and three utilities are
+available to configure expert LoRA correctly.
+
+## Quick Decision
+
+| Model family | Expert param pattern | Correct target_modules |
+|---|---|---|
+| Mixtral | `block_sparse_moe.w1/w2/w3` | `["w1", "w2", "w3"]` |
+| Qwen3-MoE | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+| DeepSeek-V3 | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+| GLM-4.5 | `mlp.experts.gate_proj/up_proj/down_proj` | `["gate_proj", "up_proj", "down_proj"]` |
+
+If unsure, run `detect_fused_moe_experts(model)` — it returns the correct
+list for any supported model.
+
+## Enablement
+
+### Step 1 — Detect expert parameter names
+
+```python
+from nemo_automodel.components._peft.lora import detect_fused_moe_experts
+
+targets = detect_fused_moe_experts(model)
+# e.g. returns ["w1", "w2", "w3"] for Mixtral
+#              ["down_proj", "gate_proj", "up_proj"] for Qwen3-MoE
+```
+
+### Step 2 — Build rank_pattern (optional: per-expert rank sizing)
+
+```python
+from nemo_automodel.components._peft.lora import build_expert_lora_rank_pattern
+
+rank_pattern = build_expert_lora_rank_pattern(
+    model,
+    base_rank=16,
+    expert_rank_multiplier=0.5,  # smaller rank for experts to save memory
+)
+# e.g. {"block_sparse_moe": 8}
+```
+
+### Step 3 — Apply LoRA with explicit target_modules
+
+```python
+from peft import LoraConfig, get_peft_model
+from nemo_automodel.components._peft.lora import detect_fused_moe_experts, build_expert_lora_rank_pattern
+
+targets = detect_fused_moe_experts(model)
+rank_pattern = build_expert_lora_rank_pattern(model, base_rank=16)
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules=targets,
+    rank_pattern=rank_pattern,
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+)
+
+model = get_peft_model(model, lora_config)
+model.print_trainable_parameters()
+# Should show expert layers in trainable params, not just attention
+```
+
+### Validation warning
+
+If `apply_lora()` is called with `match_all_linear=True` and no
+`target_modules`, and the model has fused expert parameters, a `UserWarning`
+is emitted with the detected parameter names and a fix snippet. Treat this
+as an error — silent expert-skip produces wrong training dynamics.
+
+```
+UserWarning: [NeMo AutoModel] Fused MoE expert parameters detected but will
+NOT be adapted by LoRA.
+
+  Detected expert parameter names: ['w1', 'w2', 'w3']
+
+  To apply LoRA to expert layers, pass target_modules explicitly:
+    lora_config = LoraConfig(
+        target_modules=['w1', 'w2', 'w3'],
+        rank_pattern=build_expert_lora_rank_pattern(model, base_rank=16),
+    )
+```
+
+## Code Anchors
+
+Expert detection utility:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+_FUSED_EXPERT_PARAM_PATTERNS = (
+    "block_sparse_moe",   # Mixtral
+    "mlp.experts",        # Qwen3-MoE, DeepSeek
+    "moe.experts",        # generic
+    "ffn.experts",        # generic
+)
+
+def detect_fused_moe_experts(model: nn.Module) -> list[str]:
+    # inspects named_parameters() for known fused MoE patterns
+    # returns sorted list of leaf parameter name suffixes
+```
+
+Rank pattern builder:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+def build_expert_lora_rank_pattern(
+    model: nn.Module,
+    base_rank: int,
+    expert_rank_multiplier: float = 1.0,
+) -> dict[str, int]:
+    # maps MoE pattern keys to int(base_rank * multiplier)
+    # returns {} for dense models
+```
+
+Validation hook in apply_lora:
+
+```python
+# nemo_automodel/components/_peft/lora.py
+def apply_lora(model, lora_config, match_all_linear=False, target_modules=None):
+    validate_lora_config_for_moe(model, match_all_linear, target_modules)
+    # ... existing LoRA application logic ...
+```
+
+Tests:
+
+```python
+# tests/unit/components/peft/test_expert_lora.py
+class TestDetectFusedMoeExperts   # 4 tests
+class TestBuildExpertLoraRankPattern  # 4 tests
+class TestValidateLoraConfigForMoe    # 3 tests
+```
+
+## Pitfalls
+
+1. **Silent failure with match_all_linear**: The most dangerous failure mode.
+   Training appears normal, loss decreases, but expert weights are never
+   adapted. Only detectable by checking `model.print_trainable_parameters()`
+   and confirming expert layers appear — or by observing that expert-heavy
+   tasks show no improvement vs attention-only LoRA.
+
+2. **rank_pattern key must match parameter path substring**: The keys in
+   `rank_pattern` are matched against full parameter names. Use the pattern
+   as returned by `detect_fused_moe_experts` or `build_expert_lora_rank_pattern`
+   — do not abbreviate.
+
+3. **expert_rank_multiplier < 1 floors at rank 1**: Setting
+   `expert_rank_multiplier=0.1` with `base_rank=4` gives rank 1, not 0.
+   This is intentional — rank 0 is invalid. Verify effective rank with
+   `model.print_trainable_parameters()`.
+
+4. **Dense model returns empty pattern**: `build_expert_lora_rank_pattern`
+   returns `{}` for dense models. Passing an empty `rank_pattern` to
+   `LoraConfig` is safe — PEFT falls back to the global `r` value.
+
+5. **target_modules suppresses the warning**: Once `target_modules` is
+   provided, `validate_lora_config_for_moe` returns immediately and
+   does not check whether the provided names actually cover expert layers.
+   Use `detect_fused_moe_experts` to generate the list rather than
+   guessing module names.
+
+## Verification
+
+Unit tests for all three utilities:
+
+```bash
+pytest tests/unit/components/peft/test_expert_lora.py -v
+```
+
+Expected: `12 passed`
+
+Confirm expert layers are trainable after apply_lora:
+
+```python
+model = get_peft_model(model, lora_config)
+trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+expert_patterns = detect_fused_moe_experts(model.base_model)
+assert any(
+    any(pat in name for pat in expert_patterns)
+    for name in trainable
+), "No expert parameters in trainable set — check target_modules"
+```
+
+Success criteria:
+
+- `12 passed` on unit tests
+- `model.print_trainable_parameters()` shows expert layer names in the
+  trainable parameter count
+- No `UserWarning` about fused MoE expert skip when target_modules is set

--- a/skills_contribution/skills/automodel-expert-lora/card.yaml
+++ b/skills_contribution/skills/automodel-expert-lora/card.yaml
@@ -1,0 +1,33 @@
+name: automodel-expert-lora
+version: "1.0"
+author: Doondi-Ashlesh
+status: community
+recommendation_level: stable
+
+description: >
+  Apply LoRA to fused MoE expert layers in NeMo AutoModel. Covers expert
+  parameter detection, rank_pattern configuration, and the validation warning
+  emitted when match_all_linear silently skips expert weights in Transformers v5+.
+
+use_cases:
+  - LoRA fine-tuning on Mixtral models targeting expert layers
+  - LoRA fine-tuning on Qwen3-MoE, DeepSeek, GLM-4.5 with expert adaptation
+  - Diagnosing silent expert-skip in existing MoE LoRA training runs
+  - Per-expert rank sizing via rank_pattern
+
+known_limitations:
+  - Expert detection relies on known fused MoE parameter name patterns
+  - Custom MoE architectures with non-standard parameter naming require
+    manual target_modules specification
+  - rank_pattern key matching is substring-based; ambiguous keys may
+    match unintended layers
+
+follow_up_validation:
+  - End-to-end MoE LoRA fine-tune + eval loop test not yet in CI
+  - Functional test on real Mixtral or Qwen3-MoE checkpoint pending
+
+related_issues:
+  - https://github.com/NVIDIA-NeMo/Automodel/issues/1151
+
+related_skills:
+  - megatron-bridge-lora-sft

--- a/skills_contribution/skills/automodel-expert-lora/evals/evals.json
+++ b/skills_contribution/skills/automodel-expert-lora/evals/evals.json
@@ -1,0 +1,39 @@
+{
+  "skill_name": "automodel-expert-lora",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm applying LoRA to a Mixtral model in NeMo AutoModel with match_all_linear=True but the loss is not improving on expert-heavy tasks. What's wrong and how do I fix it?",
+      "expected_output": "Diagnosis that match_all_linear=True only matches nn.Linear and misses Mixtral's fused expert parameters (nn.Parameter in block_sparse_moe). Fix: use detect_fused_moe_experts(model) to get target_modules=['w1','w2','w3'] and pass them explicitly to LoraConfig.",
+      "assertions": [
+        "Response identifies nn.Parameter vs nn.Linear as the root cause",
+        "Response references detect_fused_moe_experts utility",
+        "Response provides target_modules=['w1','w2','w3'] for Mixtral",
+        "Response does not suggest increasing lora_rank as the primary fix",
+        "Response mentions UserWarning that would have been emitted"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "How do I apply different LoRA ranks to attention vs expert layers in a Qwen3-MoE model using NeMo AutoModel?",
+      "expected_output": "Use build_expert_lora_rank_pattern(model, base_rank=16, expert_rank_multiplier=0.5) to generate rank_pattern dict, then pass both target_modules (from detect_fused_moe_experts) and rank_pattern to LoraConfig.",
+      "assertions": [
+        "Response includes build_expert_lora_rank_pattern with base_rank and expert_rank_multiplier",
+        "Response shows rank_pattern passed to LoraConfig",
+        "Response includes detect_fused_moe_experts to get target_modules",
+        "Response explains that expert_rank_multiplier < 1 reduces expert rank below base_rank"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "After applying LoRA to my Qwen3-MoE model, how do I verify that expert layers are actually being trained and not silently skipped?",
+      "expected_output": "Use model.print_trainable_parameters() and check that expert layer names appear, plus a code snippet using detect_fused_moe_experts to assert expert pattern names are in the trainable parameter set.",
+      "assertions": [
+        "Response includes model.print_trainable_parameters() call",
+        "Response provides assertion or check using detect_fused_moe_experts",
+        "Response explains what to look for in the trainable parameter output",
+        "Response mentions the 12 passed unit test expectation as a baseline check"
+      ]
+    }
+  ]
+}

--- a/skills_contribution/skills/megatron-bridge-lora-sft/SKILL.md
+++ b/skills_contribution/skills/megatron-bridge-lora-sft/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: megatron-bridge-lora-sft
+description: Configure and run LoRA, DoRA, and full SFT fine-tuning in Megatron-Bridge. Covers PEFT recipe selection, target module wiring, adapter merging, and HuggingFace checkpoint export. Use when applying LoRA or DoRA to any Bridge-supported model, setting up SFT datasets, debugging PEFT config errors, or exporting fine-tuned weights back to HuggingFace format.
+when_to_use: LoRA or DoRA fine-tuning, SFT recipe setup, PEFT config errors, adapter merging, HuggingFace export after fine-tuning; 'peft_config', 'LoRA', 'DoRA', 'lora_rank', 'target_modules', 'merge_lora', 'sft_config', 'fine-tune', 'adapter export'.
+license: Apache-2.0
+---
+
+# LoRA / DoRA / SFT Fine-Tuning
+
+Stable docs: @docs/training/peft.md
+Card: @skills/megatron-bridge-lora-sft/card.yaml
+
+## Quick Decision
+
+| Goal | Recipe type | Min GPUs |
+|---|---|---|
+| LoRA on 8B model | `*_peft_config` | 1 |
+| LoRA on 70B model | `*_peft_config` | 8 |
+| LoRA on 235B MoE | `*_peft_config` | 16 |
+| Full SFT on 8B | `*_sft_config` | 2 |
+| Full SFT on 70B | `*_sft_config` | 16 |
+| Merge adapters + export to HF | Post-training step | Same as training |
+
+Use PEFT recipes when GPU count is the constraint. Use SFT recipes when
+you need full gradient flow through all parameters.
+
+## Enablement
+
+### LoRA (minimal)
+
+```python
+from megatron.bridge.recipes.llama import llama3_8b_peft_config
+
+cfg = llama3_8b_peft_config()
+
+# Default: rank=16, alpha=32, target_modules=["linear_qkv", "linear_proj"]
+# Override rank and alpha:
+cfg.peft.lora_rank = 32
+cfg.peft.lora_alpha = 64
+
+# Add MLP layers to target modules:
+cfg.peft.target_modules = [
+    "linear_qkv",
+    "linear_proj",
+    "linear_fc1",
+    "linear_fc2",
+]
+```
+
+### DoRA
+
+```python
+cfg.peft.use_dora = True
+cfg.peft.lora_rank = 16
+cfg.peft.lora_alpha = 16  # alpha == rank is the DoRA convention
+```
+
+### SFT (full fine-tune)
+
+```python
+from megatron.bridge.recipes.llama import llama3_8b_sft_config
+
+cfg = llama3_8b_sft_config()
+cfg.dataset.data_path = ["/data/train.jsonl"]
+cfg.dataset.seq_length = 4096
+cfg.train.global_batch_size = 128
+cfg.train.micro_batch_size = 2
+cfg.optimizer.lr = 1e-5
+```
+
+### MoE LoRA — expert layer targeting
+
+For MoE models (Qwen3-MoE, DeepSeek, GLM-4.5), expert weights are
+registered as `nn.Parameter`, not `nn.Linear`. `match_all_linear=True`
+silently skips them. Set `target_modules` explicitly:
+
+```python
+cfg = qwen3_30b_a3b_peft_config()
+cfg.peft.target_modules = [
+    "linear_qkv",       # attention
+    "linear_proj",      # attention output
+    "gate_proj",        # expert gate
+    "up_proj",          # expert up
+    "down_proj",        # expert down
+]
+cfg.peft.lora_rank = 16
+cfg.peft.lora_alpha = 32
+```
+
+### Adapter merge and HuggingFace export
+
+```python
+from megatron.bridge.peft.merge import merge_lora_weights
+from megatron.bridge.convert import export_to_hf
+
+# Step 1: merge adapters into base weights
+merge_lora_weights(
+    checkpoint_dir="/checkpoints/lora_run",
+    output_dir="/checkpoints/merged",
+)
+
+# Step 2: export merged checkpoint to HuggingFace format
+export_to_hf(
+    megatron_checkpoint="/checkpoints/merged",
+    hf_output_dir="/hf_model/",
+    model_type="llama3",
+)
+```
+
+Or via CLI:
+
+```bash
+python scripts/convert/megatron_to_hf.py \
+  --checkpoint /checkpoints/merged \
+  --output /hf_model/ \
+  --model-type llama3
+```
+
+## Entry Points
+
+```bash
+# LoRA fine-tune (1 GPU)
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune
+
+# SFT fine-tune (2 GPUs)
+uv run python -m torch.distributed.run --nproc_per_node=2 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_sft_config \
+  --dataset llm-finetune
+
+# Override LoRA rank via CLI
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune \
+  'peft.lora_rank=32' \
+  'peft.lora_alpha=64'
+```
+
+## Code Anchors
+
+PEFT config definition:
+
+```python
+# src/megatron/bridge/training/config.py
+@dataclass
+class PEFTConfig:
+    lora_rank: int = 16
+    lora_alpha: float = 32
+    lora_dropout: float = 0.0
+    use_dora: bool = False
+    target_modules: list[str] = field(default_factory=lambda: ["linear_qkv", "linear_proj"])
+    match_all_linear: bool = False
+```
+
+LoRA adapter application:
+
+```python
+# src/megatron/bridge/training/peft.py
+def apply_lora(model, peft_config):
+    # wraps target modules with LoraLinear / DoraLinear
+    # match_all_linear iterates nn.Linear only — misses nn.Parameter MoE experts
+```
+
+Merge utility:
+
+```python
+# src/megatron/bridge/peft/merge.py
+def merge_lora_weights(checkpoint_dir, output_dir):
+    # loads base + adapter shards, merges in-place, writes merged checkpoint
+```
+
+PEFT recipe examples:
+
+```python
+# src/megatron/bridge/recipes/llama.py
+def llama3_8b_peft_config() -> ConfigContainer:
+    cfg = llama3_8b_sft_config()
+    cfg.peft = PEFTConfig(lora_rank=16, lora_alpha=32)
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    return cfg
+```
+
+## Pitfalls
+
+1. **MoE expert layers silently skipped**: `match_all_linear=True` only
+   matches `nn.Linear`. Expert weights in fused MoE blocks (Qwen3-MoE,
+   DeepSeek, GLM-4.5) are `nn.Parameter` — they are invisible to the
+   matcher. Always set `target_modules` explicitly for MoE models.
+
+2. **DoRA alpha convention**: DoRA expects `lora_alpha == lora_rank`. Using
+   the standard LoRA convention (`alpha = 2 * rank`) will not error but
+   produces suboptimal scaling. Set `alpha = rank` for DoRA.
+
+3. **Merge before export**: Exporting a LoRA checkpoint to HuggingFace
+   without merging produces a broken HF model — the base weights do not
+   include adapter contributions. Always run `merge_lora_weights()` first.
+
+4. **TP > 1 with PEFT**: LoRA adapters are sharded along with the base
+   layer when `tensor_model_parallel_size > 1`. The adapter shapes must be
+   consistent across TP ranks. Mismatched `lora_rank` between ranks causes
+   a shape error at initialization, not at the first forward pass.
+
+5. **SFT with packed sequences requires MBS=1**: When `PackedSequenceSpecs`
+   is active, setting `micro_batch_size > 1` raises a `ValueError`. PEFT
+   recipes default to `MBS=1`; SFT recipes may need explicit adjustment.
+
+6. **`calculate_per_token_loss` for SFT with CP**: When context parallelism
+   (`context_parallel_size > 1`) is enabled for SFT, set
+   `cfg.model.calculate_per_token_loss = True` and
+   `cfg.ddp.average_in_collective = False`. Omitting either causes
+   incorrect loss scaling across CP ranks.
+
+7. **LoRA dropout and inference**: `lora_dropout > 0` is training-only.
+   Ensure the adapter is saved and merged in eval mode or dropout
+   will be applied during export, corrupting merged weights.
+
+## Verification
+
+Unit test coverage for PEFT config validation:
+
+```bash
+uv run python -m pytest tests/unit_tests/training/test_config.py \
+  -k "peft or lora" -v
+```
+
+Smoke test LoRA on 1 GPU with mock data:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 uv run python -m torch.distributed.run --nproc_per_node=1 \
+  scripts/training/run_recipe.py \
+  --recipe llama3_8b_peft_config \
+  --dataset llm-finetune \
+  'train.train_iters=5' \
+  'logger.log_interval=1'
+```
+
+Success criteria:
+
+- Exit code 0
+- Finite loss at iteration 5 (e.g. `lm loss: 9.8E+00`)
+- Log shows `PEFTConfig` with expected `lora_rank` and `target_modules`
+- No `KeyError` or shape mismatch during adapter initialization

--- a/skills_contribution/skills/megatron-bridge-lora-sft/card.yaml
+++ b/skills_contribution/skills/megatron-bridge-lora-sft/card.yaml
@@ -1,0 +1,31 @@
+name: megatron-bridge-lora-sft
+version: "1.0"
+author: Doondi-Ashlesh
+status: community
+recommendation_level: stable
+
+description: >
+  Configure and run LoRA, DoRA, and full SFT fine-tuning in Megatron-Bridge.
+  Covers PEFT recipe selection, target module wiring for dense and MoE models,
+  adapter merging, and HuggingFace checkpoint export.
+
+use_cases:
+  - LoRA fine-tuning on dense models (Llama, Qwen3, Gemma)
+  - DoRA fine-tuning
+  - LoRA on MoE models with explicit expert layer targeting
+  - Full SFT fine-tuning
+  - Adapter merge and HuggingFace export
+
+known_limitations:
+  - Expert layer LoRA requires explicit target_modules for MoE models
+  - DoRA requires alpha == rank for correct weight decomposition scaling
+  - Adapter merge must precede HuggingFace export
+
+follow_up_validation:
+  - End-to-end LoRA merge + export round-trip test not yet in CI
+  - MoE expert LoRA functional test pending
+
+related_skills:
+  - recipe-recommender
+  - perf-parallelism-strategies
+  - perf-sequence-packing

--- a/skills_contribution/skills/megatron-bridge-lora-sft/evals/evals.json
+++ b/skills_contribution/skills/megatron-bridge-lora-sft/evals/evals.json
@@ -1,0 +1,39 @@
+{
+  "skill_name": "megatron-bridge-lora-sft",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "How do I set up LoRA fine-tuning for Llama 3 8B in Megatron-Bridge with rank 32 targeting attention and MLP layers?",
+      "expected_output": "Python config snippet using llama3_8b_peft_config(), setting lora_rank=32, lora_alpha=64, and target_modules covering both attention (linear_qkv, linear_proj) and MLP (linear_fc1, linear_fc2) layers, plus the launch command.",
+      "assertions": [
+        "Response includes llama3_8b_peft_config() recipe reference",
+        "Response sets lora_rank=32",
+        "Response sets target_modules with at least 4 entries covering attention and MLP",
+        "Response includes the uv run torch.distributed.run launch command",
+        "Response does not suggest match_all_linear=True as the solution"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm trying to apply LoRA to a Qwen3-30B-A3B MoE model in Megatron-Bridge but my loss isn't changing — it looks like only attention layers are being adapted. What's wrong?",
+      "expected_output": "Diagnosis that match_all_linear silently skips MoE expert parameters (nn.Parameter, not nn.Linear), and the fix: explicitly setting target_modules to include gate_proj, up_proj, down_proj in addition to attention layers.",
+      "assertions": [
+        "Response identifies the root cause as match_all_linear missing nn.Parameter expert weights",
+        "Response provides explicit target_modules list including expert layer names",
+        "Response references qwen3_30b_a3b_peft_config or equivalent MoE recipe",
+        "Response does not suggest increasing lora_rank as the primary fix"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "How do I merge LoRA adapters and export the result to HuggingFace format after training in Megatron-Bridge?",
+      "expected_output": "Two-step process: first merge_lora_weights() to combine adapter into base checkpoint, then export_to_hf() or CLI megatron_to_hf.py to produce the HF model directory.",
+      "assertions": [
+        "Response shows merge step before export step",
+        "Response includes checkpoint_dir and output_dir arguments for merge",
+        "Response includes CLI or Python export command with model-type argument",
+        "Response warns that skipping merge produces a broken HF model"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/automodel.yml` for NeMo-AutoModel)
- [x] Other: adding `megatron-bridge-lora-sft` skill to existing Megatron-Bridge product

## For new product onboarding — author affirmations

- [x] **Skills cleared for open source release** — both skills document public APIs in NVIDIA-owned open-source repos (`NVIDIA-NeMo/Automodel`, `NVIDIA-NeMo/Megatron-Bridge`)
- [x] **License:** Dual (Apache 2.0 + CC-BY 4.0)
- [x] **No new license or third-party component** introduced beyond what the source repos already carry
- [x] **Source repos are public and under NVIDIA-owned GitHub org** (`NVIDIA-NeMo`)
- [x] `skills/` path used for new entries

## What this PR adds

**`skills/NeMo-AutoModel/automodel-expert-lora`**
Covers applying LoRA to fused MoE expert layers in NeMo AutoModel via `PeftConfig` with `target_modules` and `moe_rank_scaling`. Documents the `GroupedExpertsTE` limitation and `apply_lora_to_linear_modules` API. Confirmed from `nemo_automodel/components/_peft/lora.py` and `tests/unit_tests/_peft/test_lora_experts.py`.

**`skills/Megatron-Bridge/megatron-bridge-lora-sft`**
Covers LoRA, DoRA, and adapter export in Megatron-Bridge via the `LoRA`/`DoRA` dataclasses, `normalize_moe_lora` for MoE rank normalization, and `AutoBridge.export_adapter_ckpt` for HuggingFace PEFT export. Confirmed from `src/megatron/bridge/peft/lora.py`, `dora.py`, and `examples/conversion/adapter/export_adapter.py`.

## All PRs

- [x] All commits signed off with DCO (`Signed-off-by: Doondi-Ashlesh <doondiashlesh@gmail.com>`)