### PR TITLE
components.d: add Dynamo

### DIFF
--- a/components.d/dynamo.yml
+++ b/components.d/dynamo.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Dynamo
+repo: ai-dynamo/dynamo
+description: Distributed LLM inference framework — pre-deployment sizing, model optimization, local serving, Kubernetes deployment, request-path configuration (Frontend + DynamoModel + gateway), day-2 troubleshooting, and benchmarking.
+skills:
+  - path: .agents/skills/
+    catalog_dir: Dynamo

--- a/components.d/dynamo.yml
+++ b/components.d/dynamo.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: Dynamo
 repo: ai-dynamo/dynamo
-description: Distributed LLM inference framework — pre-deployment sizing, model optimization, local serving, Kubernetes deployment, request-path configuration (Frontend + DynamoModel + gateway), day-2 troubleshooting, and benchmarking.
+description: NVIDIA Dynamo deployment bring-up on Kubernetes — pick and deploy recipes, start router modes, validate disagg NIXL/UCX/NCCL interconnect, and triage day-2 failures.
 skills:
-  - path: .agents/skills/
+  - path: skills/
     catalog_dir: Dynamo


### PR DESCRIPTION
#### Overview

Add **Dynamo** to the components catalog.

[NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) is a distributed LLM inference framework. The first set of agent skills — the Computex bring-up skills — landed on `main` in [ai-dynamo/dynamo#9782](https://github.com/ai-dynamo/dynamo/pull/9782) and are ready to mirror into this catalog via the standard daily sync pipeline.

This PR adds the one-file registry entry that registers Dynamo. No skill content lands in this repo directly — the sync workflow pulls `skills/` from `ai-dynamo/dynamo` and renders `skills/Dynamo/` on its next run.

#### Details

### What's in this PR

A single file: `components.d/dynamo.yml`.

```yaml
name: Dynamo
repo: ai-dynamo/dynamo
description: NVIDIA Dynamo deployment bring-up on Kubernetes — pick and deploy recipes, start router modes, validate disagg NIXL/UCX/NCCL interconnect, and triage day-2 failures.
skills:
  - path: skills/
    catalog_dir: Dynamo
```

The schema matches the `components.d/README.md` spec; the fields follow the pattern of existing entries (compare `cuopt.yml`, `tensorrt-llm.yml`, `nemoclaw.yml`). `path: skills/` matches the canonical layout Mohit set on 2026-05-15 (`<repo>/skills/<skill-name>/`); `.agents/skills` on the upstream is a compatibility symlink to this real directory.

### What the catalog will publish

When the next daily sync runs, `skills/Dynamo/` will contain four skill directories already merged on `ai-dynamo/dynamo:main`:

| Skill | Stage | Owns |
|---|---|---|
| `dynamo-recipe-runner` | Bring-up | Recipe selection, validation, patching, deploy, smoke test for the existing `recipes/` tree |
| `dynamo-router-starter` | Bring-up | Round-robin / KV-aware / least-loaded / device-aware routing setup and endpoint smoke tests |
| `dynamo-troubleshoot` | Day-2 | Read-only debug bundle collection, failure-decision-tree classification, layered remediation |
| `dynamo-interconnect-check` | Validation | NIXL / UCX / NCCL transport readiness for disagg over RDMA / NVLink |

Each skill ships `SKILL.md` (frontmatter with `name`, `description`, `license: Apache-2.0`, `metadata.author`, `metadata.tags`, plus `metadata.permissions` on `dynamo-recipe-runner`), a `references/` doc, a `scripts/` Python tool, and an `evals/evals.json` case set.

### Signing and validation status (upstream)

- NVSkills CI: signed end-to-end. Each skill has a `skill.oms.sig` and a `skill-card.md` (full template — Description, Owner, License, Use Case, Risks, References, Output, Evaluation Agent / Tasks / Metrics / Results, Skill Version, Ethical Considerations).
- Trigger-routing: 24/24 across the four skills (6 cases each, 3 positive + 3 negative defer).
- NV-BASE 2.12.0 static score: 83.2 / 100 (Grade B) per skill — 4-dimension breakdown in each `skill-card.md`.
- BENCHMARK.md per skill is a follow-up — NVCARPS-EVAL generation flow went live today; will land on the next upstream `/nvskills-ci` run.

### Future expansion

A second skill set — the seven lifecycle skills (`dynamo-plan`, `dynamo-optimize`, `dynamo-serve`, `dynamo-deploy`, `dynamo-frontend`, `dynamo-benchmark`, `dynamo-skill-author`) — is in flight on [ai-dynamo/dynamo#9847](https://github.com/ai-dynamo/dynamo/pull/9847). Once that merges, those skills land under the same `skills/` path and the same sync workflow picks them up automatically; no additional registry change required here.

#### Where should the reviewer start?

- `components.d/dynamo.yml` — the only file in this PR.
- Optional context: the four bring-up skills at [`ai-dynamo/dynamo:skills/`](https://github.com/ai-dynamo/dynamo/tree/main/skills) on `main`.

#### Related

- Upstream skills on main: [ai-dynamo/dynamo#9782](https://github.com/ai-dynamo/dynamo/pull/9782) (merged), follow-up rename + flip: [#10024](https://github.com/ai-dynamo/dynamo/pull/10024), [#10017](https://github.com/ai-dynamo/dynamo/pull/10017), NV-BASE compliance + cards: [#10069](https://github.com/ai-dynamo/dynamo/pull/10069).
- Future lifecycle skills: [ai-dynamo/dynamo#9847](https://github.com/ai-dynamo/dynamo/pull/9847).
