### PR TITLE
chore(.github): add NVIDIA PLC-OSS issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Bug Report
+description: Report a bug you confirmed and could not fix.
+labels: ["bug", "status: triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `npx skills add nvidia/skills --skill <skill-name>`
+        2. ...
+        3. Observe the failure
+    validations:
+      required: true
+
+  - type: input
+    id: skill
+    attributes:
+      label: Affected Skill (if applicable)
+      description: Catalog directory name (e.g., `cuopt-routing-api-python`, `nemo-mbridge-recipe-recommender`). Leave blank if the bug isn't tied to a specific skill.
+      placeholder: cuopt-routing-api-python
+    validations:
+      required: false
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent Client
+      description: Which agent client surfaced the issue?
+      options:
+        - Claude Code CLI
+        - Claude Code Desktop
+        - OpenAI Codex
+        - Hermes
+        - Skills.sh / Vercel
+        - npx skills CLI direct
+        - Other (specify in description)
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node.js version, agent client version, and any other relevant details.
+      placeholder: |
+        - OS: macOS 15.2 / Ubuntu 24.04 / Windows 11 + WSL2
+        - Node.js: v20.x
+        - Agent client: Claude Code 1.x / Codex CLI 1.x / etc.
+        - skills CLI: output of `npx skills --version`
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: Stack traces, console output, or any other relevant log lines.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I confirmed this bug is reproducible
+          required: true
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Controls the "Create new issue" picker on github.com/NVIDIA/skills/issues/new/choose.
+# - Blank issues disabled to keep every issue on a triageable template.
+# - "Questions" deliberately omitted — community questions belong in Discussions.
+# - Security vulnerabilities follow the disclosure process in SECURITY.md, not the
+#   public issue tracker.
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/NVIDIA/skills/discussions
+    about: >
+      Use Discussions for questions, ideas, or general conversation. The issue
+      tracker is for bug reports, feature proposals with a design, and
+      documentation issues.
+
+  - name: Security vulnerability
+    url: https://github.com/NVIDIA/skills/blob/main/SECURITY.md
+    about: >
+      Do not report security vulnerabilities through GitHub issues. Follow the
+      coordinated disclosure process documented in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Documentation Request or Correction
+description: Report incorrect, missing, or unclear documentation in the catalog or its docs.
+labels: ["documentation", "status: triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong, missing, or unclear in the docs?
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected Page or File
+      description: URL or file path (e.g., `docs/index.mdx`, `docs/signing-agent-skills.mdx`, `README.md#skill-catalog`, or a specific skill's `SKILL.md`).
+      placeholder: docs/signing-agent-skills.mdx
+    validations:
+      required: false
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      options:
+        - "Inaccurate information"
+        - "Missing documentation"
+        - "Unclear or confusing"
+        - "Broken link or cross-reference"
+        - "Formatting or rendering problem"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix
+      description: If you know what the correct content should be, describe it here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Feature Request
+description: Propose a feature with a design. Not a "please build this" request.
+labels: ["enhancement", "status: triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this solve? Why does it matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed Design
+      description: |
+        How should this work? Describe the system behavior, components involved, and user-facing interface.
+        This should be a design, not a wish list.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you evaluate? Why is the proposed design better?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - "enhancement: new skill request"
+        - "enhancement: catalog / sync workflow"
+        - "enhancement: distribution channel (plugin / marketplace)"
+        - "enhancement: signing / verification / trust"
+        - "enhancement: skill card / metadata"
+        - "enhancement: docs / discoverability"
+        - "enhancement: other"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: This is a design proposal, not a "please build this" request
+          required: true


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

Adopts the standard **NVIDIA PLC-OSS issue submission flow** ([reference templates](https://github.com/NVIDIA-GitHub-Management/PLC-OSS-Template/tree/main/.github/ISSUE_TEMPLATE), [working example: NemoClaw](https://github.com/NVIDIA/NemoClaw/tree/main/.github/ISSUE_TEMPLATE)).

### What changes

| File | Purpose |
|---|---|
| \`.github/ISSUE_TEMPLATE/config.yml\` | Disables blank issues. Routes questions → Discussions, security vulnerabilities → SECURITY.md via \`contact_links\` |
| \`.github/ISSUE_TEMPLATE/bug_report.yml\` | Form template for confirmed bugs — captures affected skill, agent client, environment, repro steps, logs |
| \`.github/ISSUE_TEMPLATE/feature_request.yml\` | Form template for design proposals — category dropdown covers new skills, catalog/sync, distribution channels, signing/verification, skill card, docs |
| \`.github/ISSUE_TEMPLATE/documentation.yml\` | Form template for incorrect, missing, or unclear documentation |

### "Create new issue" picker after merge

1. **Bug Report** (form)
2. **Feature Request** (form)
3. **Documentation Request or Correction** (form)
4. **Question or discussion** → links to Discussions (contact link)
5. **Security vulnerability** → links to SECURITY.md (contact link)

Deliberately **no "Question" template** — community questions belong in Discussions.

### Follow-ups (repo settings, outside this PR)

- **Enable Discussions** in repo settings (Settings → Features → Discussions). Today \`has_discussions=false\`, so the Discussions contact_link won't resolve until you flip that switch.
- **Audit label/priority write access** per the PLC-OSS guideline — only the designated engineering team should be able to modify labels or priorities.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).