### PR TITLE
docs: add Resources block (docs, livestream, blog) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [![Agent Skills Spec](https://img.shields.io/badge/Agent%20Skills-Specification-blue)](https://agentskills.io)
 [![License](https://img.shields.io/badge/License-Apache%202.0%20%2B%20CC--BY--4.0-green.svg)](LICENSE)
 
+> 📖 **Docs:** [docs.nvidia.com/skills](https://docs.nvidia.com/skills) &nbsp;·&nbsp;
+> 📺 **Livestream:** [From Vulnerable to Verified](https://www.youtube.com/watch?v=sVpKonYJ4D4&list=PL5B692fm6--vEL0FwctKghCpyEnBGAQJA&index=1) &nbsp;·&nbsp;
+> 📝 **Blog:** [NVIDIA Verified Agent Skills: Capability Governance for AI Agents](https://developer.nvidia.com/blog/nvidia-verified-agent-skills-provide-capability-governance-for-ai-agents/)
+
 ---
 
 Skills are portable instruction sets that teach AI agents how to use NVIDIA CUDA-X libraries, AI Blueprints, and platform tools correctly. This repository is a catalog: skills are maintained in their respective product repos and mirrored here daily via an automated sync pipeline. We are making NVIDIA skills available publicly and building this catalog in the open; see the [Roadmap](#roadmap) for what is planned next.


### PR DESCRIPTION
Adds a small Resources block to the top of the README surfacing three external links developers landing on the repo will want:

- 📖 **Docs:** https://docs.nvidia.com/skills
- 📺 **Livestream:** *From Vulnerable to Verified* on YouTube
- 📝 **Blog:** *NVIDIA Verified Agent Skills: Capability Governance for AI Agents* on the NVIDIA Developer Blog

Companion to the About-sidebar Website URL (also set to docs.nvidia.com/skills).

## Test plan
- [x] Markdown renders correctly in GitHub preview
- [ ] Approving reviewer confirms link text and order

Signed-off-by: Moshe Abramovitch <moshea@nvidia.com>