### PR TITLE
Add Jetson BSP component

### DIFF
--- a/components.d/jetson-bsp.yml
+++ b/components.d/jetson-bsp.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+name: Jetson BSP
+repo: NVIDIA-AI-IOT/jetson-bsp-skills
+description: Agentic skills for setting up and customizing an NVIDIA Jetson Linux Board Support Package (BSP) — pick a target, prepare image and sources, customize IO (camera, PCIe, USB, pinmux, clocks, and more), then promote, flash, and validate.
+skills:
+  - path: skills/jetson-build-source/
+    catalog_dir: jetson-build-source
+  - path: skills/jetson-customize-camera/
+    catalog_dir: jetson-customize-camera
+  - path: skills/jetson-customize-clocks/
+    catalog_dir: jetson-customize-clocks
+  - path: skills/jetson-customize-fan/
+    catalog_dir: jetson-customize-fan
+  - path: skills/jetson-customize-mgbe/
+    catalog_dir: jetson-customize-mgbe
+  - path: skills/jetson-customize-nvpmodel/
+    catalog_dir: jetson-customize-nvpmodel
+  - path: skills/jetson-customize-pcie/
+    catalog_dir: jetson-customize-pcie
+  - path: skills/jetson-customize-pinmux/
+    catalog_dir: jetson-customize-pinmux
+  - path: skills/jetson-customize-uphy/
+    catalog_dir: jetson-customize-uphy
+  - path: skills/jetson-customize-usb/
+    catalog_dir: jetson-customize-usb
+  - path: skills/jetson-derive-carrier/
+    catalog_dir: jetson-derive-carrier
+  - path: skills/jetson-download-bsp/
+    catalog_dir: jetson-download-bsp
+  - path: skills/jetson-flash-image/
+    catalog_dir: jetson-flash-image
+  - path: skills/jetson-generate-kb/
+    catalog_dir: jetson-generate-kb
+  - path: skills/jetson-init-image/
+    catalog_dir: jetson-init-image
+  - path: skills/jetson-init-source/
+    catalog_dir: jetson-init-source
+  - path: skills/jetson-init-target/
+    catalog_dir: jetson-init-target
+  - path: skills/jetson-link-docs/
+    catalog_dir: jetson-link-docs
+  - path: skills/jetson-optimize-memory/
+    catalog_dir: jetson-optimize-memory
+  - path: skills/jetson-print-bsp-info/
+    catalog_dir: jetson-print-bsp-info
+  - path: skills/jetson-promote-image/
+    catalog_dir: jetson-promote-image
+  - path: skills/jetson-quick-start/
+    catalog_dir: jetson-quick-start
+  - path: skills/jetson-set-target/
+    catalog_dir: jetson-set-target
+  - path: skills/jetson-validate-image/
+    catalog_dir: jetson-validate-image
+links:
+  contributing: false
+  discussions: false


### PR DESCRIPTION
Catalog entry for NVIDIA-AI-IOT/jetson-bsp-skills (24 skills for Jetson Linux BSP setup and customization). contributing/discussions links disabled — source repo has no CONTRIBUTING.md and is not accepting contributions.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
