### PR TITLE
components.d/nemoclaw: flat layout + flip path to public-facing skills/

### DIFF
--- a/components.d/nemoclaw.yml
+++ b/components.d/nemoclaw.yml
@@ -1,6 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: NemoClaw
 repo: NVIDIA/NemoClaw
-description: Secure agent sandboxing — run OpenClaw inside NVIDIA OpenShell with managed inference, policy management, remote deployment, sandbox monitoring, and contributor/maintainer workflows.
+description: Secure agent sandboxing — run OpenClaw inside NVIDIA OpenShell with managed inference, policy management, remote deployment, sandbox monitoring.
 skills:
-  - path: .agents/skills/
-    catalog_dir: NemoClaw
+  - path: skills/nemoclaw-user-agent-skills/
+    catalog_dir: nemoclaw-user-agent-skills
+  - path: skills/nemoclaw-user-configure-inference/
+    catalog_dir: nemoclaw-user-configure-inference
+  - path: skills/nemoclaw-user-configure-security/
+    catalog_dir: nemoclaw-user-configure-security
+  - path: skills/nemoclaw-user-deploy-remote/
+    catalog_dir: nemoclaw-user-deploy-remote
+  - path: skills/nemoclaw-user-get-started/
+    catalog_dir: nemoclaw-user-get-started
+  - path: skills/nemoclaw-user-manage-policy/
+    catalog_dir: nemoclaw-user-manage-policy
+  - path: skills/nemoclaw-user-manage-sandboxes/
+    catalog_dir: nemoclaw-user-manage-sandboxes
+  - path: skills/nemoclaw-user-monitor-sandbox/
+    catalog_dir: nemoclaw-user-monitor-sandbox
+  - path: skills/nemoclaw-user-overview/
+    catalog_dir: nemoclaw-user-overview
+  - path: skills/nemoclaw-user-reference/
+    catalog_dir: nemoclaw-user-reference


### PR DESCRIPTION
## Summary

Three changes to \`components.d/nemoclaw.yml\`:

1. **Flip source path from \`.agents/skills/\` → \`skills/\`.** NemoClaw correctly segregates customer-facing skills (10 \`nemoclaw-user-*\` under \`skills/\`) from contributor/maintainer skills (15 under \`.agents/skills/\`). The previous yml pointed at \`.agents/skills/\` which would have leaked contributor/maintainer skills into the public catalog — anti-pattern #16 (cf. NeMo-RL #61).
2. **Flat layout per-skill entries** per the convention adopted 2026-05-28.
3. **Description tightened** — drop "contributor/maintainer workflows" trailing fragment since those skills are deliberately not in the public catalog.

## Source state — all 10 skills fully 5/5 compliant

| Skill | sig | card | evals | BENCHMARK |
|---|:---:|:---:|:---:|:---:|
| nemoclaw-user-agent-skills | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-configure-inference | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-configure-security | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-deploy-remote | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-get-started | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-manage-policy | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-manage-sandboxes | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-monitor-sandbox | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-overview | ✓ | ✓ | ✓ | ✓ |
| nemoclaw-user-reference | ✓ | ✓ | ✓ | ✓ |

NemoClaw is the **fourth product to reach full artifact compliance** after Skill Card Generator, DeepStream, and AutoModel.

## Test plan

- [x] DCO + Verify Authors green
- [ ] After merge: trigger manual sync; confirm 10 skills land flat at \`skills/nemoclaw-user-*/\`
- [ ] Confirm contributor/maintainer skills under \`.agents/skills/\` do NOT appear in catalog (no leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)