### PR TITLE
Register AI-Q Blueprint skills

### DIFF
--- a/components.d/aiq.yml
+++ b/components.d/aiq.yml
@@ -1,0 +1,9 @@
+name: AI-Q Blueprint
+repo: NVIDIA-AI-Blueprints/aiq
+ref: develop
+description: NVIDIA AI-Q Blueprint - deploy local AI-Q services and run shallow or deep research workflows as agent skills.
+skills:
+  - path: skills/aiq-research/
+    catalog_dir: aiq-research
+  - path: skills/aiq-deploy/
+    catalog_dir: aiq-deploy


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)

## For new product onboarding - author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] Skills cleared for open source release per NVIDIA internal IP review process (six-question check, all answers affirmative)
- [x] License selected: Apache 2.0
- [x] No new license or new third-party component introduced beyond what the source repo already carries
- [x] Source repo is public and under an NVIDIA-owned GitHub org
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [x] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context

Registers `components.d/aiq.yml` so the skills catalog sync can mirror both public AI-Q Blueprint skills from `NVIDIA-AI-Blueprints/aiq`.

Catalog entries:

- `skills/aiq-research/` -> `skills/aiq-research/`
- `skills/aiq-deploy/` -> `skills/aiq-deploy/`

The entry currently targets `ref: develop` because the AIQ skills update is landing there first. Move this to `main` or a stable release branch once AIQ stabilizes there.

Validation:

- Parsed `components.d/aiq.yml` with the Ruby standard YAML parser.
- Ran `git diff --check`.
- Confirmed the local AIQ skill branch contains direct `SKILL.md` entrypoints for `skills/aiq-research/` and `skills/aiq-deploy/`.
- Ran a dry-run rsync check that copies each source skill path into its catalog directory without nested duplicate skill folders.