### PR TITLE
Add nemotron-retrieval-recipes skill to components.d/nemotron.yml

### DIFF
--- a/components.d/nemotron.yml
+++ b/components.d/nemotron.yml
@@ -4,3 +4,5 @@ description: Author end-to-end model development, customization, evaluation, and
 skills:
   - path: skills/nemotron-customize/
     catalog_dir: nemotron-customize
+  - path: skills/nemotron-retrieval-recipes/
+    catalog_dir: nemotron-retrieval-recipes


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- New skill (in existing `components.d/nemotron.yml` file)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [X] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [X] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [X] **No new license or new third-party component** introduced beyond what the source repo already carries
- [X] **Source repo is public and under an NVIDIA-owned GitHub org**
- [X] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
