### PR TITLE
components.d/dynamo: flat layout per-skill entries

### DIFF
--- a/components.d/dynamo.yml
+++ b/components.d/dynamo.yml
@@ -4,5 +4,11 @@ name: Dynamo
 repo: ai-dynamo/dynamo
 description: NVIDIA Dynamo deployment bring-up on Kubernetes — pick and deploy recipes, start router modes, validate disagg NIXL/UCX/NCCL interconnect, and triage day-2 failures.
 skills:
-  - path: skills/
-    catalog_dir: Dynamo
+  - path: skills/dynamo-interconnect-check/
+    catalog_dir: dynamo-interconnect-check
+  - path: skills/dynamo-recipe-runner/
+    catalog_dir: dynamo-recipe-runner
+  - path: skills/dynamo-router-starter/
+    catalog_dir: dynamo-router-starter
+  - path: skills/dynamo-troubleshoot/
+    catalog_dir: dynamo-troubleshoot


### PR DESCRIPTION
## Summary

Follow-up to PR #74 (Dan Gil's Dynamo onboarding). Restructure \`components.d/dynamo.yml\` to flat layout — one entry per skill, lowercase \`catalog_dir\` matching skill names.

## Why immediately

PR #74 merged with the legacy sweep pattern (\`path: skills/, catalog_dir: Dynamo\`) to land Dan's onboarding work tonight. Merging this PR before the first post-#74 sync runs means no nested \`skills/Dynamo/\` directory is ever created in the catalog — clean single-step migration to flat layout.

## Source state

All 4 Dynamo skills are 5/5 artifact-compliant in \`ai-dynamo/dynamo\`:

| Skill | sig | card | evals | BENCHMARK |
|---|:---:|:---:|:---:|:---:|
| dynamo-interconnect-check | ✓ | ✓ | ✓ | ✓ |
| dynamo-recipe-runner | ✓ | ✓ | ✓ | ✓ |
| dynamo-router-starter | ✓ | ✓ | ✓ | ✓ |
| dynamo-troubleshoot | ✓ | ✓ | ✓ | ✓ |

**Dynamo becomes the 9th product to reach full artifact compliance.**

## After this merges

Next sync publishes 4 skills flat at:
- \`skills/dynamo-interconnect-check/\`
- \`skills/dynamo-recipe-runner/\`
- \`skills/dynamo-router-starter/\`
- \`skills/dynamo-troubleshoot/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)