### PR TITLE
Update DeepStream skills source to mono repo

### DIFF
--- a/components.d/deepstream.yml
+++ b/components.d/deepstream.yml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 name: DeepStream
-repo: NVIDIA-AI-IOT/DeepStream_Coding_Agent
+repo: NVIDIA/DeepStream
 description: Agentic skills for guided DeepStream development.
 skills:
-  - path: skills/deepstream-dev/
-    catalog_dir: deepstream-dev
-  - path: skills/deepstream-import-vision-model/
-    catalog_dir: deepstream-import-vision-model
+  - path: skills/
+    catalog_dir: deepstream
 links:
   discussions: false

--- a/components.d/deepstream.yml
+++ b/components.d/deepstream.yml
@@ -4,7 +4,21 @@ name: DeepStream
 repo: NVIDIA/DeepStream
 description: Agentic skills for guided DeepStream development.
 skills:
-  - path: skills/
-    catalog_dir: deepstream
+  - path: skills/amc-run-sample-calibration/
+    catalog_dir: amc-run-sample-calibration
+  - path: skills/amc-run-video-calibration/
+    catalog_dir: amc-run-video-calibration
+  - path: skills/amc-setup-calibration-stack/
+    catalog_dir: amc-setup-calibration-stack
+  - path: skills/deepstream-dev/
+    catalog_dir: deepstream-dev
+  - path: skills/deepstream-generate-pipeline/
+    catalog_dir: deepstream-generate-pipeline
+  - path: skills/deepstream-import-vision-model/
+    catalog_dir: deepstream-import-vision-model
+  - path: skills/deepstream-profile-pipeline/
+    catalog_dir: deepstream-profile-pipeline
+  - path: skills/deepstream-sop/
+    catalog_dir: deepstream-sop
 links:
   discussions: false


### PR DESCRIPTION
## Summary
- Point DeepStream component sync at `NVIDIA/DeepStream` instead of `NVIDIA-AI-IOT/DeepStream_Coding_Agent`.
- List each DeepStream mono-repo skill explicitly so the catalog sync creates one entry per skill.
- Include all 8 current skills from `NVIDIA/DeepStream/skills/`:
  - `amc-run-sample-calibration`
  - `amc-run-video-calibration`
  - `amc-setup-calibration-stack`
  - `deepstream-dev`
  - `deepstream-generate-pipeline`
  - `deepstream-import-vision-model`
  - `deepstream-profile-pipeline`
  - `deepstream-sop`

## Validation
- Parsed `components.d/deepstream.yml` with `yq`.
- Verified all 8 configured paths exist in `NVIDIA/DeepStream/skills/` and contain `SKILL.md`.
- Ran `git diff --check`.