### PR TITLE
Onboard Isaac Automator skill

### DIFF
--- a/components.d/isaac-automator.yml
+++ b/components.d/isaac-automator.yml
@@ -1,0 +1,6 @@
+name: Isaac Automator
+repo: isaac-sim/IsaacAutomator
+description: Deploy and operate cloud Isaac Workstations (Isaac Sim, Isaac Lab, Isaac Lab Arena) on AWS, GCP, Azure, or Alibaba Cloud via the Isaac Automator CLI.
+skills:
+  - path: skills/isaac-automator/
+    catalog_dir: isaac-automator


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check) — pending internal review
- [x] **License selected:** Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org** (`isaac-sim/IsaacAutomator`)
- [x] `skills/` path used for new entries (`skills/isaac-automator/` in the source repo)

## All PRs

- [x] All commits signed off with DCO.

## Other context

Registers the **Isaac Automator** product with one skill, `isaac-automator`, via `components.d/isaac-automator.yml`:

- `repo`: `isaac-sim/IsaacAutomator`
- `path`: `skills/isaac-automator/` -> `catalog_dir`: `isaac-automator`

The source `SKILL.md`, `evals/`, and skill card live in the product repo; the sync workflow pulls them into the catalog. The skill covers deploying and operating cloud Isaac Workstations (Isaac Sim, Isaac Lab, Isaac Lab Arena) across AWS, GCP, Azure, and Alibaba Cloud: deploy, connect, data transfer, lifecycle/cost control, repair, import, and destroy.