### PR TITLE
Add DALI to skills catalog

### DIFF
--- a/components.d/dali.yml
+++ b/components.d/dali.yml
@@ -1,0 +1,9 @@
+name: DALI
+repo: NVIDIA/DALI
+description: GPU-accelerated data loading and processing with NVIDIA DALI.
+skills:
+  - path: .agents/skills
+    catalog_dir: DALI
+links:
+   discussions: false
+   security: false  # DALI has a SECURITY.rst file


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [X] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [X] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [X] **License selected:** Apache 2.0
- [X] **No new license or new third-party component** introduced beyond what the source repo already carries
- [X] **Source repo is public and under an NVIDIA-owned GitHub org**
- [X] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [X] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
