### PR TITLE
Add Holoscan Sensor Bridge component

### DIFF
--- a/components.d/holoscan-sensor-bridge.yml
+++ b/components.d/holoscan-sensor-bridge.yml
@@ -6,13 +6,12 @@ repo: nvidia-holoscan/holoscan-sensor-bridge
 description: Agent-ready skills for Holoscan Sensor Bridge devkit workflows, covering demo environment bring-up, FPGA flashing for Lattice and VB1940 hardware, example application execution, and QA test-plan automation.
 links:
   discussions: false
-  security: false
 skills:
-  - path: skills/hsb-setup-skill/
-    catalog_dir: hsb-setup-skill
-  - path: skills/hsb-flash-skill/
-    catalog_dir: hsb-flash-skill
-  - path: skills/hsb-app-skill/
-    catalog_dir: hsb-app-skill
-  - path: skills/hsb-test-skill/
-    catalog_dir: hsb-test-skill
+  - path: skills/hsb-setup/
+    catalog_dir: hsb-setup
+  - path: skills/hsb-flash/
+    catalog_dir: hsb-flash
+  - path: skills/hsb-app/
+    catalog_dir: hsb-app
+  - path: skills/hsb-test/
+    catalog_dir: hsb-test

--- a/components.d/holoscan-sensor-bridge.yml
+++ b/components.d/holoscan-sensor-bridge.yml
@@ -6,6 +6,7 @@ repo: nvidia-holoscan/holoscan-sensor-bridge
 description: Agent-ready skills for Holoscan Sensor Bridge devkit workflows, covering demo environment bring-up, FPGA flashing for Lattice and VB1940 hardware, example application execution, and QA test-plan automation.
 links:
   discussions: false
+  security: false
 skills:
   - path: skills/hsb-setup/
     catalog_dir: hsb-setup

--- a/components.d/holoscan-sensor-bridge.yml
+++ b/components.d/holoscan-sensor-bridge.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
+name: Holoscan Sensor Bridge
+repo: nvidia-holoscan/holoscan-sensor-bridge
+description: Agent-ready skills for Holoscan Sensor Bridge devkit workflows, covering demo environment bring-up, FPGA flashing for Lattice and VB1940 hardware, example application execution, and QA test-plan automation.
+links:
+  discussions: false
+  security: false
+skills:
+  - path: skills/hsb-setup-skill/
+    catalog_dir: hsb-setup-skill
+  - path: skills/hsb-flash-skill/
+    catalog_dir: hsb-flash-skill
+  - path: skills/hsb-app-skill/
+    catalog_dir: hsb-app-skill
+  - path: skills/hsb-test-skill/
+    catalog_dir: hsb-test-skill


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [x] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
