### PR TITLE
components.d/tilegym: flip source path from .agents/skills/ to skills/

### DIFF
--- a/components.d/tilegym.yml
+++ b/components.d/tilegym.yml
@@ -1,8 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: TileGym
 repo: NVIDIA/TileGym
 description: Tile-based GPU programming — adding new kernels, cross-framework conversion, and performance optimization.
 skills:
-  - path: .agents/skills/
+  - path: skills/
     catalog_dir: TileGym
 links:
   discussions: false


### PR DESCRIPTION
## Summary

Flip `components.d/tilegym.yml`'s `path` from `.agents/skills/` → `skills/`.

TileGym https://github.com/NVIDIA/TileGym/pull/132 migrates all 7 cuTile skill folders from `.agents/skills/` to the canonical release-facing `skills/` path. The previous `.agents/skills/` is retained as a backward-compatibility symlink for tools that still expect the agentskills.io layout, but the sync workflow's `git sparse-checkout` + `rsync` does not reliably follow that symlink — it would either copy just the symlink-as-file or miss the contents entirely.

TileGym https://github.com/NVIDIA/TileGym/pull/135 (now merged) onboarded all 7 cuTile skills to `nvskills-ci`: skills moved into `skills/`, each folder got a `tilegym-` prefix, NVSkills validation signatures + `skill-card.md` + `BENCHMARK.md` are attached for every skill, and `tilegym-adding-cutile-kernel` ships with a 5-case `evals/evals.json` (Tier 3 verdict: PASS, codex overall lift `+0.02`, best-performing agent codex).

Single-entry parent-path form (`path: skills/`, `catalog_dir: TileGym`) is retained rather than per-skill flat layout because:

1. **All 7 cuTile skills are intended for the public catalog** — there is no contributor/maintainer-only skill subset to filter out (cf. anti-pattern #16 in #113).
2. **Parent-path auto-discovers new skills** — adding `evals.json` to additional skills in follow-up TileGym PRs (6 more cuTile skills are queued) will not require additional `nvidia/skills` PRs.

Also adds the standard Apache SPDX header to match the convention adopted across `components.d/` on 2026-05-28 (cf. #109, #113).

## Source state — compliance per skill (after TileGym #135 merged)

| Skill | sig | card | evals.json | BENCHMARK.md |
|---|:---:|:---:|:---:|:---:|
| tilegym-adding-cutile-kernel | ✓ | ✓ | ✓ (5 cases) | ✓ (Tier 3 PASS, +0.02 lift) |
| tilegym-cutile-python | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |
| tilegym-cutile-autotuning | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |
| tilegym-converting-cutile-to-julia | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |
| tilegym-converting-cutile-to-triton | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |
| tilegym-improve-cutile-kernel-perf | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |
| tilegym-monkey-patch-kernels-to-transformers | ✓ | ✓ | (follow-up) | ✓ (Tier 1+2 only) |

The 1 fully compliant skill (`tilegym-adding-cutile-kernel`) syncs to `nvidia/skills/skills/TileGym/tilegym-adding-cutile-kernel/` when this PR lands. The remaining 6 stay dropped by the sync compliance gate until their `evals/evals.json` lands in subsequent TileGym PRs (these will sync automatically without further changes here).

## Test plan

- [ ] DCO + Verify Authors green
- [ ] After merge: trigger manual sync (or wait for next 12h schedule) and confirm `skills/TileGym/tilegym-adding-cutile-kernel/` appears with `skill.oms.sig`, `skill-card.md`, `evals.json`, and `BENCHMARK.md`.
