### PR TITLE
chore: remove 5 dead component descriptors producing daily sync noise

### DIFF
--- a/components.d/model-optimizer.yml
+++ b/components.d/model-optimizer.yml
@@ -1,8 +1,0 @@
-name: Model-Optimizer
-repo: NVIDIA/Model-Optimizer
-description: Model optimization — quantization, sparsity, and distillation for efficient inference.
-skills:
-  - path: .claude/skills/
-    catalog_dir: Model-Optimizer
-links:
-  discussions: false

--- a/components.d/nemo-evaluator.yml
+++ b/components.d/nemo-evaluator.yml
@@ -1,8 +1,0 @@
-name: NeMo Evaluator
-repo: NVIDIA-NeMo/Evaluator
-description: LLM evaluation — launch evaluations, access MLflow results, NeMo Evaluator Launcher assistant, and bring-your-own benchmarks.
-skills:
-  - path: packages/nemo-evaluator-launcher/.claude/skills/
-    catalog_dir: NeMo-Evaluator-Launcher
-  - path: packages/nemo-evaluator/.claude/skills/
-    catalog_dir: NeMo-Evaluator

--- a/components.d/nemo-gym.yml
+++ b/components.d/nemo-gym.yml
@@ -1,6 +1,0 @@
-name: NeMo Gym
-repo: NVIDIA-NeMo/Gym
-description: RL training environments — add benchmarks, resources servers, agent wiring, and reward profiling.
-skills:
-  - path: .claude/skills/
-    catalog_dir: NeMo-Gym

--- a/components.d/nemotron-voice-agent.yml
+++ b/components.d/nemotron-voice-agent.yml
@@ -1,6 +1,0 @@
-name: Nemotron Voice Agent
-repo: NVIDIA-AI-Blueprints/nemotron-voice-agent
-description: Real-time conversational AI — deploy speech-to-speech voice agents on Workstation, Jetson Thor, or Cloud NIMs.
-skills:
-  - path: .agents/skills/
-    catalog_dir: nemotron-voice-agent

--- a/components.d/tensorrt-llm.yml
+++ b/components.d/tensorrt-llm.yml
@@ -1,6 +1,0 @@
-name: TensorRT-LLM
-repo: NVIDIA/TensorRT-LLM
-description: LLM inference optimization — model onboarding, performance analysis and optimization, kernel writing, CI diagnostics, code contribution, and codebase exploration.
-skills:
-  - path: .claude/skills/
-    catalog_dir: TensorRT-LLM


### PR DESCRIPTION
## Summary

Removes 5 component YMLs that have been no-ops since the `components.d/` split on 2026-05-01. Each currently writes "empty or missing" lines into `failed-components.txt` on every scheduled sync run, producing daily noise in sync PRs without ever changing the catalog.

| YML removed | Reason |
|---|---|
| `model-optimizer.yml` | Source skills moved to `.agents/skills/` (symlink at `.claude/skills/`). All 14 source skills carry SKILL.md only — never signed. |
| `tensorrt-llm.yml` | 27 source skills at `.claude/skills/`, none signed. |
| `nemo-gym.yml` | 5 source skills at `.claude/skills/`, none signed. |
| `nemo-evaluator.yml` | Both configured paths (`packages/nemo-evaluator/.claude/skills/`, `packages/nemo-evaluator-launcher/.claude/skills/`) are empty in source. |
| `nemotron-voice-agent.yml` | Source has 1 skill (`nemotron-voice-agent-deploy`) missing 4 of 5 required artifacts (sig, skill-card, evals, BENCHMARK). |

## Why now

- Zero catalog skills are sourced from these 5 products today.
- Many source skill names look contributor-facing (`release-cherry-pick`, `trtllm-code-contribution`, `trtllm-codebase-exploration`, `nemo-gym-debugging`, `nemo-gym-docs`, `add-benchmark`, etc.), which belong in `.agents/contributor-skills/` per established convention rather than the public catalog.
- Outreach in flight to each source team to clarify which skills are user-facing and when they plan to run the signing flow. Descriptors will return as flat-layout per-skill entries once each team is ready.

## Verification

- `nemo-evaluator-plugin` is owned by `components.d/nemo-platform.yml` (not the removed `nemo-evaluator.yml`), so its catalog entry is unaffected.
- README auto-generates from YMLs; none of these 5 products produced content rows, so no README change is needed.

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).