### PR TITLE
docs: Skills Card -> Skill Card in README roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For issues with **this catalog repo itself** (README, structure, listing a new p
 - ✅ Security scanning for all published skills covering instruction safety and supply-chain integrity
 - 🔲 Skills signing so every published skill carries a verifiable NVIDIA signature
 - 🔲 Skills universal evaluation criteria and task-specific criteria
-- 🔲 Skills Card with machine-readable metadata for identity, provenance, quality, and behavioral boundaries
+- 🔲 Skill Card with machine-readable metadata for identity, provenance, quality, and behavioral boundaries
 - 🔲 Compliance gates before external publication
 - 🔲 Syndication to external marketplaces and MCP hubs
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [X] Other (catalog change, README fix, infrastructure, etc.)

## Other context (for non-onboarding PRs)

One-line copy fix in the Roadmap section of the README. Each catalog skill carries its own machine-readable manifest, so the proper noun is **Skill Card** (singular, per-skill artifact), not "Skills Card."

Verified this is the only occurrence of "Skills Card" anywhere in the repo (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CHANGELOG.md`, `components.d/README.md`, `docs/advanced-install.md`, PR template, workflows, and `.github/scripts/`).

No other files touched. No content changes beyond the rename.

## All PRs

- [X] All commits signed off with DCO (`git commit -s`).