### PR TITLE
docs: add download link for the trust anchor

### DIFF
--- a/docs/signing-agent-skills.mdx
+++ b/docs/signing-agent-skills.mdx
@@ -36,7 +36,12 @@ Verification needs three things:
 | `skill.oms.sig` | Detached OMS signature |
 | NVIDIA agent capabilities certificate | Trust anchor for the signature |
 
-The signing source material names the certificate file `nv-agent-root-cert.pem`.
+The signing source material names the certificate file `nv-agent-root-cert.pem`. Download the current trust anchor from this repo: [`nv-agent-root-cert.pem`](../nv-agent-root-cert.pem). From a shell:
+
+```bash
+curl -L -o nv-agent-root-cert.pem \
+  https://raw.githubusercontent.com/NVIDIA/skills/main/nv-agent-root-cert.pem
+```
 
 ## Install a Verifier
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [X] Other (catalog change, README fix, infrastructure, etc.)

## Other context

Follow-up to PR #79 which landed `nv-agent-root-cert.pem` at the repo root. This patch adds a download link and a `curl` one-liner to `docs/signing-agent-skills.mdx` so verifiers can pull the trust anchor directly rather than extracting it from the signed bundle they're trying to verify (per the secondary concern in issue #77).

Single-line edit (plus an inline code block) in one file.

## All PRs

- [X] All commits signed off with DCO (`git commit -s`).