### PR TITLE
chore(fern): bump fern version from 5.43.0 to 5.56.3

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.43.0"
+  "version": "5.56.3"
 }


### PR DESCRIPTION
## Summary
- Bumps Fern CLI version from `5.43.0` to `5.56.3` in `fern/fern.config.json`

## Test plan
- [ ] Verify Fern generation still works with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)