### PR TITLE
docs: publish Fern documentation site for NVIDIA Skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.0] - 2025-05-21
+
+### Added
+
+- Long-form documentation site published via Fern ([`fern/docs.yml`](fern/docs.yml), [`fern/fern.config.json`](fern/fern.config.json))
+- New documentation pages in [`docs/`](docs/):
+
+### Changed
+
+- Converted [`docs/advanced-install.md`](docs/advanced-install.md) to [`docs/advanced-install.mdx`](docs/advanced-install.mdx) for the Fern docs site
+- Updated [`README.md`](README.md) project structure section to list the new `docs/` and `fern/` directories
+
 ## [0.2.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,8 +180,16 @@ NVIDIA/skills/
 │   ├── ...
 │   ├── tensorrt-llm.yml
 │   └── README.md             # Schema and onboarding instructions
-├── docs/
-│   └── advanced-install.md   # Advanced skills CLI usage
+├── docs/                    # Long-form documentation (published via Fern)
+│   ├── README.md             # How to build the docs locally
+│   ├── index.mdx
+│   ├── advanced-install.mdx  # Advanced skills CLI usage
+│   ├── agent-skill-trust-pipeline.mdx
+│   ├── release-checklist.mdx
+│   ├── scanning-agent-skills.mdx
+│   ├── signing-agent-skills.mdx
+│   └── skill-cards.mdx
+├── fern/                    # Fern docs site configuration
 ├── .github/workflows/       # Automated sync pipeline
 ├── CONTRIBUTING.md          # Contribution guidelines
 ├── SECURITY.md              # Security reporting policy

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use this when you want to see available NVIDIA skills before installing anything
 npx skills add nvidia/skills --list
 ```
 
-For non-interactive installs, global installs, agent-specific installs, updates, removals, and fallback manual copying, see [Advanced installation](docs/advanced-install.md).
+For non-interactive installs, global installs, agent-specific installs, updates, removals, and fallback manual copying, see [Advanced installation](docs/advanced-install.mdx).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
+<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
+
+# Documentation
+
+Long-form documentation for the NVIDIA Agent Skills catalog. Pages are authored in MDX and published to <https://docs.nvidia.com/skills>.
+
+## Layout
+
+- `index.mdx` — landing page
+- `advanced-install.mdx` — advanced skills CLI usage
+- `agent-skill-trust-pipeline.mdx` — trust pipeline overview
+- `scanning-agent-skills.mdx` — pre-install scanning guide
+- `signing-agent-skills.mdx` — signature verification guide
+- `skill-cards.mdx` — Skill Card authoring guide
+- `release-checklist.mdx` — release process
+
+Navigation order and slugs are defined in [`../fern/docs.yml`](../fern/docs.yml).
+
+## Build Locally
+
+You only need to build locally if you are editing the documentation. The site is published automatically from `main` via the Fern GitHub integration.
+
+Prerequisites: Node.js 18+ and npm.
+
+```bash
+# Install the Fern CLI
+npm install -g fern-api
+
+# From the repo root, preview the site with live reload
+fern docs dev
+
+# Validate the docs configuration and links
+fern check
+```
+
+`fern docs dev` serves the site at <http://localhost:3000> and reloads on changes to `.mdx` files or `fern/docs.yml`.
+
+## Authoring Notes
+
+- New pages must be added to the `navigation` section of [`../fern/docs.yml`](../fern/docs.yml); otherwise they will not appear in the site.
+- Use relative links between MDX pages (`./skill-cards.mdx`) and absolute repo links (`/components.d/README.md`) for files outside `docs/`.
+- The Fern version is pinned in [`../fern/fern.config.json`](../fern/fern.config.json); bump it intentionally rather than as a side effect.

--- a/docs/advanced-install.mdx
+++ b/docs/advanced-install.mdx
@@ -1,7 +1,7 @@
-<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
-<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->
-
-# Advanced Installation
+---
+title: "Advanced Installation"
+description: "Install, update, and remove NVIDIA skills with control over agent, scope, and non-interactive workflows."
+---
 
 Use this guide when you need more control than the root README quickstart: non-interactive installs, specific agents, global vs project scope, updates, removals, or a manual fallback.
 
@@ -106,4 +106,3 @@ Common global locations are:
 | Cursor | `~/.cursor/skills/` |
 
 Manual installs do not participate in `npx skills update`, so use them only as a fallback.
-

--- a/docs/agent-skill-trust-pipeline.mdx
+++ b/docs/agent-skill-trust-pipeline.mdx
@@ -1,0 +1,61 @@
+---
+title: "A Trust Pipeline for Agent Skills"
+description: "How scanning, signing, and skill cards work together to make AI agent skills easier to review and safer to deploy."
+---
+
+AI agent skills package instructions, code, references, and assets into a format agents can reuse. They are also a new supply-chain surface: a skill can ask an agent to run commands, read files, call tools, fetch remote content, or make decisions on a user's behalf.
+
+A practical release process should answer three questions before a skill is installed:
+
+- What does this skill claim to do?
+- What did automated review find?
+- Can users verify the reviewed artifact is the artifact they received?
+
+The combination of SkillSpector scanning, a completed skill card, and an OMS signature gives those questions a concrete place in the workflow.
+
+## The Release Gate
+
+Use this order for skills intended for enterprise deployment as **NVIDIA-Verified**:
+
+1. Author the skill with a narrow purpose, clear triggers, and explicit permissions.
+2. Run SkillSpector against the complete skill directory.
+3. Fix high-risk findings or record why a finding is accepted.
+4. Complete the skill card with owner, license, use case, deployment geography, output shape, risks, and references.
+5. Sign the skill directory and publish the detached `skill.oms.sig` file with the skill.
+6. Ask consumers or CI to verify the signature before installation.
+
+<Note>
+Scanning and signing solve different problems. Scanning asks whether the content appears safe enough to ship. Signing asks whether the shipped content is the same content that was reviewed.
+</Note>
+
+## What Each Layer Catches
+
+| Layer | Primary job | Example evidence |
+|---|---|---|
+| SkillSpector scan | Detect risky behavior before installation | Markdown, JSON, SARIF, or terminal report |
+| Skill card | State human-readable intent, ownership, limits, and output behavior | `Skill Card.md` or equivalent release metadata |
+| OMS signature | Verify integrity and authenticity of the published skill directory | `skill.oms.sig` plus NVIDIA signing certificate |
+
+## Recommended Artifact Set
+
+Every released skill should ship or link to:
+
+- `SKILL.md`
+- Supporting `scripts/`, `references/`, and `assets/` as needed
+- A completed skill card
+- A SkillSpector report or CI link
+- `skill.oms.sig`
+- Verification instructions for the signing certificate and verifier command
+
+## Review Questions
+
+Before approval, reviewers should be able to answer:
+
+- Does the skill description match the behavior of its executable files?
+- Are permissions limited to what the skill actually needs?
+- Are network, shell, file, environment, and MCP capabilities declared in the `SKILL.md` frontmatter and justified by the skill's stated use case?
+- Are known risks and mitigations written in plain language?
+- Does the signature verify against the released directory?
+
+If one of those answers is unclear, the skill is not ready for broad deployment.
+

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,44 @@
+---
+title: "Trust Controls for Agent Skills"
+description: "A practical series on scanning, signing, and documenting AI agent skills before enterprise deployment."
+---
+
+Agent skills are becoming a reusable software layer for AI agents. That makes them powerful, but it also means they need the same discipline we expect from other deployable artifacts: security review, provenance, ownership, and clear use boundaries.
+
+This series describes the trust controls behind **NVIDIA-Verified skills** — agent skills that have been scanned, documented in a Skills Card, and signed before publication. The pipeline has three layers:
+
+1. Scan the skill before installation.
+2. Publish a skill card that states what the skill does and how it should be used.
+3. Sign the shipped directory so users can verify that what they received matches what was reviewed.
+
+<Cards>
+  <Card
+    title="A Trust Pipeline for Agent Skills"
+    icon="route"
+    href="/skills/agent-skill-trust-pipeline"
+  >
+    The end-to-end workflow that links scanning, skill cards, and cryptographic signing into a release gate.
+  </Card>
+  <Card
+    title="Scan Agent Skills Before Installation"
+    icon="scan-search"
+    href="/skills/scanning-agent-skills"
+  >
+    How SkillSpector checks skill bundles for security risks, malicious patterns, and supply-chain issues.
+  </Card>
+  <Card
+    title="Verify Signed Agent Skills"
+    icon="badge-check"
+    href="/skills/signing-agent-skills"
+  >
+    How detached OMS signatures help consumers verify skill integrity after publishing and installation.
+  </Card>
+  <Card
+    title="Write Skill Cards People Can Trust"
+    icon="id-card"
+    href="/skills/skill-cards"
+  >
+    A practical skill-card template for owners, users, risk reviewers, and deployment teams.
+  </Card>
+</Cards>
+

--- a/docs/release-checklist.mdx
+++ b/docs/release-checklist.mdx
@@ -1,0 +1,61 @@
+---
+title: "Release Checklist"
+description: "A practical checklist for preparing an agent skill for enterprise review and publication."
+---
+
+Use this checklist when preparing a skill for review, publication, or internal deployment.
+
+## Before Scanning
+
+- The skill has a narrow, concrete purpose.
+- `SKILL.md` describes when the skill should activate.
+- Tool, shell, network, file, environment, and MCP capabilities are declared when used.
+- Scripts and references are necessary for the stated use case.
+- Test fixtures, examples, and generated files are either intentionally included or excluded.
+
+## Scanning
+
+- Run SkillSpector against the complete skill directory.
+- Save a Markdown or SARIF report for review.
+- Resolve critical and high findings before release.
+- Review medium findings for policy or usability impact.
+- Confirm the skill description matches executable behavior.
+
+```bash
+skillspector scan ./skill-name --format markdown --output skillspector-report.md
+```
+
+## Skill Card
+
+- Description is one sentence and names the actual behavior.
+- Owner is a person or accountable team.
+- License or terms are linked.
+- Use case names intended users and workflows.
+- Deployment geography is explicit.
+- Known risks have specific mitigations.
+- Output type and format are clear.
+- Version or signing identifier matches the release.
+
+## Signing
+
+- Sign the exact directory that passed review.
+- Publish `skill.oms.sig` at the top level of the skill directory.
+- Publish or reference the expected certificate chain.
+- Verify the published artifact before announcing availability.
+
+```bash
+model_signing verify certificate SKILL_DIR \
+  --signature SKILL_DIR/skill.oms.sig \
+  --certificate-chain nv-agent-root-cert.pem
+```
+
+## Release Packet
+
+The release packet should include:
+
+- Skill source or release artifact
+- Skill card
+- SkillSpector report or CI link
+- Detached OMS signature
+- Verification instructions
+- Known limitations and support contact

--- a/docs/scanning-agent-skills.mdx
+++ b/docs/scanning-agent-skills.mdx
@@ -1,0 +1,120 @@
+---
+title: "Scan Agent Skills Before Installation"
+description: "Use SkillSpector to detect vulnerabilities, malicious patterns, and policy risks in AI agent skills."
+---
+
+Agent skills can look harmless while still containing risky instructions, hidden metadata, overbroad permissions, or executable code that does more than the description says. SkillSpector is a security scanner for AI agent skills that helps answer: should this skill be installed?
+
+SkillSpector accepts Git repositories, URLs, zip files, directories, and single files. It runs fast static checks by default and can add optional LLM semantic analysis for issues that require intent comparison.
+
+## What SkillSpector Checks
+
+SkillSpector covers 64 vulnerability patterns across 16 categories, including:
+
+- Prompt injection
+- Data exfiltration
+- Privilege escalation
+- Supply-chain issues
+- Excessive agency
+- Output handling
+- System prompt leakage
+- Memory poisoning
+- Tool misuse
+- Rogue-agent behavior
+- Trigger abuse
+- Dangerous code patterns
+- Taint tracking
+- YARA signatures
+- MCP least privilege
+- MCP tool poisoning
+
+It also supports live vulnerability lookup through OSV.dev for known vulnerable dependencies, with an offline fallback when network access is unavailable.
+
+## Install
+
+Create a virtual environment, install the package, and run the scanner from the repository:
+
+```bash
+git clone https://github.com/NVIDIA/SkillSpector.git
+cd SkillSpector
+
+uv venv .venv && source .venv/bin/activate
+make install
+```
+
+If `uv` is unavailable, use Python's built-in virtual environment support:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+make install
+```
+
+## Run a Scan
+
+```bash
+# Scan a local skill directory
+skillspector scan ./my-skill/
+
+# Scan a single SKILL.md file
+skillspector scan ./SKILL.md
+
+# Scan a Git repository
+skillspector scan https://github.com/user/my-skill
+
+# Scan a zip file
+skillspector scan ./my-skill.zip
+```
+
+## Choose an Output Format
+
+Use terminal output while iterating locally, JSON for automation, Markdown for review packets, and SARIF for CI or code scanning systems.
+
+```bash
+# Pretty terminal output
+skillspector scan ./my-skill/
+
+# Machine-readable JSON
+skillspector scan ./my-skill/ --format json --output report.json
+
+# Human-readable report
+skillspector scan ./my-skill/ --format markdown --output report.md
+
+# CI and IDE integration
+skillspector scan ./my-skill/ --format sarif --output report.sarif
+```
+
+## Static vs Semantic Analysis
+
+Static analysis is fast and deterministic. It can catch suspicious strings, dependency risk, dangerous APIs, and declared-permission mismatches.
+
+Semantic analysis uses an LLM to compare what a skill claims with what its code appears to do. This is useful for description-behavior mismatch, vague triggers, and subtle policy issues.
+
+Configure a provider when you want semantic checks:
+
+```bash
+export SKILLSPECTOR_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+skillspector scan ./my-skill/
+```
+
+For static-only review:
+
+```bash
+skillspector scan ./my-skill/ --no-llm
+```
+
+## Triage Policy
+
+Use scan results as a release gate:
+
+| Finding type | Recommended action |
+|---|---|
+| Critical or high severity | Block release until fixed or formally accepted |
+| Hidden instructions or tool poisoning | Remove hidden content before release |
+| Underdeclared capability | Update permissions or remove the behavior |
+| Known vulnerable dependency | Upgrade, pin a fixed version, or document why the dependency is acceptable |
+| Description-behavior mismatch | Rewrite the skill description or change the code |
+
+The goal is not just a clean report. The goal is a skill whose declared purpose, permissions, code, and documented risks all agree.
+

--- a/docs/signing-agent-skills.mdx
+++ b/docs/signing-agent-skills.mdx
@@ -1,0 +1,88 @@
+---
+title: "Verify Signed Agent Skills"
+description: "Use detached OMS signatures to verify the integrity and authenticity of published agent skills."
+---
+
+Cryptographic signing gives skill consumers a way to verify that a skill directory has not changed since it was signed. For agent skills, that matters because the review target is the whole directory: `SKILL.md`, scripts, references, assets, and any supporting files.
+
+NVIDIA has adopted the OpenSSF Model Signing format, also known as OMS, for detached skill signatures. OMS extends Sigstore-style bundles so verification can cover a directory tree instead of only a single file.
+
+## Signature Layout
+
+The signature is delivered as a detached file at the top level of the skill directory:
+
+```text
+skill-name/
+|-- SKILL.md
+|-- scripts/
+|-- references/
+|-- assets/
+`-- skill.oms.sig
+```
+
+By default, the signature covers the files and directories in the skill directory, excluding the signature file itself.
+
+<Note>
+If unsigned files are added after signing, strict verification should fail. That is the point: users need to know when the installed directory differs from the signed release.
+</Note>
+
+## Verification Inputs
+
+Verification needs three things:
+
+| Input | Purpose |
+|---|---|
+| Skill directory | The artifact being verified |
+| `skill.oms.sig` | Detached OMS signature |
+| NVIDIA agent capabilities certificate | Trust anchor for the signature |
+
+The signing source material names the certificate file `nv-agent-root-cert.pem`.
+
+## Install a Verifier
+
+Install an OMS-compatible verifier such as `model-signing`:
+
+```bash
+pip install model-signing
+```
+
+## Verify a Skill
+
+Run verification against the installed or downloaded skill directory:
+
+```bash
+model_signing verify certificate SKILL_DIR \
+  --signature SKILL_DIR/skill.oms.sig \
+  --certificate-chain nv-agent-root-cert.pem
+```
+
+If your policy intentionally permits additional unsigned files, add:
+
+```bash
+--ignore-unsigned-files
+```
+
+For production release checks, prefer strict verification unless there is a documented reason to permit unsigned additions.
+
+## Where Signing Fits
+
+Signing should happen after scanning and review:
+
+1. Run SkillSpector against the complete skill directory.
+2. Resolve or accept findings.
+3. Complete the skill card.
+4. Sign the exact directory that will be published.
+5. Publish `skill.oms.sig` with the skill.
+6. Verify the signature during installation or CI.
+
+Signing does not prove a skill is safe. It proves the released skill is the one that was signed. Pair it with scanning and a complete skill card for a usable trust story.
+
+## Consumer Checklist
+
+Before installing a signed skill:
+
+- Confirm the signature file is present as `skill.oms.sig`.
+- Confirm the certificate chain comes from the expected publisher.
+- Run the verification command against the final installed directory.
+- Review the skill card and scan report before enabling the skill.
+- Re-run verification after any local modification.

--- a/docs/skill-cards.mdx
+++ b/docs/skill-cards.mdx
@@ -1,0 +1,107 @@
+---
+title: "Write Skill Cards People Can Trust"
+description: "A skill card records the owner, intended use, risks, outputs, and references for an AI agent skill."
+---
+
+A scan report tells reviewers what automated checks found. A signature tells users whether the artifact changed. A skill card tells humans what they are accepting.
+
+The **Skills Card** is the per-skill release record described below. Authors can generate one by running the `Skill Card.md` skill published at [NVIDIA/Trustworthy-AI](https://github.com/NVIDIA/Trustworthy-AI/blob/main/Skill%20Card.md), which walks through each section interactively. The card should be completed before a skill is broadly shared, especially when the skill can run tools, call APIs, write files, or influence production workflows.
+
+## What a Skill Card Should Answer
+
+| Section | Question it answers |
+|---|---|
+| Description | What does this skill do in one sentence? |
+| Owner | Who is accountable for this skill? |
+| License or terms | What rules govern use and redistribution? |
+| Use case | Who should use it, and for what purpose? |
+| Deployment geography | Where is the skill intended to be used? |
+| Risks and mitigations | What could go wrong, and how is that risk reduced? |
+| References | What docs, papers, reports, or model cards support this skill? |
+| Skill output | What does the skill produce, and in what format? |
+| Skill version | Which release or signing identifier does this card describe? |
+| Ethical considerations | What governance or misuse considerations should users keep in mind? |
+
+## Minimum Useful Card
+
+Use this as the minimum release template:
+
+```markdown
+# Skill Card
+
+## Description
+
+[Skill name] [does one concrete thing] for [target user or workflow].
+
+This skill is [ready for commercial/non-commercial use | for research and development only | for demonstration purposes and not for production usage].
+
+## Owner
+
+[Team or person accountable for maintenance and review]
+
+## License/Terms of Use
+
+[License or terms link]
+
+## Use Case
+
+[Who should use this skill and for what task]
+
+## Deployment Geography for Use
+
+[Global, regional, or country-specific deployment scope]
+
+## Known Risks and Mitigations
+
+Risk: [Plain-language risk]
+
+Mitigation: [Control, limitation, review step, or monitoring plan]
+
+## References
+
+- [Reference documentation, paper, model card, or related technical source]
+- [Scan report or CI evidence]
+
+## Skill Output
+
+Output type(s): [Analysis, API calls, code, files, or other]
+
+Output format: [Markdown, JSON, string, SARIF, files, etc.]
+
+Output parameters: [Shape, dimensions, schema, or file naming rules]
+
+Other properties: [Limits, retention, side effects, or validation notes]
+
+## Skill Version
+
+[Version, release tag, or signing identifier]
+
+## Ethical Considerations
+
+[Relevant policy, human review expectation, misuse concern, or industry-specific constraint]
+```
+
+## Connect the Card to the Release
+
+The card should point to the same evidence reviewers used:
+
+- SkillSpector scan report or CI job
+- Source repository and release tag
+- Signing identifier or `skill.oms.sig` location
+- Any model cards or dependency documentation behind the skill
+- Known limitations and accepted risks
+
+## Good Risk Statements
+
+Avoid vague risks like "model may be wrong." Make risks actionable:
+
+| Weak | Stronger |
+|---|---|
+| The skill could make mistakes. | The skill may generate incorrect remediation steps; users must review proposed code changes before execution. |
+| The skill uses APIs. | The skill sends package names to OSV.dev for vulnerability lookup; no source code or secrets should be transmitted. |
+| The skill writes files. | The skill may overwrite generated reports in the configured output directory; it must not write outside that directory. |
+
+## Approval Rule
+
+A skill card is complete when a reviewer can understand the skill's purpose, owner, output, risks, and release evidence without opening the source code first.
+

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+instances:
+  - url: https://nvidia-skills.docs.buildwithfern.com/skills
+    custom-domain: docs.nvidia.com/skills
+    multi-source: true
+
+title: NVIDIA Skill Documentation
+
+global-theme: nvidia
+
+navbar-links:
+  - type: minimal
+    href: https://github.com/NVIDIA/skills
+    text: GitHub
+
+logo:
+  right-text: Skills
+
+navigation:
+  - page: Overview
+    path: ../docs/index.mdx
+    slug: /
+  - section: Documentation
+    skip-slug: true 
+    contents:
+      - page: A Trust Pipeline for Agent Skills
+        path: ../docs/agent-skill-trust-pipeline.mdx
+        slug: agent-skill-trust-pipeline
+      - page: Scan Agent Skills Before Installation
+        path: ../docs/scanning-agent-skills.mdx
+        slug: scanning-agent-skills
+      - page: Verify Signed Agent Skills
+        path: ../docs/signing-agent-skills.mdx
+        slug: signing-agent-skills
+      - page: Write Skill Cards People Can Trust
+        path: ../docs/skill-cards.mdx
+        slug: skill-cards
+      - page: Release Checklist
+        path: ../docs/release-checklist.mdx
+        slug: release-checklist
+      - page: Advanced Installation
+        path: ../docs/advanced-install.mdx
+        slug: advanced-install

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "nvidia",
+  "version": "5.27.8"
+}


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Stands up a Fern-powered long-form documentation site for the NVIDIA Skills catalog, published at <https://docs.nvidia.com/skills>.

### What changed

- **New Fern site config** under [`fern/`](fern/): `docs.yml` (navigation, theme, custom domain → `docs.nvidia.com/skills`) and `fern.config.json` (pinned Fern CLI 5.27.8).
- **New documentation pages** under [`docs/`](docs/), authored in MDX:
  - `index.mdx` — landing page
  - `agent-skill-trust-pipeline.mdx` — trust pipeline overview
  - `scanning-agent-skills.mdx` — pre-install scanning guide
  - `signing-agent-skills.mdx` — signature verification guide
  - `skill-cards.mdx` — Skill Card authoring guide
  - `release-checklist.mdx` — release process
  - `README.md` — instructions for previewing the docs locally (`fern docs dev`, `fern check`)
- **Converted** `docs/advanced-install.md` → [`docs/advanced-install.mdx`](docs/advanced-install.mdx) so it can be rendered by Fern.
- **Updated** [`README.md`](README.md) Repository Structure section to list the new `docs/` files and the `fern/` directory.
- **CHANGELOG** entry for `0.3.0`.

### How to review

- Skim the new MDX pages for content/voice.
- Verify navigation order in [`fern/docs.yml`](fern/docs.yml) matches the intended IA.
- Locally: `npm install -g fern-api && fern docs dev` from the repo root, then open <http://localhost:3000>.

### Out of scope

- No changes to skills, sync workflows, or `components.d/`.
- No changes to CI publication wiring (Fern's GitHub integration handles publication from `main`).

### Risk

Low. Docs-only change; no impact on skill consumers or the sync pipeline. Worst case the published site fails to build, which does not affect the catalog itself.
