### PR TITLE
Register Data Designer skill

### DIFF
--- a/components.d/data-designer.yml
+++ b/components.d/data-designer.yml
@@ -1,0 +1,6 @@
+name: Data Designer
+repo: NVIDIA-NeMo/DataDesigner
+description: Build declarative synthetic dataset generation pipelines with NeMo Data Designer.
+skills:
+  - path: skills/data-designer/
+    catalog_dir: data-designer

--- a/components.d/data-designer.yml
+++ b/components.d/data-designer.yml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
 name: Data Designer
 repo: NVIDIA-NeMo/DataDesigner
 description: Build declarative synthetic dataset generation pipelines with NeMo Data Designer.

--- a/components.d/data-designer.yml
+++ b/components.d/data-designer.yml
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 
 name: Data Designer
 repo: NVIDIA-NeMo/DataDesigner


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

Registers the Data Designer skill from `NVIDIA-NeMo/DataDesigner` at `skills/data-designer/` into the NVIDIA skills catalog as `data-designer`.

Validation performed locally:

- Parsed all `components.d/*.yml` files with PyYAML.
- Confirmed `catalog_dir: data-designer` is unique.
- Confirmed `NVIDIA-NeMo/DataDesigner` is public and the source path exists on `main`.
- Ran `git diff --check`.