### PR TITLE
Add i4h workflows component

### DIFF
--- a/components.d/i4h-workflows.yml
+++ b/components.d/i4h-workflows.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
+name: Isaac for Healthcare Workflows
+repo: isaac-for-healthcare/i4h-workflows
+description: Agent-ready skills for the Isaac for Healthcare Agentic workflow, covering IsaacLab-Arena task authoring, teleop and HDF5 data pipelines, LeRobot conversion, Cosmos Transfer augmentation, policy fine-tuning, and closed-loop validation.
+links:
+  discussions: false
+skills:
+  - path: skills/i4h-workflow/
+    catalog_dir: i4h-workflow
+  - path: skills/i4h-workflow-setup/
+    catalog_dir: i4h-workflow-setup
+  - path: skills/i4h-workflow-create/
+    catalog_dir: i4h-workflow-create
+  - path: skills/i4h-workflow-scene-edit/
+    catalog_dir: i4h-workflow-scene-edit
+  - path: skills/i4h-workflow-dataset-teleop/
+    catalog_dir: i4h-workflow-dataset-teleop
+  - path: skills/i4h-workflow-dataset-replay/
+    catalog_dir: i4h-workflow-dataset-replay
+  - path: skills/i4h-workflow-dataset-mimic/
+    catalog_dir: i4h-workflow-dataset-mimic
+  - path: skills/i4h-workflow-dataset-annotate/
+    catalog_dir: i4h-workflow-dataset-annotate
+  - path: skills/i4h-workflow-dataset-convert/
+    catalog_dir: i4h-workflow-dataset-convert
+  - path: skills/i4h-workflow-dataset-transfer/
+    catalog_dir: i4h-workflow-dataset-transfer
+  - path: skills/i4h-workflow-finetune/
+    catalog_dir: i4h-workflow-finetune
+  - path: skills/i4h-workflow-validate/
+    catalog_dir: i4h-workflow-validate
+  - path: skills/i4h-workflow-e2e/
+    catalog_dir: i4h-workflow-e2e
+  - path: skills/i4h-lerobot-viz/
+    catalog_dir: i4h-lerobot-viz


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [x] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
