### PR TITLE
docs(readme): fix nemoclaw skill count + round out structure example list

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,16 +235,18 @@ NVIDIA/skills/
 │   │                              synced from upstream product repos
 │   ├── README.md                 # Browser-facing install guidance
 │   ├── <product-prefix>-*/       # Flat layout — one dir per skill, product-prefixed
-│   │                               # e.g. aiq-*, cuopt-*, cupynumeric-*, dali-*,
-│   │                               # deepstream-*, digital-health-*, dynamo-*,
-│   │                               # earth2studio-*, launch-nemo-rl, mcore-*,
+│   │                               # e.g. aiq-*, cufolio, cuopt-*, cupynumeric-*,
+│   │                               # dali-*, deepstream-*, dicom-*, digital-health-*,
+│   │                               # dynamo-*, earth2studio-*, holoscan-*, hsb-*,
+│   │                               # jetson-*, launch-nemo-rl, mcore-*,
 │   │                               # nemo-automodel-*, nemo-data-designer-plugin,
 │   │                               # nemo-evaluator-plugin, nemo-mbridge-* (20 skills),
 │   │                               # nemo-retriever, nemo-rl-* (4 skills),
-│   │                               # nemoclaw-user-* (10 skills), nemotron-*,
-│   │                               # physicsnemo-*, rag-*, skill-card-generator,
-│   │                               # tilegym-*, vss-* (15 skills),
-│   │                               # accelerated-computing-cudf, cudaq-guide
+│   │                               # nemoclaw-user-guide, nemotron-*, nemotron-speech,
+│   │                               # nv-* (medical AI), physicsnemo-*, rag-*,
+│   │                               # skill-card-generator, tao-*, tilegym-*,
+│   │                               # vss-* (15 skills), accelerated-computing-cudf,
+│   │                               # cudaq-guide
 │   ├── omniverse-*/              # Physical AI — manually staged (see manual-components.yml)
 │   └── physical-ai-*/            # Physical AI — manually staged
 ├── components.d/                # Product registry — one file per component, teams onboard here


### PR DESCRIPTION
## Other context (for non-onboarding PRs)

README sweep follow-up. Two changes to the hand-written **Repository Structure** tree (the auto-generated Skill Catalog / Getting Help tables were verified current and are untouched):

1. **Correctness fix:** the example list read `nemoclaw-user-* (10 skills)` — there is exactly **one** nemoclaw skill, `nemoclaw-user-guide`. Corrected.
2. **Round-out:** filled in major product prefixes that were missing from the illustrative `e.g.` set — `cufolio`, `dicom-*`, `holoscan-*`, `hsb-*`, `jetson-*`, `nemotron-speech`, `nv-*` (medical AI), `tao-*`.

Verified the retained counts against the live catalog: `nemo-mbridge-* (20)` ✅, `nemo-rl-* (4)` ✅, `vss-* (15)` ✅, `nemoclaw` = 1 ✅.

## All PRs
- [x] All commits signed off with DCO.