### PR TITLE
feat(nemo-platform): onboard NeMo Platform skills

### DIFF
--- a/components.d/nemo-platform.yml
+++ b/components.d/nemo-platform.yml
@@ -6,6 +6,5 @@ skills:
     catalog_dir: nemo-evaluator-plugin
   - path: skills/nemo-data-designer-plugin/
     catalog_dir: nemo-data-designer-plugin
-  - path: skills/nemo-setup/
-    catalog_dir: nemo-setup
+
 

--- a/components.d/nemo-platform.yml
+++ b/components.d/nemo-platform.yml
@@ -2,7 +2,7 @@ name: NeMo Platform
 repo: NVIDIA-NeMo/nemo-platform
 description: NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, and web UI
 skills:
-  - path: plugins/nemo-evaluator/src/nemo_evaluator/skills/nemo-evaluator/
+  - path: plugins/nemo-evaluator/src/nemo_evaluator/skills/evaluator-plugin/
     catalog_dir: nemo-evaluator-plugin
   - path: plugins/nemo-data-designer/src/nemo_data_designer_plugin/skills/data-designer/
     catalog_dir: nemo-data-designer-plugin

--- a/components.d/nemo-platform.yml
+++ b/components.d/nemo-platform.yml
@@ -1,0 +1,11 @@
+name: NeMo Platform
+repo: NVIDIA-NeMo/nemo-platform
+description: NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, and web UI
+skills:
+  - path: plugins/nemo-evaluator/src/nemo_evaluator/skills/nemo-evaluator/
+    catalog_dir: nemo-evaluator-plugin
+  - path: plugins/nemo-data-designer/src/nemo_data_designer_plugin/skills/data-designer/
+    catalog_dir: nemo-data-designer-plugin
+  - path: skills/nemo-setup/
+    catalog_dir: nemo-setup
+

--- a/components.d/nemo-platform.yml
+++ b/components.d/nemo-platform.yml
@@ -2,9 +2,9 @@ name: NeMo Platform
 repo: NVIDIA-NeMo/nemo-platform
 description: NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, and web UI
 skills:
-  - path: plugins/nemo-evaluator/src/nemo_evaluator/skills/evaluator-plugin/
+  - path: skills/nemo-evaluator-plugin/
     catalog_dir: nemo-evaluator-plugin
-  - path: plugins/nemo-data-designer/src/nemo_data_designer_plugin/skills/data-designer/
+  - path: skills/nemo-data-designer-plugin/
     catalog_dir: nemo-data-designer-plugin
   - path: skills/nemo-setup/
     catalog_dir: nemo-setup


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->

## Dependency
- https://github.com/NVIDIA-NeMo/nemo-platform/pull/104
- https://github.com/NVIDIA-NeMo/nemo-platform/pull/116
