### PR TITLE
Add physical-ai-data-factory component config

### DIFF
--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -1,4 +1,4 @@
-name: physical-ai-data-factory
+name: Physical AI
 repo: NVIDIA/physical-ai-data-factory
 description: Generate labeled synthetic training data for physical-AI inspection and perception models.
 skills:
@@ -6,3 +6,5 @@ skills:
     catalog_dir: physical-ai-defect-image-generation
   - path: skills/physical-ai-video-data-augmentation/
     catalog_dir: physical-ai-video-data-augmentation
+links:
+  discussions: false

--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -1,0 +1,8 @@
+name: physical-ai-data-factory
+repo: NVIDIA/physical-ai-data-factory
+description: Generate labeled synthetic training data for physical-AI inspection and perception models.
+skills:
+  - path: skills/physical-ai-defect-image-generation/
+    catalog_dir: physical-ai-defect-image-generation
+  - path: skills/physical-ai-video-data-augmentation/
+    catalog_dir: physical-ai-video-data-augmentation


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

This PR onboards two new skills from [NVIDIA/physical-ai-data-factory](https://github.com/NVIDIA/physical-ai-data-factory), grouped under the existing **Physical AI** product entry alongside the `omniverse-*` / `physical-ai-*` skills:

- `physical-ai-defect-image-generation`
- `physical-ai-video-data-augmentation`

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Dual (Apache 2.0 + CC-BY 4.0), matching the source repo's LICENSE file
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org** (NVIDIA/physical-ai-data-factory)
- [x] `skills/` path used for new entries

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
