### PR TITLE
components.d/dali: flat layout + canonical source path

### DIFF
--- a/components.d/dali.yml
+++ b/components.d/dali.yml
@@ -1,9 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: DALI
 repo: NVIDIA/DALI
 description: GPU-accelerated data loading and processing with NVIDIA DALI.
 skills:
-  - path: .agents/skills
-    catalog_dir: DALI
+  - path: skills/dali-dynamic-mode/
+    catalog_dir: dali-dynamic-mode
 links:
-   discussions: false
-   security: false  # DALI has a SECURITY.rst file
+  discussions: false
+  security: false  # DALI has SECURITY.rst rather than SECURITY.md


### PR DESCRIPTION
## Summary

Three changes to \`components.d/dali.yml\`:

1. **Flip source path** from \`.agents/skills\` → \`skills/dali-dynamic-mode/\`. NVIDIA/DALI moved to canonical \`skills/\` layout per Mohit's 2026-05-15 directive but the catalog yml was never updated — sync has been producing 0 DALI skills in the catalog despite the source being fully 5/5 compliant.
2. **Flat layout** per the convention adopted 2026-05-28 (one-entry-per-skill, lowercase \`catalog_dir\`).
3. **SPDX + copyright headers** added. Existing \`links.discussions: false\` + \`links.security: false\` overrides retained (DALI has \`SECURITY.rst\` rather than \`.md\`).

## Source state

\`NVIDIA/DALI/skills/dali-dynamic-mode/\` is fully 5/5 artifact-compliant:

| Skill | sig | card | evals | BENCHMARK |
|---|:---:|:---:|:---:|:---:|
| dali-dynamic-mode | ✓ | ✓ | ✓ | ✓ |

SKILL.md frontmatter is exemplary — \`license: Apache-2.0\`, rich metadata block with author/tags/languages, clear trigger keywords ("DALI imperative dynamic mode", "ndd", "migrating pipelines").

## After this merges

Next sync publishes \`skills/dali-dynamic-mode/\` flat at top level. **DALI becomes the 11th product with verified content in the catalog.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)