### PR TITLE
Add Physical AI Skill Hub component

### DIFF
--- a/components.d/physical-ai-skill-hub.yml
+++ b/components.d/physical-ai-skill-hub.yml
@@ -1,0 +1,14 @@
+name: Physical AI Skill Hub
+repo: NVIDIA-dev/physical-ai-skill-hub-dev
+description: Agent skills for Omniverse and Physical AI workflows.
+skills:
+  - path: skills/omniverse-cad-to-simready/
+    catalog_dir: omniverse-cad-to-simready
+  - path: skills/omniverse-realtime-viewer/
+    catalog_dir: omniverse-realtime-viewer
+  - path: skills/omniverse-usd-performance-tuning/
+    catalog_dir: omniverse-usd-performance-tuning
+  - path: skills/physical-ai-infrastructure-setup-and-resilient-scaling/
+    catalog_dir: physical-ai-infrastructure-setup-and-resilient-scaling
+  - path: skills/physical-ai-neural-reconstruction/
+    catalog_dir: physical-ai-neural-reconstruction


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context

Adds the first-round Physical AI Skill Hub sync entries:

- `omniverse-cad-to-simready`
- `omniverse-realtime-viewer`
- `omniverse-usd-performance-tuning`
- `physical-ai-infrastructure-setup-and-resilient-scaling`
- `physical-ai-neural-reconstruction`

Sync gate note:

- Confirm `physical-ai-neural-reconstruction` has an `evals.json` before the sync gate runs; the current source tree shows `SKILL.md`, `skill-card.md`, `skill.oms.sig`, and `BENCHMARK.md`, but no `evals.json` was found.
