### PR TITLE
docs: rename product to "Digital Health"

### DIFF
--- a/components.d/digital-health.yml
+++ b/components.d/digital-health.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
-name: NVIDIA Digital Health Examples
+name: Digital Health
 repo: NVIDIA/digital-health-examples
 description: Agent skills for the clinical ASR evaluation flywheel — term curation, synthetic clinical-speech benchmark generation, KER (Keyword Error Rate) scoring, and fine-tune guidance.
 skills:


### PR DESCRIPTION
Per stakeholder request — shortening the display name for the Digital Health Examples product.

## Changes

- \`components.d/digital-health-examples.yml\` → \`components.d/digital-health.yml\` (filename rename)
- \`name: NVIDIA Digital Health Examples\` → \`name: Digital Health\` (one-line content change)

## What this affects

| Layer | Effect |
|---|---|
| README Skill Catalog + Getting Help rows | Render \`Digital Health\` after next sync |
| Source repo URL | Unchanged — still \`NVIDIA/digital-health-examples\` |
| Skill catalog_dirs | Unchanged — already prefixed \`digital-health-*\`, so the new product name reads more naturally |
| Sync workflow slug | Becomes \`digital-health\` (was \`nvidia-digital-health-examples\`) — only used by the vestigial \`sync-versions.txt\` write; no visible impact |
| Compliance / drift / sig checks | Unaffected |
| Downstream channels (Skills.sh, Codex, Claude Code, Hermes, OpenClaw) | Display name shortens on next pull |

## Test plan

- [ ] Merge
- [ ] Trigger sync (or wait for next scheduled)
- [ ] Verify README Available Skills + Getting Help rows show "Digital Health"