### PR TITLE
ci(docs): add Fern auto-publish workflow on main

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,22 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/heads/main') && github.run_number > 1 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Publish Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --docs

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -11,9 +11,8 @@ title: NVIDIA Skill Documentation
 global-theme: nvidia
 
 navbar-links:
-  - type: minimal
-    href: https://github.com/NVIDIA/skills
-    text: GitHub
+  - type: github
+    value: https://github.com/NVIDIA/skills
 
 logo:
   right-text: Skills

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.27.8"
+  "version": "5.43.0"
 }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`.github/workflows/publish-docs.yml`) that runs `fern generate --docs` on pushes to `main`, so documentation auto-publishes.
- Bump the Fern CLI version in `fern.config.json` from `5.27.8` to `5.43.0`.
- Switch the docs navbar GitHub link to the native `github` link type.

## Notes
- The workflow gates on `github.run_number > 1` to avoid firing on the initial run.
- Requires the `FERN_TOKEN` secret to be configured in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)