### PR TITLE
chore: publish NeMo MBridge skills

### DIFF
--- a/components.d/megatron-bridge.yml
+++ b/components.d/megatron-bridge.yml
@@ -1,8 +1,0 @@
-name: Megatron-Bridge
-repo: NVIDIA-NeMo/Megatron-Bridge
-description: Bridge between NeMo and Megatron — data processing, model conversion, and training utilities.
-skills:
-  - path: skills/
-    catalog_dir: Megatron-Bridge
-links:
-  security: false

--- a/components.d/nemo-mbridge.yml
+++ b/components.d/nemo-mbridge.yml
@@ -1,0 +1,44 @@
+name: NeMo MBridge
+repo: NVIDIA-NeMo/Megatron-Bridge
+description: NeMo MBridge - PyTorch-native bridge between Hugging Face and Megatron-Core for checkpoint conversion, training recipes, and NVIDIA GPU performance workflows.
+skills:
+  - path: skills/nemo-mbridge-mlm-bridge-training/
+    catalog_dir: nemo-mbridge-mlm-bridge-training
+  - path: skills/nemo-mbridge-multi-node-slurm/
+    catalog_dir: nemo-mbridge-multi-node-slurm
+  - path: skills/nemo-mbridge-perf-activation-recompute/
+    catalog_dir: nemo-mbridge-perf-activation-recompute
+  - path: skills/nemo-mbridge-perf-cpu-offloading/
+    catalog_dir: nemo-mbridge-perf-cpu-offloading
+  - path: skills/nemo-mbridge-perf-cuda-graphs/
+    catalog_dir: nemo-mbridge-perf-cuda-graphs
+  - path: skills/nemo-mbridge-perf-expert-parallel-overlap/
+    catalog_dir: nemo-mbridge-perf-expert-parallel-overlap
+  - path: skills/nemo-mbridge-perf-hierarchical-context-parallel/
+    catalog_dir: nemo-mbridge-perf-hierarchical-context-parallel
+  - path: skills/nemo-mbridge-perf-megatron-fsdp/
+    catalog_dir: nemo-mbridge-perf-megatron-fsdp
+  - path: skills/nemo-mbridge-perf-memory-tuning/
+    catalog_dir: nemo-mbridge-perf-memory-tuning
+  - path: skills/nemo-mbridge-perf-moe-comm-overlap/
+    catalog_dir: nemo-mbridge-perf-moe-comm-overlap
+  - path: skills/nemo-mbridge-perf-moe-dispatcher-selection/
+    catalog_dir: nemo-mbridge-perf-moe-dispatcher-selection
+  - path: skills/nemo-mbridge-perf-moe-hardware-configs/
+    catalog_dir: nemo-mbridge-perf-moe-hardware-configs
+  - path: skills/nemo-mbridge-perf-moe-long-context/
+    catalog_dir: nemo-mbridge-perf-moe-long-context
+  - path: skills/nemo-mbridge-perf-moe-optimization-workflow/
+    catalog_dir: nemo-mbridge-perf-moe-optimization-workflow
+  - path: skills/nemo-mbridge-perf-moe-vlm-training/
+    catalog_dir: nemo-mbridge-perf-moe-vlm-training
+  - path: skills/nemo-mbridge-perf-parallelism-strategies/
+    catalog_dir: nemo-mbridge-perf-parallelism-strategies
+  - path: skills/nemo-mbridge-perf-sequence-packing/
+    catalog_dir: nemo-mbridge-perf-sequence-packing
+  - path: skills/nemo-mbridge-perf-tp-dp-comm-overlap/
+    catalog_dir: nemo-mbridge-perf-tp-dp-comm-overlap
+  - path: skills/nemo-mbridge-recipe-recommender/
+    catalog_dir: nemo-mbridge-recipe-recommender
+  - path: skills/nemo-mbridge-resiliency/
+    catalog_dir: nemo-mbridge-resiliency


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

This replaces the existing `megatron-bridge` component slug with `nemo-mbridge` and registers the signed NeMo MBridge skills for automated catalog sync. It follows the flat, explicit skill-entry pattern used by `components.d/nemo-automodel.yml` without manually adding catalog skill content in this PR.

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache-2.0, matching the 20 upstream `SKILL.md` frontmatter entries
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> Maintainer follow-up before review: please confirm the two unchecked internal/IP-review affirmations above.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

Changes:
- Rename component slug file from `components.d/megatron-bridge.yml` to `components.d/nemo-mbridge.yml`.
- Change display name to `NeMo MBridge`.
- Follow the NeMo AutoModel pattern: one explicit customer-facing skill path per `skills:` entry and flat `catalog_dir` values.
- Register all 20 signed `skills/nemo-mbridge-*` directories from `NVIDIA-NeMo/Megatron-Bridge` for the automated sync workflow.

This PR intentionally does **not** add files under `skills/` or update `README.md`; those are generated by the sync workflow after the component entry merges.

Validation run locally:
- Parsed `components.d/nemo-mbridge.yml` and verified 20 entries.
- Verified every entry uses `path: skills/<catalog_dir>/`.
