### PR TITLE
fix(metadata): correct NeMoClaw → NemoClaw product casing

### DIFF
--- a/.github/scripts/marketplace/metadata.schema.json
+++ b/.github/scripts/marketplace/metadata.schema.json
@@ -266,7 +266,7 @@
             "NeMo Retriever Extraction",
             "NeMo Retriever Ingest",
             "NeMo RL",
-            "NeMoClaw",
+            "NemoClaw",
             "Nemotron",
             "Nemotron for Digital Health",
             "Network Operator",

--- a/plugins.d/nvidia-skills.yml
+++ b/plugins.d/nvidia-skills.yml
@@ -41,7 +41,7 @@ include_skills:
   # AIQ / NeMo Agent Toolkit
   - skills/aiq-deploy/
   - skills/aiq-research/
-  # NeMoClaw
+  # NemoClaw
   - skills/nemoclaw-user-guide/
   # Dynamo
   - skills/dynamo-router-starter/


### PR DESCRIPTION
## Other context (for non-onboarding PRs)

Fixes the `product.primary` casing flagged by @rjensenNV on #290.

**Root cause:** the marketplace product enum in `metadata.schema.json` listed `NeMoClaw` (capital M). The canonical product name is **`NemoClaw`** everywhere it is actually defined — `components.d/nemoclaw.yml`, `README.md`, `docs/index.mdx`, and the skill's own `SKILL.md`/`skill-card.md`/`evals.json`/`BENCHMARK.md`. Because the metadata generator stamps `product.primary` from this enum, the typo was propagating into the auto-generated `metadata.json` (visible on #290).

**Change:**
- `.github/scripts/marketplace/metadata.schema.json` — enum `NeMoClaw` → `NemoClaw`
- `plugins.d/nvidia-skills.yml` — cosmetic comment `# NeMoClaw` → `# NemoClaw`

After this merges and the metadata regenerates, `nemoclaw-user-guide` will carry `product.primary: "NemoClaw"`. #290 should be regenerated/closed in favor of the corrected output.

## All PRs
- [x] All commits signed off with DCO.