### PR TITLE
Add Skill Card Generator

### DIFF
--- a/components.d/skill-card-generator.yml
+++ b/components.d/skill-card-generator.yml
@@ -2,5 +2,5 @@ name: Skill-Card-Generator
 repo: NVIDIA/Trustworthy-AI
 description: Reads an agent skill's source files and produces a skill card plus a review table. Use when a skill directory exists and a governance card needs to be generated or updated.
 skills:
-  - path: AI%20Transparency%20Card%20Automation/skill-card-generator
+  - path: skills/skill-card-generator
     catalog_dir: Skill-Card-Generator

--- a/components.d/skill-card-generator.yml
+++ b/components.d/skill-card-generator.yml
@@ -1,0 +1,6 @@
+name: Skill-Card-Generator
+repo: NVIDIA/Trustworthy-AI
+description: Reads an agent skill's source files and produces a skill card plus a review table. Use when a skill directory exists and a governance card needs to be generated or updated.
+skills:
+  - path: AI%20Transparency%20Card%20Automation/skill-card-generator
+    catalog_dir: Skill-Card-Generator

--- a/components.d/skill-card-generator.yml
+++ b/components.d/skill-card-generator.yml
@@ -1,6 +1,8 @@
-name: Skill-Card-Generator
+name: Skill Card Generator
 repo: NVIDIA/Trustworthy-AI
 description: Reads an agent skill's source files and produces a skill card plus a review table. Use when a skill directory exists and a governance card needs to be generated or updated.
 skills:
-  - path: skills/skill-card-generator
-    catalog_dir: Skill-Card-Generator
+  - path: skills/skill-card-generator/
+    catalog_dir: skill-card-generator
+links:
+  discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
