### PR TITLE
components.d: register Video Search and Summarization

### DIFF
--- a/components.d/video-search-and-summarization.yml
+++ b/components.d/video-search-and-summarization.yml
@@ -1,0 +1,6 @@
+name: Video Search and Summarization
+repo: NVIDIA-AI-Blueprints/video-search-and-summarization
+description: VSS Blueprint — deploy profiles, search and summarize video, generate analysis reports, manage alerts and incidents, query VIOS sensors, and use the RTVI VLM microservice.
+skills:
+  - path: skills/
+    catalog_dir: video-search-and-summarization


### PR DESCRIPTION
## Summary

Adds \`components.d/video-search-and-summarization.yml\` to register the VSS Blueprint repo with the NVIDIA/skills sync catalog.

\`\`\`yaml
name: Video Search and Summarization
repo: NVIDIA-AI-Blueprints/video-search-and-summarization
description: VSS Blueprint — deploy profiles, search and summarize video, generate analysis reports, manage alerts and incidents, query VIOS sensors, and use the RTVI VLM microservice.
skills:
  - path: skills/
    catalog_dir: video-search-and-summarization
\`\`\`

## Path confirmation (treated as public API)

Per the onboarding guide, the \`path\` is part of the source repo's public API. Confirmed:

- **Path:** \`skills/\` (repo root, not \`.agents/skills/\` or \`.claude/skills/\`).
- **Catalog dir:** \`video-search-and-summarization\` (matches the repo basename / slug).
- The directory has been at this location since the skills landed on the source repo's \`feat/skills\` development branch and is the canonical location going forward.

## Skills currently in scope

10 SKILL.md files at the time of registration: \`alerts\`, \`deploy\`, \`report\`, \`rt-vlm\`, \`video-analytics\`, \`video-search\`, \`video-summarization\`, \`video-understanding\`, \`vios\`, \`vss-frag\`.

Each frontmatter declares \`license: Apache-2.0\` and a \`metadata:\` block with \`version\`, \`github-url\`, and Blueprint-tagged \`tags\` per the finalized publishing template (cf. PR #294 against NVIDIA-AI-Blueprints/video-search-and-summarization).

## IP / license affirmations

- All skills under \`skills/\` are licensed Apache-2.0 (declared in each \`SKILL.md\` frontmatter).
- IP review process for the source repo follows the upstream IP Review checklist.
- No new license or third-party dependency introduced by this registration entry — this PR only adds a sync-config file.

## Test plan

- [x] CI green on this PR (DCO sign-off, YAML lint, schema validation).
- [ ] Once merged, the daily sync workflow picks up \`skills/\` from the source repo and mirrors to \`skills/video-search-and-summarization/\` in this catalog.
- [ ] Available Skills table in README.md regenerates with the new entry; Version column shows the upstream short SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)