### PR TITLE
feat: register Holoscan skills catalog sync

### DIFF
--- a/components.d/holoscan-sdk.yml
+++ b/components.d/holoscan-sdk.yml
@@ -1,0 +1,8 @@
+name: Holoscan SDK
+repo: nvidia-holoscan/holoscan-sdk
+description: Install and set up the Holoscan SDK on any platform (container, Debian, Python, Conda, or source).
+skills:
+  - path: skills/
+    catalog_dir: holoscan-sdk
+links:
+  discussions: false

--- a/components.d/holoscan-sdk.yml
+++ b/components.d/holoscan-sdk.yml
@@ -2,7 +2,17 @@ name: Holoscan SDK
 repo: nvidia-holoscan/holoscan-sdk
 description: Install and set up the Holoscan SDK on any platform (container, Debian, Python, Conda, or source).
 skills:
-  - path: skills/
-    catalog_dir: holoscan-sdk
+  - path: skills/holoscan-install-debian/
+    catalog_dir: holoscan-install-debian
+  - path: skills/holoscan-install-source/
+    catalog_dir: holoscan-install-source
+  - path: skills/holoscan-install-wheel/
+    catalog_dir: holoscan-install-wheel
+  - path: skills/holoscan-install-conda/
+    catalog_dir: holoscan-install-conda
+  - path: skills/holoscan-install-container/
+    catalog_dir: holoscan-install-container
+  - path: skills/holoscan-setup/
+    catalog_dir: holoscan-setup
 links:
   discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [x] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
