### PR TITLE
fix: re-include .env.example so signed skill templates publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 # Environment and secrets
 .env
 .env.*
+!.env.example
 *.pem
 *.key
 credentials.json


### PR DESCRIPTION
See commit. Adds !.env.example after .env.* so signed skill templates publish. DCO signed off.