### PR TITLE
Add cuDF agent skill

### DIFF
--- a/components.d/cudf.yml
+++ b/components.d/cudf.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: cuDF
+repo: rapidsai/cudf
+description: Official NVIDIA-authored guidance for NVIDIA cuDF GPU DataFrames, pandas acceleration, dask-cuDF, ETL, joins, groupby, CSV/Parquet I/O, nullable semantics, and multi-GPU DataFrame workloads.
+skills:
+  - path: skills/accelerated-computing-cudf
+    catalog_dir: accelerated-computing-cudf


### PR DESCRIPTION
Add the NVIDIA-authored cuDF agent skill under the repository-level skills/ directory so compatible agent tooling and the NVIDIA skills publication pipeline can discover it.

The skill includes cuDF usage guidance, reference material, evaluation fixtures, a benchmark report, and current NVSkills validation artifacts for publication review.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Dual
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
