### PR TITLE
Add more cuPyNumeric skills

### DIFF
--- a/components.d/cupynumeric.yml
+++ b/components.d/cupynumeric.yml
@@ -2,9 +2,15 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: cuPyNumeric
 repo: nv-legate/cupynumeric
-description: NumPy and SciPy on multi-node multi-GPU systems — install and verify cuPyNumeric for Python.
+description: NumPy and SciPy on multi-node multi-GPU systems — skills to help with installing cuPyNumeric, migrating existing NumPy code, and doing parallel I/O
 skills:
+  - path: skills/cupynumeric-hdf5/
+    catalog_dir: cupynumeric-hdf5
   - path: skills/cupynumeric-install/
     catalog_dir: cupynumeric-install
+  - path: skills/cupynumeric-migration-readiness/
+    catalog_dir: cupynumeric-migration-readiness
+  - path: skills/cupynumeric-parallel-data-load/
+    catalog_dir: cupynumeric-parallel-data-load
 links:
   discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [X] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
