### PR TITLE
chore: publish Megatron-Core mcore skills

### DIFF
--- a/components.d/megatron-core.yml
+++ b/components.d/megatron-core.yml
@@ -2,18 +2,10 @@ name: Megatron-Core
 repo: NVIDIA/Megatron-LM
 description: Large-scale distributed training — model parallelism, pipeline parallelism, and mixed precision.
 skills:
-  - path: skills/mcore-build-and-dependency/
-    catalog_dir: mcore-build-and-dependency
-  - path: skills/mcore-bump-base-image/
-    catalog_dir: mcore-bump-base-image
-  - path: skills/mcore-cicd/
-    catalog_dir: mcore-cicd
   - path: skills/mcore-create-issue/
     catalog_dir: mcore-create-issue
   - path: skills/mcore-linting-and-formatting/
     catalog_dir: mcore-linting-and-formatting
-  - path: skills/mcore-onboard-gb200-1node-tests/
-    catalog_dir: mcore-onboard-gb200-1node-tests
   - path: skills/mcore-run-on-slurm/
     catalog_dir: mcore-run-on-slurm
   - path: skills/mcore-split-pr/

--- a/components.d/megatron-core.yml
+++ b/components.d/megatron-core.yml
@@ -2,7 +2,23 @@ name: Megatron-Core
 repo: NVIDIA/Megatron-LM
 description: Large-scale distributed training — model parallelism, pipeline parallelism, and mixed precision.
 skills:
-  - path: skills/
-    catalog_dir: Megatron-Core
+  - path: skills/mcore-build-and-dependency/
+    catalog_dir: mcore-build-and-dependency
+  - path: skills/mcore-bump-base-image/
+    catalog_dir: mcore-bump-base-image
+  - path: skills/mcore-cicd/
+    catalog_dir: mcore-cicd
+  - path: skills/mcore-create-issue/
+    catalog_dir: mcore-create-issue
+  - path: skills/mcore-linting-and-formatting/
+    catalog_dir: mcore-linting-and-formatting
+  - path: skills/mcore-onboard-gb200-1node-tests/
+    catalog_dir: mcore-onboard-gb200-1node-tests
+  - path: skills/mcore-run-on-slurm/
+    catalog_dir: mcore-run-on-slurm
+  - path: skills/mcore-split-pr/
+    catalog_dir: mcore-split-pr
+  - path: skills/mcore-testing/
+    catalog_dir: mcore-testing
 links:
   security: false


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

This converts the existing `Megatron-Core` component (`components.d/megatron-core.yml`) from the bulk-sync pattern (single `path: skills/` + `catalog_dir: Megatron-Core`) to the flat, explicit one-entry-per-skill pattern used by `components.d/nemo-mbridge.yml` and `components.d/nemo-automodel.yml`. It registers the signed `mcore-*` skills from `NVIDIA/Megatron-LM` for the automated catalog sync without manually adding catalog skill content in this PR.

The component slug and display name are unchanged (`Megatron-Core`) — there is no rebrand, and the `mcore-*` skills already belong to this component. This is the Megatron-LM analog of #151 (which performed the same bulk → flat conversion for Megatron-Bridge, additionally renaming to NeMo MBridge).

## Reviewer checklist (OSS Skills PIC)

- [ ] `components.d/megatron-core.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Changes:
- Replace the single bulk `skills:` entry in `components.d/megatron-core.yml` with explicit entries, one per signed skill, each using `path: skills/<catalog_dir>/` and a flat `catalog_dir`.
- Keep `name: Megatron-Core`, `repo: NVIDIA/Megatron-LM`, and `links.security: false` unchanged.

Skills registered (from NVIDIA/Megatron-LM#5066, assumed merged):
- mcore-create-issue
- mcore-linting-and-formatting
- mcore-run-on-slurm
- mcore-split-pr
- mcore-testing

This PR intentionally does **not** add files under `skills/` or update `README.md`; those are generated by the sync workflow after the component entry merges.

Validation run locally:
- Parsed `components.d/megatron-core.yml` and verified 5 entries.
- Verified every entry uses `path: skills/<catalog_dir>/` and all `catalog_dir` values are unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)