### PR TITLE
chore(tao): drop tao-run-on-lepton (removed upstream)

### DIFF
--- a/components.d/tao-toolkit.yml
+++ b/components.d/tao-toolkit.yml
@@ -106,8 +106,6 @@ skills:
     catalog_dir: tao-run-on-brev
   - path: skills/platform/tao-run-on-kubernetes/
     catalog_dir: tao-run-on-kubernetes
-  - path: skills/platform/tao-run-on-lepton/
-    catalog_dir: tao-run-on-lepton
   - path: skills/platform/tao-run-on-local-docker/
     catalog_dir: tao-run-on-local-docker
   - path: skills/platform/tao-run-on-slurm/


### PR DESCRIPTION
## Other context (for non-onboarding PRs)

Removes the `tao-run-on-lepton` entry from `components.d/tao-toolkit.yml`.

The skill was removed from the source repo (`NVIDIA-TAO/tao-skills-bank`), so the catalog entry pointed at a missing path and failed to sync — surfaced in the #304 sync run (`skills/platform/tao-run-on-lepton/ empty or missing`). Confirmed with the TAO team (Adrian Tran) that it was intentionally removed.

Dropping the entry clears the sync failure. No skill content changes.

## All PRs
- [x] All commits signed off with DCO.