### PR TITLE
docs: refresh Verifying Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,17 +164,25 @@ For issues with **this catalog repo itself** (README, structure, listing a new p
 
 ## Verifying Skills
 
-Every published skill ships with a detached OMS signature (`skill.oms.sig`). The sync pipeline drops any skill missing `skill.oms.sig`, `skill-card.md`, or `evals.json` before publishing, so anything in the catalog has all three artifacts.
+Every published skill ships with a detached OMS signature (`skill.oms.sig`). The sync pipeline drops any skill missing the required artifacts before publishing, so every skill in the catalog carries:
+
+- `SKILL.md` — the skill instructions consumed by the agent
+- `skill-card.md` — skill identity and governance card
+- `skill.oms.sig` — detached OMS signature (verifiable against `nv-agent-root-cert.pem`)
+- A Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
+- `BENCHMARK.md` — generated benchmark report capturing verifiable uplift data
 
 Verify a skill against the NVIDIA trust anchor [`nv-agent-root-cert.pem`](nv-agent-root-cert.pem):
 
 ```bash
 pip install model-signing
-model_signing verify certificate SKILL_DIR \
-  --signature SKILL_DIR/skill.oms.sig \
+model_signing verify certificate skills/cudaq-guide \
+  --signature skills/cudaq-guide/skill.oms.sig \
   --certificate_chain nv-agent-root-cert.pem \
   --ignore_unsigned_files
 ```
+
+Replace `skills/cudaq-guide` with the path to any skill in the catalog. A successful verification confirms that the skill contents have not been modified since signing by NVIDIA.
 
 See [Verify Signed Agent Skills](docs/signing-agent-skills.mdx) for signature layout, the trust pipeline, and policy options.
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ Verify a skill against the NVIDIA trust anchor [`nv-agent-root-cert.pem`](nv-age
 
 ```bash
 pip install model-signing
-model_signing verify certificate skills/cudaq-guide \
-  --signature skills/cudaq-guide/skill.oms.sig \
+model_signing verify certificate SKILL_DIR \
+  --signature SKILL_DIR/skill.oms.sig \
   --certificate_chain nv-agent-root-cert.pem \
   --ignore_unsigned_files
 ```
 
-Replace `skills/cudaq-guide` with the path to any skill in the catalog. A successful verification confirms that the skill contents have not been modified since signing by NVIDIA.
+A successful verification confirms that the skill contents have not been modified since signing by NVIDIA.
 
 See [Verify Signed Agent Skills](docs/signing-agent-skills.mdx) for signature layout, the trust pipeline, and policy options.
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

The Verifying Skills section in the README was outdated:

1. **Described the catalog gate as 3 artifacts** (\`skill.oms.sig\` + \`skill-card.md\` + \`evals.json\`). The sync gate actually publishes 5 artifacts per skill (\`SKILL.md\`, \`skill-card.md\`, \`skill.oms.sig\`, a Tier-3 eval dataset, \`BENCHMARK.md\`) and the evaluation-dataset gate accepts multiple layouts (\`evals/evals.json\`, \`evals/*.json\`, \`eval/*.json\`, \`benchmark/evals.json\`) as of PR #143.
2. **Verify example used abstract \`SKILL_DIR\` placeholder.** Switched to \`skills/cudaq-guide\` so readers can copy-paste a working command.
3. **Added one-line context** on what a successful verification confirms.

No behavioural change — documentation alignment with the current 5-artifact publishing contract and loosened eval-dataset gate.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).