### PR TITLE
docs(components): deprecate bulk catalog layout

### DIFF
--- a/components.d/README.md
+++ b/components.d/README.md
@@ -18,14 +18,14 @@ One file per component, aggregated at workflow runtime. This layout exists so si
 | `name`        | string | Display name shown in the README (e.g., `CUDA-Q`, `Nemotron Voice Agent`).  |
 | `repo`        | string | GitHub repository (`owner/repo`).                                           |
 | `description` | string | One-line description for the README's Available Skills table.               |
-| `skills`      | list   | Skill source locations (see below).                                         |
+| `skills`      | list   | Skill source locations — one entry per skill (see below).                   |
 
 Each entry under `skills:` requires:
 
-| Field         | Type   | Description                                                              |
-|---------------|--------|--------------------------------------------------------------------------|
-| `path`        | string | Directory in the source repo containing skills (e.g., `.agents/skills/`).|
-| `catalog_dir` | string | Directory name under `skills/` in this catalog (must be unique).         |
+| Field         | Type   | Description                                                                                |
+|---------------|--------|--------------------------------------------------------------------------------------------|
+| `path`        | string | Directory in the source repo containing a single skill (a directory with `SKILL.md` at its root). |
+| `catalog_dir` | string | Top-level directory name under `skills/` in this catalog (must be unique across components). |
 
 ## Optional fields
 
@@ -44,22 +44,35 @@ name: Your Product
 repo: NVIDIA/your-product
 description: One-line description of what the skills do.
 skills:
-  - path: .agents/skills/
+  - path: skills/your-product-install/
+    catalog_dir: your-product-install
+  - path: skills/your-product-deploy/
+    catalog_dir: your-product-deploy
+```
+
+Each entry points at one skill source directory and creates one top-level catalog directory under `skills/`. The catalog layout mirrors the source naming 1:1 for discoverability — each skill becomes its own `skills/<catalog_dir>/` entry in this catalog, rather than nesting under a per-product subdirectory.
+
+## Bulk layout (deprecated)
+
+> [!IMPORTANT]
+> The bulk layout — where one entry's `path` points at a *parent* directory containing multiple skills, all landing under a single nested `catalog_dir` — is deprecated for new components. Use the flat layout above instead.
+>
+> Existing components on the bulk layout continue to work and will be migrated incrementally. The sync workflow handles both layouts identically (a directory-to-directory `rsync`); the difference is in the catalog shape produced.
+
+The deprecated pattern looked like:
+
+```yaml
+# DEPRECATED — do not copy for new components
+skills:
+  - path: skills/
     catalog_dir: your-product
 ```
 
-For multi-skill components, add multiple entries under `skills:`:
+This produced nested paths like `skills/your-product/<skill-name>/` for every skill found under the source `skills/` directory. The flat layout above is preferred because:
 
-```yaml
-name: NeMo Evaluator
-repo: NVIDIA-NeMo/Evaluator
-description: LLM evaluation — launch evaluations, access MLflow results, and bring-your-own benchmarks.
-skills:
-  - path: packages/nemo-evaluator-launcher/.claude/skills/
-    catalog_dir: NeMo-Evaluator-Launcher
-  - path: packages/nemo-evaluator/.claude/skills/
-    catalog_dir: NeMo-Evaluator
-```
+- Each skill gets a discoverable top-level catalog directory, scannable alongside skills from other components.
+- The `catalog_dir` per skill makes the catalog naming explicit at onboarding time rather than relying on whatever subdirectory names happened to ship in the source `skills/` tree.
+- Source skills can be added, removed, or renamed without changing the catalog's top-level shape silently.
 
 ## How aggregation works
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [x] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->

Updates `components.d/README.md` to promote the flat catalog layout (one entry per skill, one top-level `skills/<catalog_dir>/` directory per skill) as the canonical pattern for new components, and marks the bulk layout (single entry's `path` pointing at a parent directory containing multiple skills) as deprecated.

Concretely:

- `path` is described as pointing at a single skill directory (one with `SKILL.md` at its root) rather than a parent of multiple skills.
- The canonical Example section now shows two flat-layout entries instead of the prior single bulk entry.
- A new "Bulk layout (deprecated)" section captures the old pattern inside a GitHub Admonition (`> [!IMPORTANT]`), explains why the flat layout is preferred (discoverability, explicit naming, decoupling the catalog shape from upstream source structure), and reassures existing components that they keep working — the sync workflow handles both layouts identically.

No changes to the sync workflow, schema validation, or existing components.d/*.yml files — those are unaffected and will be migrated to the flat layout incrementally.