### PR TITLE
chore: migrate cuda-q.yml to flat layout

### DIFF
--- a/components.d/cuda-q.yml
+++ b/components.d/cuda-q.yml
@@ -2,7 +2,7 @@ name: CUDA-Q
 repo: NVIDIA/cuda-quantum
 description: CUDA Quantum — onboarding guide for installation, test programs, GPU simulation, QPU hardware, and quantum applications.
 skills:
-  - path: .claude/skills/
-    catalog_dir: CUDA-Q
+  - path: skills/cudaq-guide/
+    catalog_dir: cudaq-guide
 links:
   contributing: Contributing.md


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

The CUDA-Q team moved their skill content from \`.claude/skills/\` to \`skills/cudaq-guide/\` on NVIDIA/cuda-quantum. The catalog's \`cuda-q.yml\` still pointed at the old path, so every sync was 404-ing and silently dropping the product — CUDA-Q appeared in sync PR titles but no skills ever landed in the catalog.

### Changes

- \`path: .claude/skills/\` → \`path: skills/cudaq-guide/\`
- \`catalog_dir: CUDA-Q\` → \`catalog_dir: cudaq-guide\` (flat-layout, lowercase, matches name)

### Source state verified

\`NVIDIA/cuda-quantum/skills/cudaq-guide/\` now carries the full 5-artifact set as of commit \`6c0c754\` (just landed 2026-05-30 02:27 UTC):

- ✅ \`SKILL.md\`
- ✅ \`skill-card.md\`
- ✅ \`skill.oms.sig\`
- ✅ \`evals/\` (\`EVAL.md\`, \`config.yml\`, \`evals.json\`)
- ✅ \`BENCHMARK.md\`

Next sync after merge will populate \`skills/cudaq-guide/\` in the catalog as a verified 5/5 skill — unblocks CUDA-Q for the JHH keynote-library list.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).