### PR TITLE
sync-skills: accept multi-profile eval datasets (eval/*.json, evals/*.json)

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -148,8 +148,18 @@ jobs:
           # Every catalog skill (defined by SKILL.md) must ship with:
           #   - skill.oms.sig  (detached NVIDIA signature)
           #   - skill-card.md  (skill metadata card)
-          #   - evals.json     (eval definitions, anywhere within the
-          #                     skill directory — typically under benchmark/)
+          #   - eval data      (Tier-3 NV-ACES dataset). Accepted in any
+          #                     of these forms — semantic equivalence,
+          #                     not literal-filename:
+          #                       * evals.json anywhere in the skill dir
+          #                         (canonical — recursive find)
+          #                       * any *.json under skills/<skill>/evals/
+          #                       * any *.json under skills/<skill>/eval/
+          #                     This accepts multi-profile datasets like
+          #                     eval/h100.json + eval/nvidia_hosted.json
+          #                     (RAG Blueprint pattern), benchmark/evals.json
+          #                     (cuopt-developer pattern), and the
+          #                     canonical evals/evals.json layout.
           # Skills missing any of these are dropped from the catalog
           # before the PR is created — non-compliant skills do not merge.
           dropped=/tmp/dropped-skills.txt
@@ -160,8 +170,19 @@ jobs:
             missing=""
             [ -f "$dir/skill.oms.sig" ] || missing="$missing skill.oms.sig"
             [ -f "$dir/skill-card.md" ] || missing="$missing skill-card.md"
-            [ -n "$(find "$dir" -type f -name evals.json -print -quit 2>/dev/null)" ] \
-              || missing="$missing evals.json"
+            # Eval dataset: accept canonical evals.json, OR any *.json
+            # under eval/ or evals/ subdir (multi-profile datasets).
+            has_eval=""
+            if [ -n "$(find "$dir" -type f -name evals.json -print -quit 2>/dev/null)" ]; then
+              has_eval=1
+            elif [ -d "$dir/evals" ] && \
+                 [ -n "$(find "$dir/evals" -maxdepth 1 -type f -name '*.json' -print -quit 2>/dev/null)" ]; then
+              has_eval=1
+            elif [ -d "$dir/eval" ] && \
+                 [ -n "$(find "$dir/eval" -maxdepth 1 -type f -name '*.json' -print -quit 2>/dev/null)" ]; then
+              has_eval=1
+            fi
+            [ -n "$has_eval" ] || missing="$missing evals.json"
             if [ -n "$missing" ]; then
               product=$(echo "$dir" | awk -F/ '{print $2}')
               echo "$product|$dir|$(echo "$missing" | xargs)" >> "$dropped"


### PR DESCRIPTION
## Summary

Loosen the sync compliance gate's eval-dataset check to accept multi-profile JSON layouts in addition to the canonical \`evals.json\` filename. Real teams (RAG Blueprint, cuopt-developer) ship semantically-equivalent datasets under non-canonical names — the previous strict-filename check was rejecting them despite full Tier-3 NV-ACES compatibility.

## Problem

The current check at \`.github/workflows/sync-skills.yml:163\` looks for a file literally named \`evals.json\` anywhere in the skill directory. This dropped RAG Blueprint's 3 skills (rag-blueprint, rag-eval, rag-perf) on PR #141's sync because the team uses:

\`\`\`
skills/rag-blueprint/eval/
├── h100.json
└── nvidia_hosted.json
\`\`\`

The dataset is real and Tier-3 compatible — only the filename differs from canonical.

## Fix

Accept ANY of three forms:

1. **\`evals.json\` anywhere in skill dir** — canonical, unchanged. Keeps \`cuopt-developer/benchmark/evals.json\` working.
2. **Any \`*.json\` under \`skills/<skill>/evals/\`** — multi-profile, plural dir.
3. **Any \`*.json\` under \`skills/<skill>/eval/\`** — multi-profile, singular dir (RAG pattern).

Substantive requirement unchanged: skill ships a Tier-3 eval dataset. We no longer prescribe filename when the team's pipeline already produces equivalent content. Sig + skill-card checks unchanged.

## After this merges

Next sync brings 3 RAG Blueprint skills into the catalog (rag-blueprint, rag-eval, rag-perf — all sig + card + BENCHMARK ✓ + multi-profile eval/*.json). No source-side rename needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)