### PR TITLE
components.d(vss): pin ref: develop (mirror aiq.yml)

### DIFF
--- a/components.d/video-search-and-summarization.yml
+++ b/components.d/video-search-and-summarization.yml
@@ -1,5 +1,6 @@
 name: Video Search and Summarization
 repo: NVIDIA-AI-Blueprints/video-search-and-summarization
+ref: develop
 description: VSS Blueprint — deploy profiles, search and summarize video, generate analysis reports, manage alerts and incidents, query VIOS sensors, and use the RTVI VLM microservice.
 skills:
   - path: skills/


### PR DESCRIPTION
Pin the VSS component registration to the `develop` branch, mirroring how `components.d/aiq.yml` declares `ref: develop`.

The VSS skills catalog (16 skills, each with `SKILL.md`, `skill-card.md`, `BENCHMARK.md`, `skill.oms.sig`) lives on the `develop` branch of `NVIDIA-AI-Blueprints/video-search-and-summarization`, not `main`. Without a `ref:`, the components scanner defaults to `main` and resolves an older/empty `skills/` tree.

### Change
```diff
 name: Video Search and Summarization
 repo: NVIDIA-AI-Blueprints/video-search-and-summarization
+ref: develop
 description: VSS Blueprint — ...
 skills:
   - path: skills/
     catalog_dir: video-search-and-summarization
```

Matches the existing pattern in `components.d/aiq.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)