### PR TITLE
docs(index): reflect Nemotron Speech in Conversational AI row

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -43,7 +43,7 @@ The catalogs group skills by the kind of work the user is trying to do, while th
 | Group | What it covers | Example skill areas |
 |---|---|---|
 | Agentic AI | RAG, AI-Q, sandboxing, policy, evaluation, and agent workflow automation | RAG Blueprint, AI-Q, NemoClaw |
-| Conversational AI | Speech, ASR evaluation loops, and voice-agent workflows | clinical ASR evaluation and fine-tuning workflows |
+| Conversational AI | Speech NIMs, ASR/TTS/NMT deployment, ASR evaluation loops, and voice-agent workflows | Nemotron Speech (Riva ASR/TTS/NMT NIMs) and clinical ASR evaluation and fine-tuning workflows |
 | Data Science | Data preparation, exploration, and accelerated analytics workflows | cuDF and cuPyNumeric |
 | Decision Optimization | Routing, scheduling, and numerical optimization | cuOpt routing and numerical optimization |
 | GPU Development | CUDA-adjacent kernel work, framework integration, and performance tuning | TileGym kernel development |


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

Updates the **Conversational AI** category row on the docs landing page (\`docs/index.mdx\`) to mention **Nemotron Speech** (Riva ASR/TTS/NMT NIMs) alongside the existing clinical ASR evaluation example. Nemotron Speech onboarded 2026-06-01 via #95 and is the catalog's primary entry point for deploying and operating speech NIMs.

### Diff

\`\`\`diff
- | Conversational AI | Speech, ASR evaluation loops, and voice-agent workflows | clinical ASR evaluation and fine-tuning workflows |
+ | Conversational AI | Speech NIMs, ASR/TTS/NMT deployment, ASR evaluation loops, and voice-agent workflows | Nemotron Speech (Riva ASR/TTS/NMT NIMs) and clinical ASR evaluation and fine-tuning workflows |
\`\`\`

Fern's GitHub integration will auto-publish to https://docs.nvidia.com/skills once this merges to main.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).