### PR TITLE
Add Jetson Device component

### DIFF
--- a/components.d/jetson-device.yml
+++ b/components.d/jetson-device.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Jetson Device
+repo: NVIDIA-AI-IOT/jetson-device-skills
+description: Device-side agent skills for working with a live NVIDIA Jetson after boot — diagnostics, memory auditing, headless setup, inference memory tuning, LLM serving and benchmarking, packaging guidance, and speculative decoding.
+skills:
+  - path: skills/jetson-diagnostic/
+    catalog_dir: jetson-diagnostic
+  - path: skills/jetson-headless-mode/
+    catalog_dir: jetson-headless-mode
+  - path: skills/jetson-inference-mem-tune/
+    catalog_dir: jetson-inference-mem-tune
+  - path: skills/jetson-llm-benchmark/
+    catalog_dir: jetson-llm-benchmark
+  - path: skills/jetson-llm-serve/
+    catalog_dir: jetson-llm-serve
+  - path: skills/jetson-memory-audit/
+    catalog_dir: jetson-memory-audit
+  - path: skills/jetson-package/
+    catalog_dir: jetson-package
+  - path: skills/jetson-print-device-info/
+    catalog_dir: jetson-print-device-info
+  - path: skills/jetson-speculative-decoding/
+    catalog_dir: jetson-speculative-decoding
+links:
+  contributing: false
+  discussions: false


### PR DESCRIPTION
Catalog entry for NVIDIA-AI-IOT/jetson-device-skills (9 device-side skills). contributing/discussions links disabled — source repo has no CONTRIBUTING.md and is not accepting contributions.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
