### PR TITLE
Register NVIDIA Digital Health Examples skills

### DIFF
--- a/components.d/digital-health-examples.yml
+++ b/components.d/digital-health-examples.yml
@@ -2,7 +2,15 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: NVIDIA Digital Health Examples
 repo: NVIDIA/digital-health-examples
-description: Agent skills for the clinical ASR evaluation flywheel — term curation, synthetic clinical-speech benchmark generation, KER (Keyword Error Rate) scoring, and fine-tune guidance. Skills are self-contained (no sibling-skill dependencies). Includes clinical-flywheel-{setup,build,eval,finetune}.
+description: Agent skills for the clinical ASR evaluation flywheel — term curation, synthetic clinical-speech benchmark generation, KER (Keyword Error Rate) scoring, and fine-tune guidance.
 skills:
-  - path: .agents/skills/
-    catalog_dir: digital-health-examples
+  - path: skills/digital-health-clinical-asr-setup/
+    catalog_dir: digital-health-clinical-asr-setup
+  - path: skills/digital-health-clinical-asr-build/
+    catalog_dir: digital-health-clinical-asr-build
+  - path: skills/digital-health-clinical-asr-eval/
+    catalog_dir: digital-health-clinical-asr-eval
+  - path: skills/digital-health-clinical-asr-finetune/
+    catalog_dir: digital-health-clinical-asr-finetune
+links:
+  discussions: false

--- a/components.d/digital-health-examples.yml
+++ b/components.d/digital-health-examples.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: NVIDIA Digital Health Examples
 repo: NVIDIA/digital-health-examples
-description: Agent skills for clinical AI workflows — clinical ASR evaluation flywheel (term curation, synthetic benchmark generation, KER scoring, fine-tune guidance).
+description: Agent skills for the clinical ASR evaluation flywheel — term curation, synthetic clinical-speech benchmark generation, KER (Keyword Error Rate) scoring, and fine-tune guidance. Skills are self-contained (no sibling-skill dependencies). Includes clinical-flywheel-{setup,build,eval,finetune}.
 skills:
   - path: .agents/skills/
     catalog_dir: digital-health-examples

--- a/components.d/digital-health-examples.yml
+++ b/components.d/digital-health-examples.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: NVIDIA Digital Health Examples
+repo: NVIDIA/digital-health-examples
+description: Agent skills for clinical AI workflows — clinical ASR evaluation flywheel (term curation, synthetic benchmark generation, KER scoring, fine-tune guidance).
+skills:
+  - path: .agents/skills/
+    catalog_dir: digital-health-examples


### PR DESCRIPTION
Add catalog entry for NVIDIA/digital-health-examples with 4 clinical ASR workflow skills:
- clinical-asr-setup
- clinical-asr-build
- clinical-asr-eval
- clinical-asr-finetune

Skills are docs-only workflow guides (SKILL.md + references + evals), licensed Apache-2.0, cleared via OSRB 6177622, registered in nSpect as NSPECT-OZP0-77O4 alpha-0.1.0.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
