### PR TITLE
Update skill-cards.mdx

### DIFF
--- a/docs/skill-cards.mdx
+++ b/docs/skill-cards.mdx
@@ -16,6 +16,7 @@ The **Skills Card** is the per-skill release record described below. Authors can
 | License or terms | What rules govern use and redistribution? |
 | Use case | Who should use it, and for what purpose? |
 | Deployment geography | Where is the skill intended to be used? |
+| Requirements / Dependencies |  What components are needed for the skill to run successfully? |
 | Risks and mitigations | What could go wrong, and how is that risk reduced? |
 | References | What docs, papers, reports, or model cards support this skill? |
 | Skill output | What does the skill produce, and in what format? |
@@ -50,6 +51,12 @@ This skill is [ready for commercial/non-commercial use | for research and develo
 ## Deployment Geography for Use
 
 [Global, regional, or country-specific deployment scope]
+
+### Requirements / Dependencies
+Requires API Key or External Credential: [Yes / No / Optional / Not Specified] 
+Credential Type(s): [API key, OAuth Token, Cloud Credentials, Service Account, None, Other [Specify]  
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate.
 
 ## Known Risks and Mitigations
 

--- a/docs/skill-cards.mdx
+++ b/docs/skill-cards.mdx
@@ -54,7 +54,7 @@ This skill is [ready for commercial/non-commercial use | for research and develo
 
 ### Requirements / Dependencies
 Requires API Key or External Credential: [Yes / No / Optional / Not Specified] 
-Credential Type(s): [API key, OAuth Token, Cloud Credentials, Service Account, None, Other [Specify]  
+Credential Type(s): [API key, OAuth Token, Cloud Credentials, Service Account, None, Other [Specify]]  
 
 Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate.
 


### PR DESCRIPTION
Incorporated new section in table and schema for requirements and dependencies.

<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
- [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
- [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
