### PR TITLE
Improve README quickstart readability and command discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,81 @@ We are building this in the open. The catalog, sync pipeline, and roadmap are pu
 
 Use the [`skills` CLI](https://github.com/vercel-labs/skills) to install NVIDIA skills into the AI agent you use. The CLI runs through `npx`, so you do not need to clone this repo or copy skill folders by hand.
 
+Pick the command that matches what you want to do. Each section below keeps commands in copyable command blocks.
+
+| Goal | Start here |
+|------|------------|
+| Browse the catalog | [Browse the Catalog](#browse-the-catalog) |
+| Install interactively | [Install Interactively](#install-interactively) |
+| Install one skill without prompts | [Install One Skill](#install-one-skill) |
+| Install one skill for a specific agent | [Install for Specific Agents](#install-for-specific-agents) |
+
+### Browse the Catalog
+
+Use this when you want to see available NVIDIA skills before installing anything.
+
 ```bash
-# Browse the NVIDIA catalog without installing anything
 npx skills add nvidia/skills --list
+```
 
-# Install from the NVIDIA catalog (interactive)
+### Install Interactively
+
+Use this when you want the CLI to walk you through skill and destination choices.
+
+```bash
 npx skills add nvidia/skills
+```
 
-# Install one skill into the current project and skip prompts
+### Install One Skill
+
+Use this when you already know the skill name and want to skip prompts.
+
+```bash
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --yes
 ```
 
-That's it — the skill activates automatically the next time your agent encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API.
+Replace `cuopt-numerical-optimization-api-python` with any skill name from the catalog.
 
-The CLI can prompt you to choose where to install the skill, or you can target agents explicitly using a `--agent` option, e.g. `--agent claude-code --agent codex --agent cursor`.
+### Install for Specific Agents
+
+Use `--agent` to target a specific AI coding agent. These are common client targets; for the full list of supported clients, see the [`skills` CLI Supported Agents table](https://github.com/vercel-labs/skills#supported-agents).
+
+**Claude Code**
+
+```bash
+npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent claude-code
+```
+
+**Codex**
+
+```bash
+npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent codex
+```
+
+**Cursor**
+
+```bash
+npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent cursor
+```
+
+**Kiro CLI**
+
+```bash
+npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent kiro-cli
+```
+
+Use `--agent` more than once to install the same skill into multiple agents.
+
+```bash
+npx skills add nvidia/skills \
+  --skill cuopt-numerical-optimization-api-python \
+  --agent claude-code \
+  --agent codex \
+  --agent cursor \
+  --agent kiro-cli
+```
+
+That's it — the skill is available the next time your agent loads skills and encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API.
 
 For non-interactive installs, global installs, agent-specific installs, updates, removals, and fallback manual copying, see [Advanced installation](docs/advanced-install.md).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. We are making NVIDIA skills available publicly and building this catalog in the open; see the [Roadmap](#roadmap) for what is planned next.
+Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. This repository is a catalog: skills are maintained in their respective product repos and mirrored here daily via an automated sync pipeline. We are making NVIDIA skills available publicly and building this catalog in the open; see the [Roadmap](#roadmap) for what is planned next.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use this when you already know the skill name and want to skip prompts.
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --yes
 ```
 
-Replace `cuopt-numerical-optimization-api-python` with any skill name from the catalog.
+Replace `cuopt-numerical-optimization-api-python` with any skill name from the [Skill Catalog](#skill-catalog).
 
 ### Install for a Specific Agent
 
@@ -94,7 +94,7 @@ For non-interactive installs, global installs, agent-specific installs, updates,
 
 ---
 
-## Available Skills
+## Skill Catalog
 
 <!-- skills-table-start -->
 | Product | Description | Skills | Catalog | Source | Version |
@@ -189,7 +189,7 @@ NVIDIA/skills/
 └── LICENSE                  # Apache 2.0
 ```
 
-Skills are maintained in their respective product repos (see the **Source** column in [Available Skills](#available-skills)) and automatically synced to this repo daily.
+Skills are maintained in their respective product repos (see the **Source** column in the [Skill Catalog](#skill-catalog)) and automatically synced to this repo daily.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --a
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent cursor
 ```
 
-**Kiro CLI**
+**Kiro**
 
 ```bash
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --agent kiro-cli

--- a/README.md
+++ b/README.md
@@ -11,44 +11,23 @@
 
 ---
 
-Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. From solving vehicle routing problems with cuOpt, to deploying RAG pipelines, to onboarding models into TensorRT-LLM, every skill listed here is **published and verified by NVIDIA**.
-
-This repository is a **catalog** — skills are maintained in their respective product repos and mirrored here daily via an automated sync pipeline. It follows the open [Agent Skills specification](https://agentskills.io/specification), making skills compatible with any AI agent or framework that supports the standard.
-
-We are building this in the open. The catalog, sync pipeline, and roadmap are public so the community can see what we ship, what we plan to ship, and how we secure skills for use. As we add signing, scanning, and evaluation, each improvement lands here incrementally.
+Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. Every skill listed here is **published and verified by NVIDIA**.
 
 ---
 
 ## Quickstart
 
-Use the [`skills` CLI](https://github.com/vercel-labs/skills) to install NVIDIA skills into the AI agent you use. The CLI runs through `npx`, so you do not need to clone this repo or copy skill folders by hand.
-
-Pick the command that matches what you want to do. Each section below keeps commands in copyable command blocks.
-
-| Goal | Start here |
-|------|------------|
-| Browse the catalog | [Browse the Catalog](#browse-the-catalog) |
-| Install interactively | [Install Interactively](#install-interactively) |
-| Install one skill without prompts | [Install One Skill](#install-one-skill) |
-| Install one skill for a specific agent | [Install for Specific Agents](#install-for-specific-agents) |
-
-### Browse the Catalog
-
-Use this when you want to see available NVIDIA skills before installing anything.
-
-```bash
-npx skills add nvidia/skills --list
-```
-
-### Install Interactively
-
-Use this when you want the CLI to walk you through skill and destination choices.
+Install NVIDIA skills with the default [`skills` CLI](https://github.com/vercel-labs/skills) flow:
 
 ```bash
 npx skills add nvidia/skills
 ```
 
-### Install One Skill
+The CLI runs through `npx` and prompts you to choose a skill and install destination. You do not need to clone this repo or copy skill folders by hand.
+
+The skill is available the next time your agent loads skills and encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API.
+
+### Install One Skill Without Prompts
 
 Use this when you already know the skill name and want to skip prompts.
 
@@ -58,7 +37,7 @@ npx skills add nvidia/skills --skill cuopt-numerical-optimization-api-python --y
 
 Replace `cuopt-numerical-optimization-api-python` with any skill name from the catalog.
 
-### Install for Specific Agents
+### Install for a Specific Agent
 
 Use `--agent` to target a specific AI coding agent. These are common client targets; for the full list of supported clients, see the [`skills` CLI Supported Agents table](https://github.com/vercel-labs/skills#supported-agents).
 
@@ -97,7 +76,13 @@ npx skills add nvidia/skills \
   --agent kiro-cli
 ```
 
-That's it — the skill is available the next time your agent loads skills and encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API.
+### Browse the Catalog
+
+Use this when you want to see available NVIDIA skills before installing anything.
+
+```bash
+npx skills add nvidia/skills --list
+```
 
 For non-interactive installs, global installs, agent-specific installs, updates, removals, and fallback manual copying, see [Advanced installation](docs/advanced-install.md).
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 <!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
 <!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
 
-<p align="center">
-  <a href="https://commons.wikimedia.org/wiki/File:NVIDIA_logo.svg">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/NVIDIA_logo.svg" alt="NVIDIA logo" width="180">
-  </a>
-</p>
-
-# NVIDIA Agent Skills
+<h1>
+  <a href="https://commons.wikimedia.org/wiki/File:NVIDIA_logo.svg"><img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/NVIDIA_logo.svg" alt="NVIDIA" height="36"></a>
+  Agent Skills
+</h1>
 
 **Official, NVIDIA-verified skills for AI agents.**
 
@@ -17,7 +14,7 @@
 
 ---
 
-Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. Every skill listed here is **published and verified by NVIDIA**.
+Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. We are making NVIDIA skills available publicly and building this catalog in the open; see the [Roadmap](#roadmap) for what is planned next.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
 <!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
 
-<h1>
-  <a href="https://commons.wikimedia.org/wiki/File:NVIDIA_logo.svg"><img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/NVIDIA_logo.svg" alt="NVIDIA" height="36"></a>
-  Agent Skills
-</h1>
+# NVIDIA Agent Skills
 
 **Official, NVIDIA-verified skills for AI agents.**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
 <!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
 
+<p align="center">
+  <a href="https://commons.wikimedia.org/wiki/File:NVIDIA_logo.svg">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/NVIDIA_logo.svg" alt="NVIDIA logo" width="180">
+  </a>
+</p>
+
 # NVIDIA Agent Skills
 
 **Official, NVIDIA-verified skills for AI agents.**


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Summary

- Pruned the README intro so the repository purpose and Quickstart appear sooner.
- Made the default install flow the first and most prominent Quickstart command:

  ```bash
  npx skills add nvidia/skills
  ```

- Reorganized secondary install paths under Quickstart:
  - one-skill installs without prompts
  - agent-specific installs
  - multi-agent installs
  - catalog browsing
- Split commands into copyable fenced blocks.
- Added common agent callouts for Claude Code, Codex, Cursor, and Kiro.
- Linked to the upstream `skills` CLI supported agents table.
- Renamed `Available Skills` to `Skill Catalog`.
- Linked Quickstart guidance directly to the Skill Catalog.
- Updated the intro to note that NVIDIA skills are available publicly and that the catalog is being built in the open, with a Roadmap link.

## Validation

- Ran `git diff --check`.
- Markdown-only README changes; no runtime tests needed.
