### PR TITLE
Register AIQ skills

### DIFF
--- a/components.d/aiq.yml
+++ b/components.d/aiq.yml
@@ -1,0 +1,8 @@
+name: AIQ
+repo: NVIDIA-AI-Blueprints/aiq
+description: NVIDIA AI-Q Blueprint - deploy local AI-Q services and run shallow or deep research workflows as agent skills.
+skills:
+  - path: skills/aiq-research/
+    catalog_dir: aiq-research
+  - path: skills/aiq-deploy/
+    catalog_dir: aiq-deploy


### PR DESCRIPTION
## Summary
- Register AIQ as a component in the skills catalog.
- Add catalog mappings for aiq-research and aiq-deploy.
- Use the default source branch by omitting an explicit ref override.

## Validation
- Component file is named components.d/aiq.yml and uses name: AIQ so the name-derived slug is aiq.
- Commit includes DCO sign-off.