### PR TITLE
ci: add Verify Signed Skills workflow

### DIFF
--- a/.github/workflows/verify-signed-skills.yml
+++ b/.github/workflows/verify-signed-skills.yml
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Verify every published skill.oms.sig in the catalog against the
+# NVIDIA Agentic Capabilities trust anchor. Guards against signed
+# directories drifting from what the catalog publishes (e.g. when
+# the daily sync pipeline lands a SKILL.md newer than the signed
+# snapshot — the failure mode reported in issue #77).
+#
+# Trust anchor lookup order:
+#   1. .github/trust/nv-agent-root-cert.pem (committed)
+#   2. Repository secret NV_AGENT_ROOT_CERT_PEM (PEM contents)
+#
+# When neither is present the job is skipped with a warning. This
+# lets the workflow merge before the cert distribution decision is
+# settled; it activates as soon as the anchor is provided.
+
+name: Verify Signed Skills
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - ".github/workflows/verify-signed-skills.yml"
+      - ".github/trust/**"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".github/trust/**"
+  schedule:
+    # Daily at 09:00 UTC — runs after both sync passes (06:00 / 18:00)
+    # and the prior day's signing activity.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install model-signing
+        run: pip install "model-signing==1.1.1"
+
+      - name: Provision trust anchor
+        id: trust
+        env:
+          NV_AGENT_ROOT_CERT_PEM: ${{ secrets.NV_AGENT_ROOT_CERT_PEM }}
+        run: |
+          set -euo pipefail
+          CERT_PATH="${GITHUB_WORKSPACE}/.github/trust/nv-agent-root-cert.pem"
+          if [ ! -f "$CERT_PATH" ] && [ -n "${NV_AGENT_ROOT_CERT_PEM:-}" ]; then
+            mkdir -p "$(dirname "$CERT_PATH")"
+            printf '%s' "$NV_AGENT_ROOT_CERT_PEM" > "$CERT_PATH"
+          fi
+          if [ ! -f "$CERT_PATH" ]; then
+            echo "::warning::No NVIDIA Agentic Capabilities root certificate available."
+            echo "::warning::Commit it at .github/trust/nv-agent-root-cert.pem or set repo secret NV_AGENT_ROOT_CERT_PEM."
+            echo "has_cert=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_cert=true" >> "$GITHUB_OUTPUT"
+            echo "cert_path=$CERT_PATH" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify all signed skills
+        if: steps.trust.outputs.has_cert == 'true'
+        run: |
+          set -euo pipefail
+          CERT="${{ steps.trust.outputs.cert_path }}"
+          PASS=0
+          FAIL=0
+          : > /tmp/verify-summary.md
+          while IFS= read -r sig; do
+            DIR="$(dirname "$sig")"
+            SKILL="${DIR#skills/}"
+            if model_signing verify certificate "$DIR" \
+                 --signature "$sig" \
+                 --certificate_chain "$CERT" \
+                 --ignore_unsigned_files > /tmp/verify.log 2>&1; then
+              echo "- pass: \`$SKILL\`" >> /tmp/verify-summary.md
+              PASS=$((PASS + 1))
+            else
+              ERR="$(grep -E 'Verification failed|Hash mismatch' /tmp/verify.log | head -2 | tr '\n' ' ' | sed 's/`/\\`/g')"
+              echo "- **fail**: \`$SKILL\` — $ERR" >> /tmp/verify-summary.md
+              FAIL=$((FAIL + 1))
+            fi
+          done < <(find skills -name "skill.oms.sig" | sort)
+          {
+            echo "## Signed Skill Verification"
+            echo ""
+            echo "Passed: $PASS · Failed: $FAIL"
+            echo ""
+            cat /tmp/verify-summary.md
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$FAIL" -gt 0 ]; then
+            echo "::error::$FAIL signed skill(s) failed verification. See job summary."
+            exit 1
+          fi
+          if [ "$PASS" -eq 0 ]; then
+            echo "::warning::No skill.oms.sig files were found in the catalog."
+          fi
+
+      - name: Report skipped run
+        if: steps.trust.outputs.has_cert != 'true'
+        run: |
+          {
+            echo "## Signed Skill Verification — SKIPPED"
+            echo ""
+            echo "No NVIDIA Agentic Capabilities root certificate configured."
+            echo ""
+            echo "To enable, do one of:"
+            echo ""
+            echo "- Commit the trust anchor at \`.github/trust/nv-agent-root-cert.pem\`."
+            echo "- Set repo secret \`NV_AGENT_ROOT_CERT_PEM\` to the PEM contents."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-signed-skills.yml
+++ b/.github/workflows/verify-signed-skills.yml
@@ -8,12 +8,12 @@
 # snapshot — the failure mode reported in issue #77).
 #
 # Trust anchor lookup order:
-#   1. .github/trust/nv-agent-root-cert.pem (committed)
-#   2. Repository secret NV_AGENT_ROOT_CERT_PEM (PEM contents)
+#   1. ./nv-agent-root-cert.pem at repo root (where NVIDIA publishes it
+#      as of commit c27e3d0)
+#   2. .github/trust/nv-agent-root-cert.pem (committed fallback)
+#   3. Repository secret NV_AGENT_ROOT_CERT_PEM (PEM contents)
 #
-# When neither is present the job is skipped with a warning. This
-# lets the workflow merge before the cert distribution decision is
-# settled; it activates as soon as the anchor is provided.
+# When none is present the job is skipped with a warning.
 
 name: Verify Signed Skills
 
@@ -23,11 +23,13 @@ on:
       - "skills/**"
       - ".github/workflows/verify-signed-skills.yml"
       - ".github/trust/**"
+      - "nv-agent-root-cert.pem"
   push:
     branches: [main]
     paths:
       - "skills/**"
       - ".github/trust/**"
+      - "nv-agent-root-cert.pem"
   schedule:
     # Daily at 09:00 UTC — runs after both sync passes (06:00 / 18:00)
     # and the prior day's signing activity.
@@ -58,14 +60,22 @@ jobs:
           NV_AGENT_ROOT_CERT_PEM: ${{ secrets.NV_AGENT_ROOT_CERT_PEM }}
         run: |
           set -euo pipefail
-          CERT_PATH="${GITHUB_WORKSPACE}/.github/trust/nv-agent-root-cert.pem"
-          if [ ! -f "$CERT_PATH" ] && [ -n "${NV_AGENT_ROOT_CERT_PEM:-}" ]; then
+          ROOT_CERT="${GITHUB_WORKSPACE}/nv-agent-root-cert.pem"
+          TRUST_CERT="${GITHUB_WORKSPACE}/.github/trust/nv-agent-root-cert.pem"
+          if [ -f "$ROOT_CERT" ]; then
+            CERT_PATH="$ROOT_CERT"
+          elif [ -f "$TRUST_CERT" ]; then
+            CERT_PATH="$TRUST_CERT"
+          elif [ -n "${NV_AGENT_ROOT_CERT_PEM:-}" ]; then
+            CERT_PATH="$TRUST_CERT"
             mkdir -p "$(dirname "$CERT_PATH")"
             printf '%s' "$NV_AGENT_ROOT_CERT_PEM" > "$CERT_PATH"
+          else
+            CERT_PATH=""
           fi
-          if [ ! -f "$CERT_PATH" ]; then
+          if [ -z "$CERT_PATH" ]; then
             echo "::warning::No NVIDIA Agentic Capabilities root certificate available."
-            echo "::warning::Commit it at .github/trust/nv-agent-root-cert.pem or set repo secret NV_AGENT_ROOT_CERT_PEM."
+            echo "::warning::Commit it at ./nv-agent-root-cert.pem (preferred) or .github/trust/nv-agent-root-cert.pem, or set repo secret NV_AGENT_ROOT_CERT_PEM."
             echo "has_cert=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_cert=true" >> "$GITHUB_OUTPUT"
@@ -120,6 +130,7 @@ jobs:
             echo ""
             echo "To enable, do one of:"
             echo ""
-            echo "- Commit the trust anchor at \`.github/trust/nv-agent-root-cert.pem\`."
+            echo "- Commit the trust anchor at \`./nv-agent-root-cert.pem\` (preferred, matches NVIDIA's published location)."
+            echo "- Commit it at \`.github/trust/nv-agent-root-cert.pem\` (fallback)."
             echo "- Set repo secret \`NV_AGENT_ROOT_CERT_PEM\` to the PEM contents."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Runs `model_signing verify certificate` against every `skill.oms.sig` on PR, push to main, and daily at 09:00 UTC (after the sync passes). Motivated by #77 — this would have caught the cuOpt `SKILL.md` drift before it shipped.

## Trust anchor

Lookup order (first match wins):

1. `./nv-agent-root-cert.pem` at repo root — where NVIDIA committed it in `c27e3d0` and documented at `fd1516e`.
2. `.github/trust/nv-agent-root-cert.pem` — committed fallback.
3. Repo secret `NV_AGENT_ROOT_CERT_PEM` — PEM contents, written into the fallback path at runtime.

If none is present the job skips with a warning. With NVIDIA's existing `nv-agent-root-cert.pem` at repo root, no additional setup is needed for this workflow to activate on merge.

## Local dry-run at HEAD `fd1516e`

```
Passed: 0 · Failed: 12 (all signed cuOpt skills, Hash mismatch on SKILL.md)
```

The original 9 from #77 plus three newly signed since: `cuopt-developer`, `cuopt-install`, `cuopt-numerical-optimization-api-python`. The drift has expanded — this CI gate would have prevented that.

## Test plan

- [ ] CI on this PR: verify step finds `./nv-agent-root-cert.pem` and reports 12 failures (matching the dry-run)
- [ ] On merge: scheduled run continues to catch drift introduced by the sync pipeline