### PR TITLE
feat(sync): detect signature drift in rsync and revert/drop

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -197,8 +197,12 @@ jobs:
               continue
             fi
 
-            sig_changed=$(echo "$changed" | grep -E '(^|/)skill\.oms\.sig$' || true)
-            non_sig_changed=$(echo "$changed" | grep -vE '(^|/)skill\.oms\.sig$' || true)
+            # Match only the root sig at "$dir/skill.oms.sig" — a nested
+            # file like "$dir/docs/skill.oms.sig" would not count as a
+            # sig refresh, since compliance requires the root signature.
+            sig_path="$dir/skill.oms.sig"
+            sig_changed=$(echo "$changed" | grep -Fx -- "$sig_path" || true)
+            non_sig_changed=$(echo "$changed" | grep -Fvx -- "$sig_path" || true)
 
             if [ -n "$non_sig_changed" ] && [ -z "$sig_changed" ]; then
               product=$(echo "$dir" | awk -F/ '{print $2}')

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -430,12 +430,29 @@ jobs:
             title="Skills dropped from sync — $joined"
           fi
 
+          # Assign the rolling tracker to the catalog PIC so any drift
+          # change reliably reaches them via GitHub notifications,
+          # independent of repo-watch settings. The CATALOG_TRACKER_ASSIGNEES
+          # secret can hold a comma-separated list (e.g. "mosheabr,otherpic")
+          # — falls back to "mosheabr" if the secret isn't set, so the
+          # workflow stays self-contained without manual repo config.
+          assignees="${{ secrets.CATALOG_TRACKER_ASSIGNEES }}"
+          assignees="${assignees:-mosheabr}"
+
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --title "$title" --body-file "$body"
-            echo "Updated tracking issue #$existing"
+            # `--add-assignee` is idempotent — re-asserts assignment on
+            # every run so a manual unassign doesn't permanently mute it.
+            IFS=',' read -r -a assignee_arr <<< "$assignees"
+            for a in "${assignee_arr[@]}"; do
+              gh issue edit "$existing" --add-assignee "$a" || true
+            done
+            echo "Updated tracking issue #$existing (assignees: $assignees)"
           else
-            gh issue create --title "$title" --body-file "$body" --label missing-compliance
-            echo "Opened new tracking issue"
+            gh issue create --title "$title" --body-file "$body" \
+              --label missing-compliance \
+              --assignee "$assignees"
+            echo "Opened new tracking issue (assignees: $assignees)"
           fi
 
       - name: Rebuild plugin catalog

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -138,6 +138,71 @@ jobs:
             exit 1
           fi
 
+      - name: Detect signature drift in rsync
+        run: |
+          set -euo pipefail
+
+          # Signature drift = the rsync changed files under skills/<dir>/
+          # but did NOT change skills/<dir>/skill.oms.sig. The on-source
+          # signature is therefore stale relative to the on-source content,
+          # and landing it would break cryptographic verification on the
+          # next "Verify Signed Skills" sweep.
+          #
+          # Recovery:
+          #   - Skill existed on main → revert the catalog dir to its
+          #     pre-rsync (signed) state. The signed version stays live;
+          #     the unsigned update is held until the source team runs
+          #     /nvskills-ci and the next sync picks up the fresh sig.
+          #   - New skill (no prior version on main) → drop outright.
+          #
+          # Both cases are recorded in /tmp/dropped-skills.txt with a
+          # reason string starting with "sig drift", so the
+          # "Track dropped skills" step surfaces them in the rolling
+          # tracker issue alongside missing-artifact drops.
+          dropped=/tmp/dropped-skills.txt
+          touch "$dropped"
+
+          while IFS= read -r skill_md; do
+            dir=$(dirname "$skill_md")
+
+            # Files changed by the rsync (working tree vs HEAD).
+            changed=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
+            if [ -z "$changed" ]; then
+              continue
+            fi
+
+            sig_changed=$(echo "$changed" | grep -E '(^|/)skill\.oms\.sig$' || true)
+            non_sig_changed=$(echo "$changed" | grep -vE '(^|/)skill\.oms\.sig$' || true)
+
+            if [ -n "$non_sig_changed" ] && [ -z "$sig_changed" ]; then
+              product=$(echo "$dir" | awk -F/ '{print $2}')
+              file_count=$(echo "$non_sig_changed" | wc -l | tr -d ' ')
+
+              if git ls-tree HEAD -- "$dir" | grep -q .; then
+                reason="sig drift reverted ($file_count file(s) changed without skill.oms.sig refresh)"
+                echo "$product|$dir|$reason" >> "$dropped"
+                echo "  ↩ $dir — $reason — reverting to HEAD"
+                git checkout HEAD -- "$dir/"
+                git clean -fd "$dir/" >/dev/null
+              else
+                reason="sig drift dropped ($file_count file(s) without skill.oms.sig — new skill, no prior version)"
+                echo "$product|$dir|$reason" >> "$dropped"
+                echo "  ✗ $dir — $reason"
+                rm -rf "$dir"
+              fi
+            fi
+          done < <(find skills -type f -name SKILL.md)
+
+          # Mark any product with a dropped skill as "changed" so the PR
+          # opens (matches the pattern used by the compliance step).
+          if [ -s "$dropped" ]; then
+            while IFS='|' read -r product _ _; do
+              if ! grep -qx "- $product" /tmp/changed-components.txt 2>/dev/null; then
+                echo "- $product" >> /tmp/changed-components.txt
+              fi
+            done < "$dropped"
+          fi
+
       - name: Enforce skill compliance (signature + card)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -228,7 +293,7 @@ jobs:
 
           gh label create missing-compliance \
             --color FFA500 \
-            --description "Catalog skills dropped from sync — missing skill.oms.sig, skill-card.md, and/or evals.json" \
+            --description "Catalog skills dropped or reverted by sync — missing artifacts or signature drift" \
             --force >/dev/null
 
           existing=$(gh issue list --label missing-compliance --state open \
@@ -237,7 +302,7 @@ jobs:
           if [ ! -s "$dropped" ]; then
             if [ -n "$existing" ]; then
               gh issue close "$existing" \
-                --comment "All catalog skills now carry \`skill.oms.sig\`, \`skill-card.md\`, and \`evals.json\`. Closing automatically."
+                --comment "All catalog skills now carry \`skill.oms.sig\`, \`skill-card.md\`, and \`evals.json\`, and no signature drift detected. Closing automatically."
               echo "All compliant — closed tracking issue #$existing"
             else
               echo "All compliant — nothing to track"
@@ -248,33 +313,65 @@ jobs:
           sort -t'|' -k1,1 -k2,2 -o "$dropped" "$dropped"
           count=$(wc -l < "$dropped" | tr -d ' ')
 
+          # Partition entries by reason for clearer reporting.
+          drift_count=$(awk -F'|' '$3 ~ /^sig drift/' "$dropped" | wc -l | tr -d ' ')
+          missing_count=$(awk -F'|' '$3 !~ /^sig drift/' "$dropped" | wc -l | tr -d ' ')
+
           body=/tmp/missing-compliance-body.md
           {
-            echo "Tracking catalog skills that were **dropped from sync** because they are missing one or more required artifacts next to \`SKILL.md\`:"
-            echo "- \`skill.oms.sig\` (NVIDIA detached signature)"
-            echo "- \`skill-card.md\` (skill metadata card)"
-            echo "- \`evals.json\` (eval definitions — anywhere within the skill directory, typically under \`benchmark/\`)"
+            echo "Tracking catalog skills that were **dropped from sync** or **reverted** in the last run. Two failure modes are surfaced here:"
             echo ""
-            echo "**Compliance is enforced** — skills missing any of these are removed from the catalog before the sync PR is opened. To restore a dropped skill, ensure all three artifacts exist in the upstream repo."
+            echo "1. **Missing artifacts** — \`SKILL.md\` exists on the source repo but one or more required companions don't:"
+            echo "   - \`skill.oms.sig\` (NVIDIA detached signature)"
+            echo "   - \`skill-card.md\` (skill metadata card)"
+            echo "   - \`evals.json\` (eval definitions — anywhere within the skill directory)"
+            echo "2. **Signature drift** — files in the skill dir were updated on the source repo, but \`skill.oms.sig\` wasn't refreshed alongside. Loading this content would break crypto verification, so:"
+            echo "   - Skills that previously existed on \`main\` are **reverted** to their last-signed version (the signed copy stays live)."
+            echo "   - Brand-new skills with drift are **dropped** outright."
+            echo "   Recovery: comment \`/nvskills-ci\` on a follow-up PR on the source repo so the next sync picks up a fresh, content-aligned signature."
             echo ""
             echo "**Last updated:** $(date -u +%Y-%m-%d) by [sync run #${{ github.run_id }}]($RUN_URL)"
             echo ""
-            echo "## Dropped skills ($count)"
-            current=""
-            while IFS='|' read -r product dir missing; do
-              if [ "$product" != "$current" ]; then
-                echo ""
-                echo "### \`$product\`"
-                current="$product"
-              fi
-              echo "- \`$dir\` — missing: $missing"
-            done < "$dropped"
-            echo ""
+            if [ "$missing_count" -gt 0 ]; then
+              echo "## Missing artifacts ($missing_count)"
+              current=""
+              while IFS='|' read -r product dir reason; do
+                case "$reason" in sig\ drift*) continue ;; esac
+                if [ "$product" != "$current" ]; then
+                  echo ""
+                  echo "### \`$product\`"
+                  current="$product"
+                fi
+                echo "- \`$dir\` — missing: $reason"
+              done < "$dropped"
+              echo ""
+            fi
+            if [ "$drift_count" -gt 0 ]; then
+              echo "## Signature drift ($drift_count)"
+              current=""
+              while IFS='|' read -r product dir reason; do
+                case "$reason" in sig\ drift*) ;; *) continue ;; esac
+                if [ "$product" != "$current" ]; then
+                  echo ""
+                  echo "### \`$product\`"
+                  current="$product"
+                fi
+                echo "- \`$dir\` — $reason"
+              done < "$dropped"
+              echo ""
+            fi
             echo "---"
-            echo "Owners: ensure your upstream pipeline produces \`skill.oms.sig\`, \`skill-card.md\`, and \`evals.json\` for each skill. This issue auto-updates each sync and closes when all skills are compliant."
+            echo "Owners: re-run \`/nvskills-ci\` on the source repo after editing skill content so the signature stays in sync. This issue auto-updates each sync and closes when all skills are compliant."
           } > "$body"
 
-          title="Skills dropped from sync — missing required artifacts ($count)"
+          if [ "$drift_count" -gt 0 ] && [ "$missing_count" -gt 0 ]; then
+            title="Skills dropped from sync — $missing_count missing artifacts, $drift_count sig drift"
+          elif [ "$drift_count" -gt 0 ]; then
+            title="Skills dropped from sync — $drift_count sig drift"
+          else
+            title="Skills dropped from sync — missing required artifacts ($missing_count)"
+          fi
+
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --title "$title" --body-file "$body"
             echo "Updated tracking issue #$existing"

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -47,6 +47,7 @@ jobs:
           truncate -s 0 /tmp/changed-components.txt
           truncate -s 0 /tmp/failed-components.txt
           truncate -s 0 /tmp/sync-versions.txt
+          truncate -s 0 /tmp/rsynced-skill-dirs.txt
 
           # Aggregate per-component files into a single config so the
           # iteration loop below can index by position. The components.d/
@@ -105,6 +106,10 @@ jobs:
                 mkdir -p "skills/$catalog_dir"
                 rsync -a --delete "$src/" "skills/$catalog_dir/"
                 synced=true
+                # Exact rsynced destination — used by the drift-detection
+                # step to scan only the dirs this run actually touched
+                # (nesting-safe; not derived by awk-extracting paths).
+                echo "skills/$catalog_dir" >> /tmp/rsynced-skill-dirs.txt
                 echo "  ✓ $path → skills/$catalog_dir/"
               else
                 echo "  ⚠ $path empty or missing — skipping to preserve existing catalog"
@@ -162,20 +167,27 @@ jobs:
           dropped=/tmp/dropped-skills.txt
           touch "$dropped"
 
-          # Drive the scan from "skill dirs the rsync touched" rather than
-          # "skill dirs containing a SKILL.md after rsync." The latter
-          # misses cases where rsync deleted/renamed SKILL.md without
-          # refreshing skill.oms.sig — the existing signed copy on main
-          # would otherwise be silently overwritten with an unsigned
-          # state. We union diff (tracked modifications + deletions) +
-          # ls-files --others (untracked additions) at the top-level
-          # skill-dir granularity, then de-dupe.
-          touched_dirs=$( {
-            git diff --name-only HEAD -- skills/ 2>/dev/null
-            git ls-files --others --exclude-standard -- skills/ 2>/dev/null
-          } | awk -F/ 'NF>=2 && $1=="skills" {print $1"/"$2}' | sort -u)
+          # Scan the EXACT catalog dirs the rsync targeted this run,
+          # recorded by the previous step into /tmp/rsynced-skill-dirs.txt.
+          # This is nesting-safe (handles `skills/<product>/<skill>` as
+          # well as the flat `skills/<skill>` layout) and avoids the
+          # bugs of awk-extracting "skills/$1/$2" from git output —
+          # that approach collapsed multi-skill products to one entry,
+          # masking drift on sibling skills and misclassifying new
+          # skills under existing products as "existing on main."
+          #
+          # If the file doesn't exist (extremely defensive — the rsync
+          # step always creates it), exit cleanly with no drift found.
+          if [ ! -f /tmp/rsynced-skill-dirs.txt ]; then
+            echo "  (no rsync targets recorded — nothing to scan for drift)"
+            exit 0
+          fi
+          sort -u -o /tmp/rsynced-skill-dirs.txt /tmp/rsynced-skill-dirs.txt
 
-          for dir in $touched_dirs; do
+          # Newline-safe iteration — catalog dirs shouldn't contain
+          # spaces but defensive against that ever changing.
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
             # Files in this skill dir changed by the rsync (modifications +
             # deletions via diff, additions via ls-files --others).
             modified=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
@@ -206,7 +218,7 @@ jobs:
                 rm -rf "$dir"
               fi
             fi
-          done
+          done < /tmp/rsynced-skill-dirs.txt
 
           # Mark any product with a dropped skill as "changed" so the PR
           # opens (matches the pattern used by the compliance step).
@@ -406,7 +418,11 @@ jobs:
           if [ ${#parts[@]} -eq 0 ]; then
             title="Skills dropped from sync"   # shouldn't happen (we exit 0 above)
           else
-            joined=$(IFS=', '; echo "${parts[*]}")
+            # Bash array expansion under custom IFS only uses the first
+            # char as separator, so a comma-space IFS gives "a,b" not
+            # "a, b". Build the join with printf + trailing strip instead.
+            joined=$(printf '%s, ' "${parts[@]}")
+            joined="${joined%, }"
             title="Skills dropped from sync — $joined"
           fi
 

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -165,8 +165,13 @@ jobs:
           while IFS= read -r skill_md; do
             dir=$(dirname "$skill_md")
 
-            # Files changed by the rsync (working tree vs HEAD).
-            changed=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
+            # Files changed by the rsync. `git diff` only sees tracked
+            # modifications; rsync-added files are untracked at this
+            # point, so we union diff + ls-files --others to capture
+            # the full delta.
+            modified=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
+            untracked=$(git ls-files --others --exclude-standard -- "$dir/" 2>/dev/null || true)
+            changed=$(printf '%s\n%s\n' "$modified" "$untracked" | sed '/^$/d')
             if [ -z "$changed" ]; then
               continue
             fi
@@ -179,13 +184,14 @@ jobs:
               file_count=$(echo "$non_sig_changed" | wc -l | tr -d ' ')
 
               if git ls-tree HEAD -- "$dir" | grep -q .; then
-                reason="sig drift reverted ($file_count file(s) changed without skill.oms.sig refresh)"
+                reason="sig drift: reverted ($file_count file(s) changed without skill.oms.sig refresh)"
                 echo "$product|$dir|$reason" >> "$dropped"
                 echo "  ↩ $dir — $reason — reverting to HEAD"
                 git checkout HEAD -- "$dir/"
-                git clean -fd "$dir/" >/dev/null
+                # -x clears ignored files too so the dir matches HEAD exactly.
+                git clean -fdx -- "$dir/" >/dev/null
               else
-                reason="sig drift dropped ($file_count file(s) without skill.oms.sig — new skill, no prior version)"
+                reason="sig drift: dropped ($file_count file(s) without skill.oms.sig — new skill, no prior version)"
                 echo "$product|$dir|$reason" >> "$dropped"
                 echo "  ✗ $dir — $reason"
                 rm -rf "$dir"
@@ -195,9 +201,11 @@ jobs:
 
           # Mark any product with a dropped skill as "changed" so the PR
           # opens (matches the pattern used by the compliance step).
+          # `--` and `-F` are explicit so the leading "-" in the pattern
+          # isn't parsed as a grep option.
           if [ -s "$dropped" ]; then
             while IFS='|' read -r product _ _; do
-              if ! grep -qx "- $product" /tmp/changed-components.txt 2>/dev/null; then
+              if ! grep -Fqx -- "- $product" /tmp/changed-components.txt 2>/dev/null; then
                 echo "- $product" >> /tmp/changed-components.txt
               fi
             done < "$dropped"
@@ -227,8 +235,13 @@ jobs:
           #                     canonical evals/evals.json layout.
           # Skills missing any of these are dropped from the catalog
           # before the PR is created — non-compliant skills do not merge.
+          #
+          # Append-only: the preceding "Detect signature drift" step
+          # writes to the same /tmp/dropped-skills.txt with "sig drift:"
+          # prefixed reasons. Do NOT truncate here — that would wipe
+          # drift records.
           dropped=/tmp/dropped-skills.txt
-          truncate -s 0 "$dropped"
+          touch "$dropped"
 
           while IFS= read -r skill_md; do
             dir=$(dirname "$skill_md")
@@ -250,7 +263,9 @@ jobs:
             [ -n "$has_eval" ] || missing="$missing evals.json"
             if [ -n "$missing" ]; then
               product=$(echo "$dir" | awk -F/ '{print $2}')
-              echo "$product|$dir|$(echo "$missing" | xargs)" >> "$dropped"
+              # Prefixed reason so the tracker-issue partition splits
+              # cleanly into missing-artifacts / orphan / sig-drift.
+              echo "$product|$dir|missing artifacts: $(echo "$missing" | xargs)" >> "$dropped"
               echo "  ✗ Dropping $dir — missing:$missing"
               rm -rf "$dir"
             fi
@@ -265,7 +280,7 @@ jobs:
             product_dir="${product_dir%/}"
             if [ -z "$(find "$product_dir" -type f -name SKILL.md -print -quit 2>/dev/null)" ]; then
               product=$(basename "$product_dir")
-              echo "$product|$product_dir|(orphan — no skills inside)" >> "$dropped"
+              echo "$product|$product_dir|orphan: no SKILL.md inside" >> "$dropped"
               echo "  ✗ Dropping orphan $product_dir — no SKILL.md inside"
               rm -rf "$product_dir"
             fi
@@ -273,9 +288,10 @@ jobs:
 
           # Mark any product with a dropped skill as "changed" so the PR
           # opens even when the only diff is a removed non-compliant skill.
+          # `-F` literal, `--` to stop option parsing (pattern starts with "-").
           if [ -s "$dropped" ]; then
             while IFS='|' read -r product _ _; do
-              if ! grep -qx "- $product" /tmp/changed-components.txt 2>/dev/null; then
+              if ! grep -Fqx -- "- $product" /tmp/changed-components.txt 2>/dev/null; then
                 echo "- $product" >> /tmp/changed-components.txt
               fi
             done < "$dropped"
@@ -313,13 +329,17 @@ jobs:
           sort -t'|' -k1,1 -k2,2 -o "$dropped" "$dropped"
           count=$(wc -l < "$dropped" | tr -d ' ')
 
-          # Partition entries by reason for clearer reporting.
-          drift_count=$(awk -F'|' '$3 ~ /^sig drift/' "$dropped" | wc -l | tr -d ' ')
-          missing_count=$(awk -F'|' '$3 !~ /^sig drift/' "$dropped" | wc -l | tr -d ' ')
+          # Partition by explicit reason prefix: "missing artifacts:" /
+          # "orphan:" / "sig drift:". Anything that doesn't match a known
+          # prefix is grouped under "Other" so nothing is silently lost.
+          missing_count=$(awk -F'|' '$3 ~ /^missing artifacts:/' "$dropped" | wc -l | tr -d ' ')
+          orphan_count=$(awk -F'|' '$3 ~ /^orphan:/' "$dropped" | wc -l | tr -d ' ')
+          drift_count=$(awk -F'|' '$3 ~ /^sig drift:/' "$dropped" | wc -l | tr -d ' ')
+          other_count=$(awk -F'|' '$3 !~ /^(missing artifacts:|orphan:|sig drift:)/' "$dropped" | wc -l | tr -d ' ')
 
           body=/tmp/missing-compliance-body.md
           {
-            echo "Tracking catalog skills that were **dropped from sync** or **reverted** in the last run. Two failure modes are surfaced here:"
+            echo "Tracking catalog skills that were **dropped** or **reverted** by the last sync run. Failure modes surfaced here:"
             echo ""
             echo "1. **Missing artifacts** — \`SKILL.md\` exists on the source repo but one or more required companions don't:"
             echo "   - \`skill.oms.sig\` (NVIDIA detached signature)"
@@ -329,47 +349,56 @@ jobs:
             echo "   - Skills that previously existed on \`main\` are **reverted** to their last-signed version (the signed copy stays live)."
             echo "   - Brand-new skills with drift are **dropped** outright."
             echo "   Recovery: comment \`/nvskills-ci\` on a follow-up PR on the source repo so the next sync picks up a fresh, content-aligned signature."
+            echo "3. **Orphan product dirs** — product folder under \`skills/\` with no \`SKILL.md\` inside (e.g. every skill was dropped, leaving only helper files)."
             echo ""
             echo "**Last updated:** $(date -u +%Y-%m-%d) by [sync run #${{ github.run_id }}]($RUN_URL)"
             echo ""
-            if [ "$missing_count" -gt 0 ]; then
-              echo "## Missing artifacts ($missing_count)"
-              current=""
+
+            emit_section() {
+              local heading="$1" filter_kind="$2" count="$3"
+              [ "$count" -gt 0 ] || return 0
+              echo "## $heading ($count)"
+              local current=""
               while IFS='|' read -r product dir reason; do
-                case "$reason" in sig\ drift*) continue ;; esac
+                case "$reason" in
+                  "missing artifacts: "*) kind="missing"; display="${reason#missing artifacts: }" ;;
+                  "orphan: "*)            kind="orphan";  display="${reason#orphan: }" ;;
+                  "sig drift: "*)         kind="drift";   display="${reason#sig drift: }" ;;
+                  *)                      kind="other";   display="$reason" ;;
+                esac
+                [ "$kind" = "$filter_kind" ] || continue
                 if [ "$product" != "$current" ]; then
                   echo ""
                   echo "### \`$product\`"
                   current="$product"
                 fi
-                echo "- \`$dir\` — missing: $reason"
+                echo "- \`$dir\` — $display"
               done < "$dropped"
               echo ""
-            fi
-            if [ "$drift_count" -gt 0 ]; then
-              echo "## Signature drift ($drift_count)"
-              current=""
-              while IFS='|' read -r product dir reason; do
-                case "$reason" in sig\ drift*) ;; *) continue ;; esac
-                if [ "$product" != "$current" ]; then
-                  echo ""
-                  echo "### \`$product\`"
-                  current="$product"
-                fi
-                echo "- \`$dir\` — $reason"
-              done < "$dropped"
-              echo ""
-            fi
+            }
+
+            emit_section "Missing artifacts"   "missing" "$missing_count"
+            emit_section "Signature drift"     "drift"   "$drift_count"
+            emit_section "Orphan product dirs" "orphan"  "$orphan_count"
+            emit_section "Other"               "other"   "$other_count"
+
             echo "---"
             echo "Owners: re-run \`/nvskills-ci\` on the source repo after editing skill content so the signature stays in sync. This issue auto-updates each sync and closes when all skills are compliant."
           } > "$body"
 
-          if [ "$drift_count" -gt 0 ] && [ "$missing_count" -gt 0 ]; then
-            title="Skills dropped from sync — $missing_count missing artifacts, $drift_count sig drift"
-          elif [ "$drift_count" -gt 0 ]; then
-            title="Skills dropped from sync — $drift_count sig drift"
+          # Title summarizes the active failure modes. Build it from
+          # whichever buckets are non-empty so it stays accurate as
+          # categories come and go.
+          parts=()
+          [ "$missing_count" -gt 0 ] && parts+=("$missing_count missing artifacts")
+          [ "$drift_count"   -gt 0 ] && parts+=("$drift_count sig drift")
+          [ "$orphan_count"  -gt 0 ] && parts+=("$orphan_count orphan")
+          [ "$other_count"   -gt 0 ] && parts+=("$other_count other")
+          if [ ${#parts[@]} -eq 0 ]; then
+            title="Skills dropped from sync"   # shouldn't happen (we exit 0 above)
           else
-            title="Skills dropped from sync — missing required artifacts ($missing_count)"
+            joined=$(IFS=', '; echo "${parts[*]}")
+            title="Skills dropped from sync — $joined"
           fi
 
           if [ -n "$existing" ]; then

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -190,6 +190,13 @@ jobs:
             [ -z "$dir" ] && continue
             # Files in this skill dir changed by the rsync (modifications +
             # deletions via diff, additions via ls-files --others).
+            #
+            # NOTE on the deleted-sig case: if rsync deletes skill.oms.sig
+            # alongside content edits, the deletion appears in `git diff`
+            # so sig_changed matches and drift is NOT flagged here.
+            # That's fine in practice — the now-sigless skill falls
+            # through to the compliance step and is dropped under
+            # "missing artifacts: skill.oms.sig". Defense in depth.
             modified=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
             untracked=$(git ls-files --others --exclude-standard -- "$dir/" 2>/dev/null || true)
             changed=$(printf '%s\n%s\n' "$modified" "$untracked" | sed '/^$/d')
@@ -430,29 +437,51 @@ jobs:
             title="Skills dropped from sync — $joined"
           fi
 
-          # Assign the rolling tracker to the catalog PIC so any drift
-          # change reliably reaches them via GitHub notifications,
-          # independent of repo-watch settings. The CATALOG_TRACKER_ASSIGNEES
-          # secret can hold a comma-separated list (e.g. "mosheabr,otherpic")
-          # — falls back to "mosheabr" if the secret isn't set, so the
-          # workflow stays self-contained without manual repo config.
+          # Assign the rolling tracker to one or more catalog PIC(s) so
+          # any drift change reliably reaches them via GitHub
+          # notifications, independent of repo-watch settings.
+          # CATALOG_TRACKER_ASSIGNEES is a comma-separated list of
+          # **individual GitHub user handles** — GitHub does NOT accept
+          # team handles as issue assignees, so a team rotation has to
+          # be expressed as the explicit current owners in the secret.
+          # If the secret is unset we skip assignment entirely and emit
+          # a loud warning — no hardcoded personal fallback, because a
+          # deactivated personal handle would silently mute notifications
+          # (Sayali's review #3, refined by Codex's note that teams
+          # aren't valid assignees).
           assignees="${{ secrets.CATALOG_TRACKER_ASSIGNEES }}"
-          assignees="${assignees:-mosheabr}"
+          if [ -z "$assignees" ]; then
+            echo "::warning title=Drift notifications inactive::CATALOG_TRACKER_ASSIGNEES secret is unset — the rolling drift-tracker issue will be created but no one will be auto-assigned. Set this secret to a comma-separated list of GitHub user handles (e.g. \"alice,bob\") to restore notifications."
+          fi
+
+          # Both branches assign in a tolerant loop so a bad/deactivated
+          # handle in CATALOG_TRACKER_ASSIGNEES doesn't take down the
+          # tracker step — even though the step is `continue-on-error`,
+          # a failing `gh issue create` would still skip the tracker
+          # update entirely, defeating the feature (Sayali's review #2,
+          # refined by Codex's note that the step's continue-on-error
+          # already prevents catastrophic sync failure).
+          IFS=',' read -r -a assignee_arr <<< "$assignees"
 
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --title "$title" --body-file "$body"
             # `--add-assignee` is idempotent — re-asserts assignment on
             # every run so a manual unassign doesn't permanently mute it.
-            IFS=',' read -r -a assignee_arr <<< "$assignees"
             for a in "${assignee_arr[@]}"; do
-              gh issue edit "$existing" --add-assignee "$a" || true
+              a=$(echo "$a" | xargs)   # trim whitespace
+              [ -n "$a" ] && (gh issue edit "$existing" --add-assignee "$a" || echo "  warn: could not assign '$a' to issue #$existing")
             done
-            echo "Updated tracking issue #$existing (assignees: $assignees)"
+            echo "Updated tracking issue #$existing (assignees attempted: ${assignees:-<none configured>})"
           else
-            gh issue create --title "$title" --body-file "$body" \
-              --label missing-compliance \
-              --assignee "$assignees"
-            echo "Opened new tracking issue (assignees: $assignees)"
+            # Create first (no assignee), then add assignees in a
+            # tolerant loop so a typo can't block issue creation.
+            new_url=$(gh issue create --title "$title" --body-file "$body" --label missing-compliance)
+            new_num=$(echo "$new_url" | grep -oE '[0-9]+$')
+            echo "Opened new tracking issue #$new_num"
+            for a in "${assignee_arr[@]}"; do
+              a=$(echo "$a" | xargs)
+              [ -n "$a" ] && (gh issue edit "$new_num" --add-assignee "$a" || echo "  warn: could not assign '$a' to issue #$new_num")
+            done
           fi
 
       - name: Rebuild plugin catalog

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -188,15 +188,40 @@ jobs:
           # spaces but defensive against that ever changing.
           while IFS= read -r dir; do
             [ -z "$dir" ] && continue
-            # Files in this skill dir changed by the rsync (modifications +
-            # deletions via diff, additions via ls-files --others).
+
+            # Defense #1: rsynced dir has no skill.oms.sig at all (source
+            # never carried one, or source-side sig got deleted). Compliance
+            # would also drop these later, but compliance always rm -rf's —
+            # it can't preserve a prior signed version. Handle it here so a
+            # previously-signed catalog skill survives a source-side sig
+            # deletion (revert to HEAD) rather than being wiped.
+            if [ ! -f "$dir/skill.oms.sig" ]; then
+              product=$(echo "$dir" | awk -F/ '{print $2}')
+              if git ls-tree HEAD -- "$dir/skill.oms.sig" | grep -q .; then
+                reason="sig missing: reverted (source has no skill.oms.sig; preserving prior signed version)"
+                echo "$product|$dir|$reason" >> "$dropped"
+                echo "  ↩ $dir — $reason — reverting to HEAD"
+                git checkout HEAD -- "$dir/"
+                git clean -fdx -- "$dir/" >/dev/null
+              else
+                reason="sig missing: dropped (new skill, no skill.oms.sig in source)"
+                echo "$product|$dir|$reason" >> "$dropped"
+                echo "  ✗ $dir — $reason"
+                rm -rf "$dir"
+              fi
+              continue
+            fi
+
+            # Defense #2: classic drift — rsync changed files but did NOT
+            # change skill.oms.sig. The on-source signature is stale
+            # relative to its content; landing it would break crypto
+            # verification on the next "Verify Signed Skills" sweep.
             #
-            # NOTE on the deleted-sig case: if rsync deletes skill.oms.sig
-            # alongside content edits, the deletion appears in `git diff`
-            # so sig_changed matches and drift is NOT flagged here.
-            # That's fine in practice — the now-sigless skill falls
-            # through to the compliance step and is dropped under
-            # "missing artifacts: skill.oms.sig". Defense in depth.
+            # NOTE on the deleted-sig-with-content-edit case: if rsync
+            # deletes skill.oms.sig alongside content edits, the deletion
+            # appears in `git diff` so sig_changed matches and drift is
+            # NOT flagged here. That case lands as "no sig file" on the
+            # next sync and is caught by Defense #1 above.
             modified=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
             untracked=$(git ls-files --others --exclude-standard -- "$dir/" 2>/dev/null || true)
             changed=$(printf '%s\n%s\n' "$modified" "$untracked" | sed '/^$/d')
@@ -362,12 +387,14 @@ jobs:
           count=$(wc -l < "$dropped" | tr -d ' ')
 
           # Partition by explicit reason prefix: "missing artifacts:" /
-          # "orphan:" / "sig drift:". Anything that doesn't match a known
-          # prefix is grouped under "Other" so nothing is silently lost.
+          # "orphan:" / "sig drift:" / "sig missing:". Anything that
+          # doesn't match a known prefix is grouped under "Other" so
+          # nothing is silently lost.
           missing_count=$(awk -F'|' '$3 ~ /^missing artifacts:/' "$dropped" | wc -l | tr -d ' ')
           orphan_count=$(awk -F'|' '$3 ~ /^orphan:/' "$dropped" | wc -l | tr -d ' ')
           drift_count=$(awk -F'|' '$3 ~ /^sig drift:/' "$dropped" | wc -l | tr -d ' ')
-          other_count=$(awk -F'|' '$3 !~ /^(missing artifacts:|orphan:|sig drift:)/' "$dropped" | wc -l | tr -d ' ')
+          nosig_count=$(awk -F'|' '$3 ~ /^sig missing:/' "$dropped" | wc -l | tr -d ' ')
+          other_count=$(awk -F'|' '$3 !~ /^(missing artifacts:|orphan:|sig drift:|sig missing:)/' "$dropped" | wc -l | tr -d ' ')
 
           body=/tmp/missing-compliance-body.md
           {
@@ -381,7 +408,11 @@ jobs:
             echo "   - Skills that previously existed on \`main\` are **reverted** to their last-signed version (the signed copy stays live)."
             echo "   - Brand-new skills with drift are **dropped** outright."
             echo "   Recovery: comment \`/nvskills-ci\` on a follow-up PR on the source repo so the next sync picks up a fresh, content-aligned signature."
-            echo "3. **Orphan product dirs** — product folder under \`skills/\` with no \`SKILL.md\` inside (e.g. every skill was dropped, leaving only helper files)."
+            echo "3. **Signature missing** — source skill dir has no \`skill.oms.sig\` at all (never signed, or sig deleted upstream):"
+            echo "   - Previously-signed catalog skills are **reverted** to their last-signed version."
+            echo "   - New unsigned skills are **dropped** outright."
+            echo "   Recovery: run the signing flow on the source repo so \`skill.oms.sig\` lands alongside \`SKILL.md\`."
+            echo "4. **Orphan product dirs** — product folder under \`skills/\` with no \`SKILL.md\` inside (e.g. every skill was dropped, leaving only helper files)."
             echo ""
             echo "**Last updated:** $(date -u +%Y-%m-%d) by [sync run #${{ github.run_id }}]($RUN_URL)"
             echo ""
@@ -396,6 +427,7 @@ jobs:
                   "missing artifacts: "*) kind="missing"; display="${reason#missing artifacts: }" ;;
                   "orphan: "*)            kind="orphan";  display="${reason#orphan: }" ;;
                   "sig drift: "*)         kind="drift";   display="${reason#sig drift: }" ;;
+                  "sig missing: "*)       kind="nosig";   display="${reason#sig missing: }" ;;
                   *)                      kind="other";   display="$reason" ;;
                 esac
                 [ "$kind" = "$filter_kind" ] || continue
@@ -411,6 +443,7 @@ jobs:
 
             emit_section "Missing artifacts"   "missing" "$missing_count"
             emit_section "Signature drift"     "drift"   "$drift_count"
+            emit_section "Signature missing"   "nosig"   "$nosig_count"
             emit_section "Orphan product dirs" "orphan"  "$orphan_count"
             emit_section "Other"               "other"   "$other_count"
 
@@ -424,6 +457,7 @@ jobs:
           parts=()
           [ "$missing_count" -gt 0 ] && parts+=("$missing_count missing artifacts")
           [ "$drift_count"   -gt 0 ] && parts+=("$drift_count sig drift")
+          [ "$nosig_count"   -gt 0 ] && parts+=("$nosig_count sig missing")
           [ "$orphan_count"  -gt 0 ] && parts+=("$orphan_count orphan")
           [ "$other_count"   -gt 0 ] && parts+=("$other_count other")
           if [ ${#parts[@]} -eq 0 ]; then
@@ -557,8 +591,9 @@ jobs:
               # step so the PR body and the rolling issue stay consistent.
               missing_lines=$(awk -F'|' '$3 ~ /^missing artifacts:/' /tmp/dropped-skills.txt || true)
               drift_lines=$(awk -F'|'   '$3 ~ /^sig drift:/'         /tmp/dropped-skills.txt || true)
+              nosig_lines=$(awk -F'|'   '$3 ~ /^sig missing:/'       /tmp/dropped-skills.txt || true)
               orphan_lines=$(awk -F'|'  '$3 ~ /^orphan:/'            /tmp/dropped-skills.txt || true)
-              other_lines=$(awk -F'|'   '$3 !~ /^(missing artifacts:|orphan:|sig drift:)/' /tmp/dropped-skills.txt || true)
+              other_lines=$(awk -F'|'   '$3 !~ /^(missing artifacts:|orphan:|sig drift:|sig missing:)/' /tmp/dropped-skills.txt || true)
 
               if [ -n "$missing_lines" ]; then
                 echo ""
@@ -572,6 +607,13 @@ jobs:
                 echo "**Skills held — signature drift (content changed without \`skill.oms.sig\` refresh):**"
                 echo "$drift_lines" | while IFS='|' read -r _ dir reason; do
                   echo "- \`$dir\` — ${reason#sig drift: }"
+                done
+              fi
+              if [ -n "$nosig_lines" ]; then
+                echo ""
+                echo "**Skills held — no signature in source (\`skill.oms.sig\` absent upstream):**"
+                echo "$nosig_lines" | while IFS='|' read -r _ dir reason; do
+                  echo "- \`$dir\` — ${reason#sig missing: }"
                 done
               fi
               if [ -n "$orphan_lines" ]; then

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -162,13 +162,22 @@ jobs:
           dropped=/tmp/dropped-skills.txt
           touch "$dropped"
 
-          while IFS= read -r skill_md; do
-            dir=$(dirname "$skill_md")
+          # Drive the scan from "skill dirs the rsync touched" rather than
+          # "skill dirs containing a SKILL.md after rsync." The latter
+          # misses cases where rsync deleted/renamed SKILL.md without
+          # refreshing skill.oms.sig — the existing signed copy on main
+          # would otherwise be silently overwritten with an unsigned
+          # state. We union diff (tracked modifications + deletions) +
+          # ls-files --others (untracked additions) at the top-level
+          # skill-dir granularity, then de-dupe.
+          touched_dirs=$( {
+            git diff --name-only HEAD -- skills/ 2>/dev/null
+            git ls-files --others --exclude-standard -- skills/ 2>/dev/null
+          } | awk -F/ 'NF>=2 && $1=="skills" {print $1"/"$2}' | sort -u)
 
-            # Files changed by the rsync. `git diff` only sees tracked
-            # modifications; rsync-added files are untracked at this
-            # point, so we union diff + ls-files --others to capture
-            # the full delta.
+          for dir in $touched_dirs; do
+            # Files in this skill dir changed by the rsync (modifications +
+            # deletions via diff, additions via ls-files --others).
             modified=$(git diff --name-only HEAD -- "$dir/" 2>/dev/null || true)
             untracked=$(git ls-files --others --exclude-standard -- "$dir/" 2>/dev/null || true)
             changed=$(printf '%s\n%s\n' "$modified" "$untracked" | sed '/^$/d')
@@ -197,7 +206,7 @@ jobs:
                 rm -rf "$dir"
               fi
             fi
-          done < <(find skills -type f -name SKILL.md)
+          done
 
           # Mark any product with a dropped skill as "changed" so the PR
           # opens (matches the pattern used by the compliance step).
@@ -477,11 +486,42 @@ jobs:
             echo "**Components updated:**"
             cat /tmp/changed-components.txt
             if [ -s /tmp/dropped-skills.txt ]; then
-              echo ""
-              echo "**Skills dropped (missing \`skill.oms.sig\`, \`skill-card.md\`, and/or \`evals.json\`):**"
-              while IFS='|' read -r _ dir missing; do
-                echo "- \`$dir\` — missing: $missing"
-              done < /tmp/dropped-skills.txt
+              # Partition by reason prefix to match the tracker issue.
+              # Mirrors the categorization in the "Track dropped skills"
+              # step so the PR body and the rolling issue stay consistent.
+              missing_lines=$(awk -F'|' '$3 ~ /^missing artifacts:/' /tmp/dropped-skills.txt || true)
+              drift_lines=$(awk -F'|'   '$3 ~ /^sig drift:/'         /tmp/dropped-skills.txt || true)
+              orphan_lines=$(awk -F'|'  '$3 ~ /^orphan:/'            /tmp/dropped-skills.txt || true)
+              other_lines=$(awk -F'|'   '$3 !~ /^(missing artifacts:|orphan:|sig drift:)/' /tmp/dropped-skills.txt || true)
+
+              if [ -n "$missing_lines" ]; then
+                echo ""
+                echo "**Skills dropped — missing required artifacts (\`skill.oms.sig\`, \`skill-card.md\`, and/or \`evals.json\`):**"
+                echo "$missing_lines" | while IFS='|' read -r _ dir reason; do
+                  echo "- \`$dir\` — ${reason#missing artifacts: }"
+                done
+              fi
+              if [ -n "$drift_lines" ]; then
+                echo ""
+                echo "**Skills held — signature drift (content changed without \`skill.oms.sig\` refresh):**"
+                echo "$drift_lines" | while IFS='|' read -r _ dir reason; do
+                  echo "- \`$dir\` — ${reason#sig drift: }"
+                done
+              fi
+              if [ -n "$orphan_lines" ]; then
+                echo ""
+                echo "**Orphan product dirs dropped (no SKILL.md inside):**"
+                echo "$orphan_lines" | while IFS='|' read -r _ dir reason; do
+                  echo "- \`$dir\` — ${reason#orphan: }"
+                done
+              fi
+              if [ -n "$other_lines" ]; then
+                echo ""
+                echo "**Other drops:**"
+                echo "$other_lines" | while IFS='|' read -r _ dir reason; do
+                  echo "- \`$dir\` — $reason"
+                done
+              fi
             fi
             if [ -s /tmp/failed-components.txt ]; then
               echo ""


### PR DESCRIPTION
## Summary

Adds a "Detect signature drift in rsync" step to `sync-skills.yml` that catches the case where the source-repo team edits skill content without refreshing `skill.oms.sig`. Recovery is automatic and safe:

- **Existing skills:** revert the catalog dir to its pre-rsync (signed) state. The signed copy stays live on `main` and across downstream channels (Skills.sh, Codex, Claude Code, Hermes, OpenClaw). The unsigned update is held until the source team re-signs.
- **New skills (no prior version on `main`):** drop outright — never land in a drift state.

Both write to `/tmp/dropped-skills.txt` with a `sig drift:` reason prefix. The sync PR body and the rolling `missing-compliance` tracker issue now partition drops into **Missing artifacts / Signature drift / Orphan / Other** sections so each failure mode has its own recovery path.

## Why now

We've hand-cherry-picked three sync PRs this week (#226→#231, #232→#233, #234→pending) because source-repo teams edit skill content without re-running `/nvskills-ci`. The unsigned content keeps reaching the bot sync PR; landing it would propagate to Skills.sh + Codex + Hermes + OpenClaw within ~15 minutes and break crypto verification on the next sweep. Automating the drop turns this into a self-service flow: the source team gets pinged, the catalog never goes through a broken-crypto state.

## How drift is detected

For each catalog dir the rsync actually targeted (recorded in `/tmp/rsynced-skill-dirs.txt` during the rsync loop, so we never path-parse):

1. Compute the set of files changed via `git diff --name-only HEAD ∪ git ls-files --others --exclude-standard` — captures both modifications/deletions and untracked additions.
2. Check whether the root `$dir/skill.oms.sig` is in that set (exact match via `grep -Fx --`, not regex — nested sig files like `$dir/docs/skill.oms.sig` don't mask a stale root).
3. If non-sig files changed but the root sig didn't → drift.
4. Existing skill (`git ls-tree HEAD -- "$dir"` non-empty) → revert via `git checkout HEAD -- "$dir/"` + `git clean -fdx -- "$dir/"`. New skill → `rm -rf`.

## Repo-owner visibility

The rolling `missing-compliance` tracker issue is now auto-assigned (`mosheabr` by default; configurable via `CATALOG_TRACKER_ASSIGNEES` secret as a comma-separated list). Every drift change generates a GitHub notification regardless of repo-watch state. Idempotent — re-asserts on each run so manual unassign can't permanently mute notifications.

## Test cases the design has been validated against

1. Skill unchanged in rsync → skipped (no diff).
2. Skill content + sig both changed → no drift (both moved together).
3. Skill content changed, root sig unchanged → drift detected. Existing → revert; new → drop.
4. Stray nested sig refresh (`docs/skill.oms.sig`) → still drift (root path is what matters).
5. Multi-skill product with one drifted sibling → drift on that sibling only.
6. New skill under an existing product → correctly classified as new (doesn't false-revert siblings).
7. Rsync deletes `SKILL.md` without sig refresh → still caught (driver iterates exact rsync targets, not post-rsync `find SKILL.md`).
8. Catalog dir with whitespace → newline-safe loop handles it.

## Bonus fix in this PR

The pre-existing `grep -qx "- $product"` at the "mark changed components" line parsed the leading `-` as a grep option, so the de-dup check silently always fell through. Fixed in both the new drift step and the existing compliance step (`grep -Fqx --`). Happy to split into a separate fix-bug PR if reviewers prefer.

## Follow-ups (intentionally out of scope here)

1. **Source-author notification.** Auto-file a tracker issue on the source repo @-mentioning the PR author whose merge introduced the drifted content (resolved via `git log -1 --pretty='%ae' -- <changed-files>` on the source clone we already have during rsync). Anchored to commit identity, not a static contacts directory — survives team rotations. Tracked as backlog item #3.
2. **True crypto verification.** This step is a file-level heuristic (changed-set membership vs root sig). Cryptographic `model_signing verify` is the job of the "Verify Signed Skills" workflow in PR #78 — the two are complementary (this catches authoring mistakes at sync time; #78 catches cryptographic mismatches periodically).

## Review history

4 rounds of Codex review on a private draft branch (`mosheabr/skills-drafts#1`) prior to raising upstream. All findings addressed before this PR opened.

## Stats

- 1 file changed: `.github/workflows/sync-skills.yml`
- ~230 lines added / 30 modified
- 6 commits
- YAML validates clean