### PR TITLE
docs(readme,contributing): route catalog issues to the new templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This repository is a catalog of NVIDIA-verified agent skills. Skills are maintai
 
 To contribute to a skill or propose a new one, use the contributing guidelines in the relevant source repo. See the [Available Skills](README.md#available-skills) and [Getting Help & Contributing](README.md#getting-help--contributing) sections in the README for links.
 
-For changes to the catalog itself (fixing links, adding a new product listing), open a [pull request](../../pulls) or [issue](../../issues).
+For changes to the catalog itself (fixing links, adding a new product listing), open a [pull request](../../pulls). For catalog-level bug reports, feature proposals, or documentation problems, file an [issue](../../issues/new/choose) using one of the catalog issue templates (Bug Report, Feature Request, Documentation Request or Correction). Questions and general discussion belong in [Discussions](../../discussions); security vulnerabilities follow the disclosure process in [SECURITY.md](SECURITY.md).
 
 ## Recommended Skill Directory Path
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,14 @@ For non-interactive installs, global installs, agent-specific installs, updates,
 
 ## Getting Help & Contributing
 
-For skill-related issues, feature requests, new skill ideas, discussions, and contributions — use the source repo for the relevant product:
+**Where to file an issue depends on what's broken:**
+
+- **Skill content issues** (a specific skill has a bug, missing functionality, or incorrect content) — file in the **source repo** for that product, using the per-product table below.
+- **Catalog issues** (catalog README errors, sync workflow problems, distribution channels, signing/verification flow, docs in this repo) — file [here](../../issues/new/choose) using the catalog issue templates: **Bug Report**, **Feature Request**, or **Documentation Request or Correction**.
+- **Questions or general discussion** — use [Discussions](../../discussions). The issue tracker is reserved for bug reports, feature proposals with a design, and documentation issues.
+- **Security vulnerabilities** — follow the disclosure process in [SECURITY.md](SECURITY.md); do not open a public issue.
+
+Per-product source repo links:
 
 <!-- help-table-start -->
 | Product | Issues | Discussions | Contributing | Security |


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new \`components.d/<slug>.yml\` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Other context

Follow-up to #213 (added catalog-level issue templates). README and CONTRIBUTING still routed **all** reporting to source repos, so anyone hitting a catalog-level problem (sync workflow, README error, distribution channel, signing flow) had no obvious home for it.

### Changes

- **README \"Getting Help & Contributing\"**: split routing into four buckets:
  - Skill content issues → source repo (per-product table)
  - Catalog issues → new \`/issues/new/choose\` picker
  - Questions → Discussions
  - Security → SECURITY.md
- **CONTRIBUTING**: same split applied to the catalog-level paragraph, with a direct link to the issue-template picker.

Per-product source repo table unchanged — it's still the right answer for skill-content issues.

## All PRs

- [x] All commits signed off with DCO (\`git commit -s\`).