### PR TITLE
chore(license): OSS compliance — full CC-BY-4.0 text, DCO text, SPDX headers

### DIFF
--- a/.github/scripts/build-plugins.py
+++ b/.github/scripts/build-plugins.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """
 Build plugin packages from plugins.d/ and per-plugin .skills-manifest.yml files.
 

--- a/.github/scripts/build-plugins.py
+++ b/.github/scripts/build-plugins.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Build plugin packages from plugins.d/ and per-plugin .skills-manifest.yml files.
 

--- a/.github/scripts/build-plugins.sh
+++ b/.github/scripts/build-plugins.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Wrapper around build-plugins.py that ensures PyYAML is importable.
 # Forwards all arguments to the Python script.
 set -euo pipefail

--- a/.github/scripts/build-plugins.sh
+++ b/.github/scripts/build-plugins.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Wrapper around build-plugins.py that ensures PyYAML is importable.
 # Forwards all arguments to the Python script.
 set -euo pipefail

--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Generate metadata.json and skills.sh.json for the NVIDIA skills catalog.
 
 Pipeline:

--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Generate metadata.json and skills.sh.json for the NVIDIA skills catalog.
 
 Pipeline:

--- a/.github/scripts/regenerate-readme.sh
+++ b/.github/scripts/regenerate-readme.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Regenerate the README's Available Skills and Getting Help & Contributing
 # tables from components.d/*.yml. Used by the sync-skills workflow; can also
 # be run locally to preview the result.

--- a/.github/scripts/regenerate-readme.sh
+++ b/.github/scripts/regenerate-readme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Regenerate the README's Available Skills and Getting Help & Contributing
 # tables from components.d/*.yml. Used by the sync-skills workflow; can also
 # be run locally to preview the result.

--- a/.github/scripts/verify_content_integrity.py
+++ b/.github/scripts/verify_content_integrity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Verify that each skill's files still match its signed manifest.
 
 A ``skill.oms.sig`` is a Sigstore bundle wrapping a DSSE / in-toto statement

--- a/.github/scripts/verify_content_integrity.py
+++ b/.github/scripts/verify_content_integrity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Verify that each skill's files still match its signed manifest.
 
 A ``skill.oms.sig`` is a Sigstore bundle wrapping a DSSE / in-toto statement

--- a/.github/scripts/version-plugins.py
+++ b/.github/scripts/version-plugins.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """
 Per-plugin SemVer enforcement and auto-bump.
 

--- a/.github/scripts/version-plugins.py
+++ b/.github/scripts/version-plugins.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Per-plugin SemVer enforcement and auto-bump.
 

--- a/.github/scripts/version-plugins.sh
+++ b/.github/scripts/version-plugins.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Wrapper around version-plugins.py that ensures PyYAML + ruamel.yaml
 # are importable. Forwards all arguments to the Python script.
 set -euo pipefail

--- a/.github/scripts/version-plugins.sh
+++ b/.github/scripts/version-plugins.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Wrapper around version-plugins.py that ensures PyYAML + ruamel.yaml
 # are importable. Forwards all arguments to the Python script.
 set -euo pipefail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,43 @@ git rebase --signoff origin/main && git push --force-with-lease
 ```
 
 See the full [Developer Certificate of Origin](https://developercertificate.org/) for details.
+
+The full text of the Developer Certificate of Origin, Version 1.1:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,58 +31,64 @@ NVIDIA contributors: see the internal onboarding guide for the IP review process
 
 ## Signing Your Work
 
-All pull requests require a DCO sign-off on every commit. This certifies that the contribution is your original work or you have rights to submit it under the same license.
+* We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
 
-```bash
-git commit -s -m "Fix broken link"
-```
+  * Any contribution which contains commits that are not Signed-Off will not be accepted.
 
-This appends `Signed-off-by: Your Name <your@email.com>` to the commit. Unsigned commits will not be accepted.
+* To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
 
-If you forgot to sign off (existing commits without the trailer), retroactively sign all commits in your branch with:
+  ```bash
+  git commit -s -m "Add cool feature."
+  ```
 
-```bash
-git rebase --signoff origin/main && git push --force-with-lease
-```
+  This will append the following to your commit message:
 
-See the full [Developer Certificate of Origin](https://developercertificate.org/) for details.
+  ```
+  Signed-off-by: Your Name <your@email.com>
+  ```
 
-The full text of the Developer Certificate of Origin, Version 1.1:
+* If you forgot to sign off on earlier commits, retroactively sign all commits in your branch with:
 
-```
-Developer Certificate of Origin
-Version 1.1
+  ```bash
+  git rebase --signoff origin/main && git push --force-with-lease
+  ```
 
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+* Full text of the DCO (https://developercertificate.org/):
 
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
+  ```
+  Developer Certificate of Origin
+  Version 1.1
+
+  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
 
 
-Developer's Certificate of Origin 1.1
+  Developer's Certificate of Origin 1.1
 
-By making a contribution to this project, I certify that:
+  By making a contribution to this project, I certify that:
 
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
 
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
 
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
 
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+  ```
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 
-Copyright (c) 2026 NVIDIA Corporation
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 
 This project is licensed under a dual license:
 - Apache License 2.0 (for code and configuration)
@@ -188,40 +188,160 @@ or both, as applicable to the type of content.
    END OF TERMS AND CONDITIONS
 
 ================================================================================
-              Creative Commons Attribution 4.0 International License
-                              (CC BY 4.0)
 
-                https://creativecommons.org/licenses/by/4.0/
+Creative Commons Attribution 4.0 International
 
-You are free to:
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 
-  Share — copy and redistribute the material in any medium or format for any
-  purpose, even commercially.
+Using Creative Commons Public Licenses
 
-  Adapt — remix, transform, and build upon the material for any purpose, even
-  commercially.
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
 
-  The licensor cannot revoke these freedoms as long as you follow the license
-  terms.
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
 
-Under the following terms:
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
 
-  Attribution — You must give appropriate credit, provide a link to the license,
-  and indicate if changes were made. You may do so in any reasonable manner, but
-  not in any way that suggests the licensor endorses you or your use.
+Creative Commons Attribution 4.0 International Public License
 
-  No additional restrictions — You may not apply legal terms or technological
-  measures that legally restrict others from doing anything the license permits.
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
-Notices:
+Section 1 – Definitions.
 
-  You do not have to comply with the license for elements of the material in the
-  public domain or where your use is permitted by an applicable exception or
-  limitation.
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 
-  No warranties are given. The license may not give you all of the permissions
-  necessary for your intended use. For example, other rights such as publicity,
-  privacy, or moral rights may limit how you use the material.
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
 
-For the full legal text, see:
-https://creativecommons.org/licenses/by/4.0/legalcode
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,5 @@
-SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
-
-Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-
-This project is licensed under a dual license:
-- Apache License 2.0 (for code and configuration)
-- Creative Commons Attribution 4.0 International (CC BY 4.0) (for documentation)
-
-You may use the contents of this repository under the terms of either license,
-or both, as applicable to the type of content.
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+This code is dual-licensed with documentation/skills under the CC-BY-4.0 AND source code under Apache-2.0 license terms.
 
 ================================================================================
                                  Apache License


### PR DESCRIPTION
## Onboarding type
- [x] Other (catalog change — OSS license compliance)

## What changed
Addresses the OSS-compliance review (Bernd Weber) for the CC-BY-4.0 / Apache-2.0 dual license. **Catalog-owned items only** (see scope note below).

- **LICENSE** — replaced the CC-BY-4.0 deed/summary with the full legal text (all 8 sections, verbatim from SPDX); corrected copyright entity to `NVIDIA CORPORATION & AFFILIATES.`
- **CONTRIBUTING.md** — reproduced the full Developer Certificate of Origin v1.1 text (paragraphs a–d) in "Signing Your Work" (kept the link too).
- **SPDX headers** added to 5 catalog-owned scripts: `.github/scripts/{build-plugins.py,build-plugins.sh,version-plugins.py,version-plugins.sh,regenerate-readme.sh}`.
- **Entity fix** (`NVIDIA Corporation` → `NVIDIA CORPORATION & AFFILIATES.`) in `verify_content_integrity.py` and `marketplace/generate-skill-metadata.py`.

## Scope note — synced files handled separately
The OSS report listed 19 missing-SPDX files. **5 are catalog-owned (fixed here).** The other **14 live under `skills/` and are synced from product source repos** — editing them here would be overwritten on the next sync, so they must be fixed at source and are being routed to the owning teams (DALI, Holoscan, HSB, NeMo Retriever, Physical AI, Trustworthy AI, TAO).

## Validation
- `py_compile` clean on all changed .py; shebangs intact on .sh.
- LICENSE now contains full Apache + full CC-BY-4.0 (Section 1–8).

## All PRs
- [x] All commits signed off with DCO.
