### PR TITLE
docs: align MDX artifact lists with the 5-artifact catalog gate

### DIFF
--- a/docs/agent-skill-trust-pipeline.mdx
+++ b/docs/agent-skill-trust-pipeline.mdx
@@ -42,8 +42,10 @@ Every released skill should ship or link to:
 
 - `SKILL.md`
 - Supporting `scripts/`, `references/`, and `assets/` as needed
-- A completed skill card
+- A completed skill card (`skill-card.md`)
 - A SkillSpector report or CI link
+- A Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
+- `BENCHMARK.md` capturing the benchmark report from the evaluation run
 - `skill.oms.sig`
 - Verification instructions for the signing certificate and verifier command
 

--- a/docs/release-checklist.mdx
+++ b/docs/release-checklist.mdx
@@ -54,8 +54,10 @@ model_signing verify certificate SKILL_DIR \
 The release packet should include:
 
 - Skill source or release artifact
-- Skill card
+- Skill card (`skill-card.md`)
 - SkillSpector report or CI link
-- Detached OMS signature
+- Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
+- `BENCHMARK.md` capturing the benchmark report from the evaluation run
+- Detached OMS signature (`skill.oms.sig`)
 - Verification instructions
 - Known limitations and support contact


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

The Recommended Artifact Set in \`docs/agent-skill-trust-pipeline.mdx\` and the Release Packet in \`docs/release-checklist.mdx\` both pre-dated the Tier-3 evaluation gate and the \`BENCHMARK.md\` publishing requirement. The sync pipeline enforces both, and the README Verifying Skills section already lists the full 5-artifact contract (PR #190).

### Changes

- **\`agent-skill-trust-pipeline.mdx\`**: add Tier-3 eval dataset (with the four accepted paths: \`evals/evals.json\`, \`evals/*.json\`, \`eval/*.json\`, \`benchmark/evals.json\`) and \`BENCHMARK.md\` to the Recommended Artifact Set; tighten the skill-card line to mention \`skill-card.md\` explicitly
- **\`release-checklist.mdx\`**: same additions to the Release Packet plus the \`skill-card.md\` filename

No content claims about what evaluation or signing pipelines do beyond what the README already states. Both pages are already in \`fern/docs.yml\` navigation, so no nav config change is needed.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).