### PR TITLE
Use AIQ develop branch for sync

### DIFF
--- a/components.d/aiq.yml
+++ b/components.d/aiq.yml
@@ -1,5 +1,6 @@
 name: AIQ
 repo: NVIDIA-AI-Blueprints/aiq
+ref: develop
 description: NVIDIA AI-Q Blueprint - deploy local AI-Q services and run shallow or deep research workflows as agent skills.
 skills:
   - path: skills/aiq-research/


### PR DESCRIPTION
## Summary
- Set the AIQ component sync ref to develop.

## Why
- The AIQ repository default branch is develop, while the catalog sync workflow falls back to main when ref is omitted.
- Without this ref, the sync workflow cannot find skills/aiq-research or skills/aiq-deploy, so AIQ does not get copied into the catalog or listed in README.

## Validation
- Verified NVIDIA-AI-Blueprints/aiq default branch is develop.
- Commit includes DCO sign-off.