### PR TITLE
Import ci: add ClawHub publish workflow (NVIDIA/skills#195)

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Manually publish NVIDIA skills to ClawHub.
+#
+# Start with `dry-run` to preview the full catalog. Use `publish-single` for a
+# scoped release of one skill folder, or `publish-catalog` to sync every skill
+# under `skills/`.
+
+name: Publish Skills to ClawHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: What to run.
+        type: choice
+        required: true
+        default: dry-run
+        options:
+          - dry-run
+          - publish-single
+          - publish-catalog
+      skill_path:
+        description: Skill folder for publish-single, for example skills/rag-blueprint.
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate-single:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-single'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate single-skill input
+        env:
+          SKILL_PATH: ${{ inputs.skill_path }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SKILL_PATH}" ]]; then
+            echo "::error::skill_path is required when mode is publish-single."
+            exit 1
+          fi
+          if [[ ! "${SKILL_PATH}" =~ ^skills/[^/]+$ ]]; then
+            echo "::error::skill_path must be exactly one folder under skills/, for example skills/rag-blueprint."
+            exit 1
+          fi
+          if [[ ! -d "${SKILL_PATH}" || ! -f "${SKILL_PATH}/SKILL.md" ]]; then
+            echo "::error::skill_path must point to an existing skill folder with SKILL.md."
+            exit 1
+          fi
+
+  dry-run:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'dry-run'
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@05d5fc115102bdce829de93aab2ddd386415d033
+    with:
+      owner: nvidia
+      dry_run: true
+
+  publish-single:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-single'
+    needs: validate-single
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@05d5fc115102bdce829de93aab2ddd386415d033
+    with:
+      owner: nvidia
+      skill_path: ${{ inputs.skill_path }}
+      dry_run: false
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
+
+  publish-catalog:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-catalog'
+    uses: openclaw/clawhub/.github/workflows/skill-publish.yml@05d5fc115102bdce829de93aab2ddd386415d033
+    with:
+      owner: nvidia
+      dry_run: false
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
Add a manual ClawHub publishing workflow for NVIDIA skills, with modes to dry-run the full catalog, publish a single validated `skills/<name>` folder, or publish the full catalog using `CLAWHUB_TOKEN`.

References a pinned upstream `openclaw/clawhub` workflow. Checks out caller ref, installs the ClawHub CLI, scans local skill folders, compares them against the registry by skill fingerprint/sync state, and then either emits JSON dry-run output or publishes new/updated skills under the `nvidia` ClawHub organization.

Original PR: https://github.com/NVIDIA/skills/pull/195
Cherry-picked-from: 6ea4b70de377cada4f2c53f6587a03078af7a6e2

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
