### PR TITLE
components.d/tilegym: flat layout per-skill entries

### DIFF
--- a/components.d/tilegym.yml
+++ b/components.d/tilegym.yml
@@ -4,7 +4,19 @@ name: TileGym
 repo: NVIDIA/TileGym
 description: Tile-based GPU programming — adding new kernels, cross-framework conversion, and performance optimization.
 skills:
-  - path: skills/
-    catalog_dir: TileGym
+  - path: skills/tilegym-adding-cutile-kernel/
+    catalog_dir: tilegym-adding-cutile-kernel
+  - path: skills/tilegym-converting-cutile-to-julia/
+    catalog_dir: tilegym-converting-cutile-to-julia
+  - path: skills/tilegym-converting-cutile-to-triton/
+    catalog_dir: tilegym-converting-cutile-to-triton
+  - path: skills/tilegym-cutile-autotuning/
+    catalog_dir: tilegym-cutile-autotuning
+  - path: skills/tilegym-cutile-python/
+    catalog_dir: tilegym-cutile-python
+  - path: skills/tilegym-improve-cutile-kernel-perf/
+    catalog_dir: tilegym-improve-cutile-kernel-perf
+  - path: skills/tilegym-monkey-patch-kernels-to-transformers/
+    catalog_dir: tilegym-monkey-patch-kernels-to-transformers
 links:
   discussions: false


### PR DESCRIPTION
## Summary

Follow-up to PR #121 (Hannah's path flip from \`.agents/skills/\` → canonical \`skills/\`). Restructure \`components.d/tilegym.yml\` to one-entry-per-skill flat layout matching the \`tilegym-\` prefixed names Hannah landed in source.

## Why immediately after #121

PR #121 merged with the legacy sweep pattern to land the canonical-path correction quickly. Merging this PR before the first post-#121 sync runs means no nested \`skills/TileGym/\` directory is ever created in the catalog — single-step migration to flat layout, same pattern as Dynamo (#74 → #127).

## Source state

7 skills, all renamed with \`tilegym-\` prefix + sig + card + BENCHMARK. 1 of 7 is fully 5/5; the other 6 lack eval datasets:

| Skill | sig | card | evals | BENCHMARK |
|---|:---:|:---:|:---:|:---:|
| tilegym-adding-cutile-kernel | ✓ | ✓ | ✓ | ✓ |
| tilegym-converting-cutile-to-julia | ✓ | ✓ | ✗ | ✓ |
| tilegym-converting-cutile-to-triton | ✓ | ✓ | ✗ | ✓ |
| tilegym-cutile-autotuning | ✓ | ✓ | ✗ | ✓ |
| tilegym-cutile-python | ✓ | ✓ | ✗ | ✓ |
| tilegym-improve-cutile-kernel-perf | ✓ | ✓ | ✗ | ✓ |
| tilegym-monkey-patch-kernels-to-transformers | ✓ | ✓ | ✗ | ✓ |

## After this merges

Next sync publishes \`tilegym-adding-cutile-kernel\` flat at top level (5/5 compliant). The other 6 will drop on enforcement until Hannah's team adds eval datasets — Slack drafted separately to track the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)