### PR TITLE
Create request-nvskills-ci.yml

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/nvskills-ci/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
