### PR TITLE
components.d/deepstream: flat layout + discussions override

### DIFF
--- a/components.d/deepstream.yml
+++ b/components.d/deepstream.yml
@@ -1,6 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: DeepStream
 repo: NVIDIA-AI-IOT/DeepStream_Coding_Agent
-description: Agentic skills for guided DeepStream development. 
+description: Agentic skills for guided DeepStream development.
 skills:
-  - path: skills/
-    catalog_dir: deepstream
+  - path: skills/deepstream-dev/
+    catalog_dir: deepstream-dev
+  - path: skills/deepstream-import-vision-model/
+    catalog_dir: deepstream-import-vision-model
+links:
+  discussions: false


### PR DESCRIPTION
## Summary

- Restructure `components.d/deepstream.yml` to flat layout (one entry per skill) per the convention adopted 2026-05-28
- Add `links.discussions: false` since the source repo (`NVIDIA-AI-IOT/DeepStream_Coding_Agent`) has Discussions disabled
- Drop trailing whitespace in description; add SPDX + copyright headers

## Source state

Both DeepStream skills are fully 5/5 artifact-compliant as of Unni Sreekumar's merge today (`3daf16a` in `NVIDIA-AI-IOT/DeepStream_Coding_Agent` PR #3):

| Skill | SKILL.md | skill-card.md | skill.oms.sig | evals.json | BENCHMARK.md |
|---|:---:|:---:|:---:|:---:|:---:|
| deepstream-dev | ✓ | ✓ | ✓ | ✓ | ✓ |
| deepstream-import-vision-model | ✓ | ✓ | ✓ | ✓ | ✓ |

DeepStream is the **second component to reach full artifact compliance** after Skill Card Generator (which landed earlier today). Good Computex story.

## What sync will do after this merges

| Before | After |
|---|---|
| `skills/deepstream/<skill>/` (nested under PascalCase-ish parent dir) | `skills/deepstream-dev/` and `skills/deepstream-import-vision-model/` (flat top-level) |

Today the catalog shows 0 DeepStream skills because the previous yml + missing source artifacts → enforcement workflow dropped them. After this lands, the next 06:00 / 18:00 UTC sync will publish both skills cleanly.

## Heads-up — allowlist gap (for Sayali)

`NVIDIA-AI-IOT` is NOT in `nvskills-ci/config/onboarded-repositories.json` `allowed_owners` (currently: NVIDIA, NVIDIA-AI-Blueprints, NVIDIA-dev, ai-dynamo, nvidia-riva, NVIDIA-NeMo, nv-legate). That's why Unni signed in GitLab (`DeepStreamSDK/ds-copilot`) and mirrored to GitHub manually. The artifacts are correctly there now, but adding `NVIDIA-AI-IOT` would let future DeepStream signing runs happen natively in GitHub. Filing this as a separate ask.

## Test plan

- [ ] DCO + Verify Authors green
- [ ] After merge: trigger manual sync or wait for next daily sync; confirm `skills/deepstream-dev/` and `skills/deepstream-import-vision-model/` land in catalog with full artifact set
- [ ] README auto-regenerated tables include DeepStream row with 2 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)