### PR TITLE
README: refresh Repository Structure section for flat layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,24 @@ See [Verify Signed Agent Skills](docs/signing-agent-skills.mdx) for signature la
 
 ```
 NVIDIA/skills/
-├── skills/                      # Verified skills, mirrored daily from product repos
-│   ├── README.md                 # Install guidance for people browsing this folder directly
-│   ├── aiq-research/             # AIQ — deep/shallow research workflow
-│   ├── aiq-deploy/               # AIQ — local service deployment
-│   └── cuopt/                    # cuOpt skills (routing, optimization, server, install, …)
+├── skills/                      # Verified skills, mirrored from product repos
+│   ├── README.md                 # Install guidance for people browsing this folder
+│   ├── aiq-deploy/               # AIQ — deploy AI-Q services
+│   ├── aiq-research/             # AIQ — research workflows
+│   ├── cuopt-developer/          # cuOpt — internals & contribution
+│   ├── cuopt-install/            # cuOpt — installation
+│   ├── cuopt-routing-api-python/ # cuOpt — VRP/TSP routing (Python)
+│   ├── dali-dynamic-mode/        # DALI — dynamic-mode pipeline authoring
+│   ├── deepstream-dev/           # DeepStream — guided development
+│   ├── dynamo-recipe-runner/     # Dynamo — Kubernetes recipe deploys
+│   ├── nemo-automodel-*/         # NeMo AutoModel — distributed training (4 skills)
+│   ├── nemoclaw-user-*/          # NemoClaw — secure agent sandboxing (10 skills)
+│   ├── nemotron-customize/       # Nemotron — model customization
+│   ├── rag-blueprint/            # RAG Blueprint — RAG pipeline
+│   ├── skill-card-generator/     # Trustworthy-AI — skill card generation
+│   └── tilegym-adding-cutile-kernel/  # TileGym — cuTile kernel authoring
+│                                 # Each skill lives flat at top level (no product parent
+│                                 # dir), so `npx skills add --skill <name>` resolves cleanly
 ├── components.d/                # Product registry — one file per component, teams onboard here
 │   ├── README.md                 # Schema and onboarding instructions
 │   ├── aiq.yml
@@ -216,7 +229,13 @@ NVIDIA/skills/
 └── LICENSE                      # Apache 2.0 / CC BY 4.0
 ```
 
-Skills are maintained in their respective product repos (see the **Source** column in the [Skill Catalog](#skill-catalog)) and automatically synced to this repo daily. Products only appear under `skills/` after the sync pipeline confirms each skill carries `skill.oms.sig`, `skill-card.md`, and `evals.json`.
+Skills are maintained in their respective product repos (see the **Source** column in the [Skill Catalog](#skill-catalog)) and synced to this repo daily. Products only appear under `skills/` after the sync pipeline confirms each skill carries:
+
+- `skill.oms.sig` — detached OMS-format signature (verifiable against `nv-agent-root-cert.pem`)
+- `skill-card.md` — skill identity and governance card
+- A Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
+
+When evaluation runs produce a `BENCHMARK.md`, it ships alongside the skill so consumers can see verifiable benchmark uplift data.
 
 ---
 


### PR DESCRIPTION
## Summary

Refresh the **Repository Structure** section in README.md to reflect the current state of the catalog:

1. **Directory-tree example uses flat layout.** Previously showed \`cuopt/\` as a nested product parent dir — that pattern has been migrated to flat top-level skill directories across all products. New tree lists representative flat top-level entries from each product currently in the catalog.

2. **Gating description enumerates accepted eval-dataset paths.** Previously said skills must carry \`evals.json\` (single canonical filename). Now lists all accepted forms per the loosened compliance gate:
   - \`evals/evals.json\` (canonical)
   - \`evals/*.json\` (multi-profile, plural dir)
   - \`eval/*.json\` (multi-profile, singular dir)
   - \`benchmark/evals.json\` (legacy)

3. **Adds a one-line callout** that each skill lives flat at top level so \`npx skills add --skill <name>\` resolves cleanly.

## Why

The README's Repository Structure section is what product teams read when first looking at the catalog to understand layout. After the cross-product flat-layout migration, the old example was misleading.

## Test plan

- [x] DCO + Verify Authors
- [ ] Visual review of the rendered Repository Structure section
- [ ] Confirm no other README sections need related updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)