### PR TITLE
Register cuFOLIO Mean-CVaR portfolio optimization skill

### DIFF
--- a/components.d/cufolio.yml
+++ b/components.d/cufolio.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: cuFOLIO
+repo: NVIDIA-AI-Blueprints/cuFOLIO
+description: GPU-accelerated Mean-CVaR portfolio optimization with NVIDIA cuOpt — CVaR optimization, efficient frontier, scenario generation, backtesting, and rebalancing.
+skills:
+  - path: skills/cufolio/
+    catalog_dir: cufolio


### PR DESCRIPTION
## Register cuFOLIO skill

Adds `components.d/cufolio.yml` to register the **cufolio** skill from
`NVIDIA-AI-Blueprints/cuFOLIO` (`skills/cufolio/`, catalog dir `cufolio`).

cufolio is an instruction-only skill for GPU-accelerated **Mean-CVaR portfolio
optimization** with NVIDIA cuOpt: CVaR optimization, efficient frontier, KDE scenario
generation, backtesting, and rebalancing. License: Apache-2.0.

- Product PR (skill artifacts): NVIDIA-AI-Blueprints/cuFOLIO#46
- NV-BASE static validation: Grade A (100/100)
- Evals: 5 positive + 4 negative cases in `skills/cufolio/evals/evals.json`

Mirrors the existing `cuopt.yml` registration convention.

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative) — https://nvbugspro.nvidia.com/bug/6274686
- [x] **License selected:** Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries (instruction-only skill; no new dependencies)
- [x] **Source repo is public and under an NVIDIA-owned GitHub org** (`NVIDIA-AI-Blueprints/cuFOLIO`)
- [x] `skills/` path used for the new entry

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
