### PR TITLE
Register Nemotron-Customizer skills

### DIFF
--- a/components.d/nemotron.yml
+++ b/components.d/nemotron.yml
@@ -1,6 +1,6 @@
 name: Nemotron
 repo: NVIDIA-NeMo/Nemotron
-description: Build sovereign model customization pipelines for diverse models using NVIDIA-authored agent skills.
+description: NVIDIA-authored agent skills for model development, customization, evaluation, and deployment workflows.
 skills:
   - path: skills/nemotron-customize/
-    catalog_dir: nemotron
+    catalog_dir: nemotron-customize

--- a/components.d/nemotron.yml
+++ b/components.d/nemotron.yml
@@ -1,6 +1,6 @@
 name: Nemotron
 repo: NVIDIA-NeMo/Nemotron
-description: NVIDIA-authored agent skills for model development, customization, evaluation, and deployment workflows.
+description: Author end-to-end model development, customization, evaluation, and deployment pipelines using the NVIDIA AI stack.
 skills:
   - path: skills/nemotron-customize/
     catalog_dir: nemotron-customize

--- a/components.d/nemotron.yml
+++ b/components.d/nemotron.yml
@@ -1,0 +1,6 @@
+name: Nemotron
+repo: NVIDIA-NeMo/Nemotron
+description: Build sovereign model customization pipelines for diverse models using NVIDIA-authored agent skills.
+skills:
+  - path: skills/nemotron-customize/
+    catalog_dir: nemotron


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
