### PR TITLE
chore(sync): use rolling tracker for sync-failure issues

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -367,53 +367,105 @@ jobs:
           body: ${{ steps.summary.outputs.body }}
           delete-branch: true
 
-      - name: Open issue for failed components
-        if: steps.summary.outputs.has_failures == 'true'
+      - name: Update sync-failure tracking issue (rolling)
+        if: always()
         continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const failed = fs.readFileSync('/tmp/failed-components.txt', 'utf8').trim();
-            const title = `Skills sync: some components failed — ${new Date().toISOString().slice(0, 10)}`;
-            const body = [
-              `The [sync-skills workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) completed but some components failed to sync.`,
-              ``,
-              `**Failed components:**`,
-              failed,
-              ``,
-              `**Run:** ${context.runId}`,
-              `**Trigger:** \`${context.eventName}\``,
-              ``,
-              `This usually means the skill path in \`components.d/<slug>.yml\` doesn't match the actual directory in the source repo (e.g. symlink, renamed, or removed).`
-            ].join('\n');
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['sync-failure']
-            });
+            const hasFailures = '${{ steps.summary.outputs.has_failures }}' === 'true';
+            const jobFailed = '${{ job.status }}' === 'failure';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-      - name: Open issue on total failure
-        if: failure()
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = `Skills sync failed — ${new Date().toISOString().slice(0, 10)}`;
-            const body = [
-              `The [sync-skills workflow](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) failed.`,
-              ``,
-              `**Trigger:** \`${context.eventName}\``,
-              `**Run:** ${context.runId}`,
-              ``,
-              `Please investigate and re-run if needed.`
-            ].join('\n');
-            await github.rest.issues.create({
+            // Find the existing rolling tracker (if any).
+            const { data: openIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ['sync-failure']
+              state: 'open',
+              labels: 'sync-failure',
             });
+            const tracker = openIssues[0];
+
+            if (!hasFailures && !jobFailed) {
+              // Clean run — close the rolling tracker if open, then exit.
+              if (tracker) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracker.number,
+                  body: `Sync run [#${context.runId}](${runUrl}) completed cleanly — closing the rolling sync-failure tracker. A new tracker opens automatically if a future sync fails.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracker.number,
+                  state: 'closed',
+                });
+                console.log(`Clean run — closed tracker #${tracker.number}`);
+              } else {
+                console.log('Clean run — no tracker to close');
+              }
+              return;
+            }
+
+            // There IS a failure to report. Build a single rolling body that
+            // reflects the current state, not a historical run log.
+            let title, bodyLines = [];
+            const today = new Date().toISOString().slice(0, 10);
+
+            if (jobFailed) {
+              title = `Sync failure tracker — sync workflow run failed (${today})`;
+              bodyLines.push(
+                `The most recent sync workflow run failed entirely.`,
+                ``,
+                `**Most recent run:** [#${context.runId}](${runUrl})`,
+                `**Trigger:** \`${context.eventName}\``,
+                `**Last updated:** ${today}`,
+                ``,
+                `This issue auto-updates on every sync run and closes when sync runs cleanly again.`,
+              );
+            } else {
+              // Partial failure — read the failed components list.
+              let failed = '';
+              try {
+                failed = fs.readFileSync('/tmp/failed-components.txt', 'utf8').trim();
+              } catch (e) {
+                failed = '(failed-components.txt not available)';
+              }
+              const count = failed.split('\n').filter(l => l.trim()).length;
+              title = `Sync failure tracker — ${count} component(s) currently failing (${today})`;
+              bodyLines.push(
+                `Components that failed to sync on the most recent run. This issue auto-updates each sync and closes when all components are syncing cleanly.`,
+                ``,
+                `**Currently failing components (${count}):**`,
+                failed,
+                ``,
+                `**Most recent run:** [#${context.runId}](${runUrl})`,
+                `**Trigger:** \`${context.eventName}\``,
+                `**Last updated:** ${today}`,
+                ``,
+                `Failures usually mean the skill path in \`components.d/<slug>.yml\` doesn't match the actual directory in the source repo (e.g. symlink, renamed, removed, or moved branch).`,
+              );
+            }
+            const body = bodyLines.join('\n');
+
+            if (tracker) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracker.number,
+                title,
+                body,
+              });
+              console.log(`Updated rolling tracker #${tracker.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['sync-failure'],
+              });
+              console.log('Opened new rolling tracker');
+            }


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

Today's sync workflow opens a **fresh GitHub issue every time** a sync run encounters a partial component failure OR a total workflow failure. That accumulates noise — **30 sync-failure issues piled up in the past two weeks**, each a snapshot of a single run, none actionable after the next sync.

### Fix

Replaces the two issue-creation steps with a single **rolling tracker** pattern that mirrors how the missing-compliance tracker already works (same file, lines 230–280):

- **Clean run** (no failed components, no job failure): close the existing tracker if one is open
- **Run with failures**: update the existing tracker in place with current state, OR open a new one if none exists

Net effect: at most **one open \`sync-failure\` issue at any time**, auto-updating each run, auto-closing when sync recovers.

### Behavior matrix

| Sync run state | Open tracker exists? | Action |
|---|---|---|
| Clean | Yes | Close with comment |
| Clean | No | No-op |
| Partial fail | Yes | Update title + body with current failures |
| Partial fail | No | Open new tracker |
| Total fail | Yes | Update title + body |
| Total fail | No | Open new tracker |

Same data, different lifecycle. No change to sync logic or to what gets reported.

### Cleanup already done

The 30 legacy \`sync-failure\` issues from the per-run pattern were bulk-closed 2026-06-01 alongside this change.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).