### PR TITLE
ci: verify skill content matches its signed manifest

### DIFF
--- a/.github/scripts/verify_content_integrity.py
+++ b/.github/scripts/verify_content_integrity.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+"""Verify that each skill's files still match its signed manifest.
+
+A ``skill.oms.sig`` is a Sigstore bundle wrapping a DSSE / in-toto statement
+whose ``predicate.resources`` lists every signed file together with its
+sha256 digest. Signature *presence* and *authenticity* tell you a genuine
+signature exists; they do NOT tell you the files still match what was signed.
+
+A skill can therefore carry a perfectly genuine signature while its content
+has drifted — e.g. a team signs commit 1, makes more commits, and the sync
+picks up a later content with the stale signature. This script closes that
+gap: for each signed file it recomputes the sha256 on disk and compares it to
+the signed digest, failing on any mismatch or missing file.
+
+Scope:
+  * pull_request  -> only the skills changed in the PR (fast; catches drift
+                     being introduced).
+  * schedule / workflow_dispatch / anything else -> the whole catalog
+                     (safety net; catches pre-existing drift already on main).
+
+Exit code 0 = all checked skills match their signatures; 1 = drift found.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SKILLS_DIR = Path("skills")
+SIG_NAME = "skill.oms.sig"
+
+
+def changed_skill_dirs(base_sha: str, head_sha: str) -> list[Path]:
+    """Skill directories touched between the PR merge-base and its head."""
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    dirs: set[Path] = set()
+    for path in diff:
+        parts = path.split("/")
+        if len(parts) >= 2 and parts[0] == "skills":
+            dirs.add(SKILLS_DIR / parts[1])
+    return sorted(d for d in dirs if d.is_dir())
+
+
+def all_skill_dirs() -> list[Path]:
+    if not SKILLS_DIR.is_dir():
+        return []
+    return sorted(d for d in SKILLS_DIR.iterdir() if d.is_dir())
+
+
+def signed_resources(sig_path: Path) -> list[dict]:
+    """Decode the DSSE/in-toto payload and return its resource list."""
+    bundle = json.loads(sig_path.read_text())
+    payload = base64.b64decode(bundle["dsseEnvelope"]["payload"])
+    statement = json.loads(payload)
+    return statement["predicate"]["resources"]
+
+
+def verify_skill(skill_dir: Path) -> list[str]:
+    """Return a list of human-readable problems (empty == content matches)."""
+    sig = skill_dir / SIG_NAME
+    if not sig.exists():
+        # Out of scope for this check (a separate gate enforces signature
+        # presence). Surface it as a note, but don't fail the integrity check.
+        return []
+    try:
+        resources = signed_resources(sig)
+    except Exception as exc:  # malformed bundle is itself a real problem
+        return [f"{skill_dir}/{SIG_NAME}: could not parse signature bundle: {exc}"]
+
+    problems: list[str] = []
+    for res in resources:
+        name = res["name"]
+        want = res["digest"]
+        target = skill_dir / name
+        if not target.is_file():
+            problems.append(f"{skill_dir}/{name}: MISSING — listed in signature, absent on disk")
+            continue
+        got = hashlib.sha256(target.read_bytes()).hexdigest()
+        if got != want:
+            problems.append(
+                f"{skill_dir}/{name}: HASH MISMATCH — content does not match signature"
+            )
+    return problems
+
+
+def main() -> int:
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    if event == "pull_request":
+        base_sha = os.environ["BASE_SHA"]
+        head_sha = os.environ["HEAD_SHA"]
+        targets = changed_skill_dirs(base_sha, head_sha)
+        scope = f"PR — {len(targets)} changed skill dir(s)"
+    else:
+        targets = all_skill_dirs()
+        scope = f"full catalog — {len(targets)} skill dir(s)"
+
+    print(f"Content-integrity check ({scope})")
+    if not targets:
+        print("No skill directories in scope; nothing to verify.")
+        return 0
+
+    problems: list[str] = []
+    unsigned: list[str] = []
+    checked = 0
+    for skill_dir in targets:
+        if not (skill_dir / SIG_NAME).exists():
+            if (skill_dir / "SKILL.md").exists():
+                unsigned.append(skill_dir.name)
+            continue
+        checked += 1
+        skill_problems = verify_skill(skill_dir)
+        if skill_problems:
+            problems.extend(skill_problems)
+            print(f"  FAIL  {skill_dir.name}")
+            for p in skill_problems:
+                print(f"          {p}")
+        else:
+            print(f"  ok    {skill_dir.name}")
+
+    print(f"\nChecked {checked} signed skill(s).")
+    if unsigned:
+        print(f"Note: {len(unsigned)} changed skill(s) have no {SIG_NAME} "
+              f"(reported, not failed here): {', '.join(sorted(unsigned))}")
+
+    if problems:
+        print(f"\nFAILED — {len(problems)} content-integrity problem(s):")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "\nThese files no longer match what their signature signed. The skill "
+            "owner must re-run the signing pipeline so content and skill.oms.sig "
+            "are consistent, then re-sync. See CONTRIBUTING.md."
+        )
+        return 1
+
+    print("OK — all checked skills match their signatures.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-content-integrity.yml
+++ b/.github/workflows/verify-content-integrity.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Verify that each skill's files still match its signed manifest.
+#
+# A skill.oms.sig is a Sigstore bundle wrapping a DSSE/in-toto statement that
+# lists every signed file and its sha256 digest. Checking that a signature is
+# *present* and *genuine* does NOT prove the files still match it — a skill can
+# carry a real signature while its content has drifted (e.g. a team signs an
+# early commit, keeps editing, and the sync picks up later content with the
+# stale signature). This check recomputes each signed file's hash and compares
+# it to the manifest, failing on any mismatch or missing file.
+#
+# On a pull request it checks only the skills changed in the PR (so it catches
+# drift being introduced without blocking on unrelated pre-existing state). On
+# a schedule / manual run it checks the whole catalog as a safety net for
+# drift already on main.
+
+name: Verify Content Integrity
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Daily full-catalog sweep (07:17 UTC). Surfaces pre-existing drift.
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  content-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the PR diff (base...head) can be computed.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify content matches signatures
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/verify_content_integrity.py


### PR DESCRIPTION
## Problem

Our checks confirm a skill's signature is **present** and **genuine**, but nothing confirms the files on `main` still **match** what that signature signed. A signature signs a manifest of per-file sha256 hashes — so a skill can carry a 100% genuine signature while its content has drifted (a team signs an early commit, keeps editing, and the sync picks up later content against the stale signature). "Signed" is not the same as "the signature is telling the truth about what's inside."

This gap is real and live: a full-catalog audit found **6 skills** whose files don't match their own signature, none of which any existing check caught.

## What this adds

A content-integrity check (`.github/scripts/verify_content_integrity.py` + workflow):
- Decodes each `skills/<skill>/skill.oms.sig` manifest, recomputes the sha256 of every signed file on disk, and compares.
- **Fails on any hash mismatch or missing signed file.**
- **pull_request:** checks only the skills changed in the PR — catches drift being *introduced*, without blocking on unrelated pre-existing state.
- **schedule (daily) + workflow_dispatch:** checks the whole catalog — safety net for drift already on `main`.
- Pure Python stdlib, runs against the local checkout: fast (local hashing, scoped to changed files), no network, no secrets, no extra deps.

This is complementary to the existing signature presence/authenticity gates — it adds the *freshness* dimension ("does the content still match the signature").

## Validation

Run against the current catalog it reports **195 ok / 6 drifted** — exactly the known set (VSS ×3, NemoClaw ×2, TAO ×1), which the owning teams are already remediating. PR-mode correctly scopes to changed skills; a clean diff passes.

## All PRs
- [x] All commits signed off with DCO.