### PR TITLE
feat: register NeMo-RL for skills catalog sync

### DIFF
--- a/components.d/nemo-rl.yml
+++ b/components.d/nemo-rl.yml
@@ -1,0 +1,6 @@
+name: NeMo-RL
+repo: NVIDIA-NeMo/RL
+description: RLHF training on Ray — GRPO, DPO, and SFT for LLMs and VLMs with FSDP2 and Megatron-Core.
+skills:
+  - path: skills/
+    catalog_dir: NeMo-RL


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Dual (Apache 2.0 + CC-BY 4.0) — pending IP review for initial customer-facing skills
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org** (`NVIDIA-NeMo/RL`)
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`) — `skills/` at repo root; `.agents/skills` symlinks to `../skills`

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Component entry

- **File:** `components.d/nemo-rl.yml`
- **Source repo:** https://github.com/NVIDIA-NeMo/RL
- **Skills path:** `skills/`
- **Catalog dir:** `NeMo-RL`

Registration-only PR. Follow-up on the source repo will move contributor-facing skills out of the synced tree and add customer-facing `ai-ml-nemo-rl-*` skills before relying on the first sync.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

Signed-off-by: Anwith Kiran <anwithk@nvidia.com>