### PR TITLE
components.d/rag-blueprint: ref develop + flat layout + canonical paths

### DIFF
--- a/components.d/rag-blueprint.yml
+++ b/components.d/rag-blueprint.yml
@@ -1,6 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: RAG Blueprint
 repo: NVIDIA-AI-Blueprints/rag
+ref: develop
 description: RAG pipeline — deploy, configure, troubleshoot, and manage retrieval augmented generation with Docker Compose or Helm.
 skills:
-  - path: skill-source/.agents/skills/
-    catalog_dir: rag
+  - path: skills/rag-blueprint/
+    catalog_dir: rag-blueprint
+  - path: skills/rag-eval/
+    catalog_dir: rag-eval
+  - path: skills/rag-perf/
+    catalog_dir: rag-perf


### PR DESCRIPTION
## Summary

Three changes to \`components.d/rag-blueprint.yml\`:

1. **Add \`ref: develop\`.** RAG Blueprint team moved skill content to the canonical \`skills/\` path on the \`develop\` branch; nothing exists at the old \`skill-source/.agents/skills/\` path on main anymore.
2. **Flip source path** from \`skill-source/.agents/skills/\` → \`skills/<skill>/\` per skill.
3. **Flat layout** (one-entry-per-skill, lowercase \`catalog_dir\`) per the convention adopted 2026-05-28.

## Source state on \`develop\`

3 newly-signed skills sitting orphaned because the catalog yml never got updated after the team restructured:

| Skill | sig | card | BENCHMARK | eval data |
|---|:---:|:---:|:---:|---|
| rag-blueprint | ✓ | ✓ | ✓ | \`eval/h100.json\` + \`eval/nvidia_hosted.json\` (non-canonical, see note below) |
| rag-eval | ✓ | ✓ | ✓ | \`eval/\` (non-canonical) |
| rag-perf | ✓ | ✓ | ✓ | \`eval/\` (non-canonical) |

## Eval path note

The skills use \`eval/\` (singular, with profile-named JSON files) instead of the canonical \`evals/evals.json\`. Sync enforcement does a recursive eval-discovery so they may land under lenient enforcement (same as \`cuopt-developer/benchmark/evals.json\`). If strict enforcement drops them, a follow-up source PR can move \`eval/\` → \`evals/evals.json\`.

## After this merges

Next sync publishes 3 RAG Blueprint skills flat at top-level: \`skills/rag-blueprint/\`, \`skills/rag-eval/\`, \`skills/rag-perf/\`. **RAG Blueprint goes from 0 → 3 verified skills in the catalog and becomes the 12th product with content.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)