### PR TITLE
ci(dco): exempt bot/regenerate-skill-metadata branch

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,10 +4,12 @@
 # Verify every commit in a pull request carries a Signed-off-by
 # trailer per the project's DCO requirement (see CONTRIBUTING.md).
 #
-# The automated/sync-skills branch is exempt — it's the daily mirror
-# bot, not a contributor. The legal anchor for synced content lives
-# on the human onboarding PR that registered the component in
-# components.yml; the daily sync is downstream plumbing.
+# The automated/sync-skills and bot/regenerate-skill-metadata branches
+# are exempt — they're bot-managed (the daily mirror bot and the skill
+# metadata regenerator), not contributors. The legal anchor for synced
+# content lives on the human onboarding PR that registered the component
+# in components.d; the daily sync and metadata regen are downstream
+# plumbing.
 
 name: DCO Check
 
@@ -36,11 +38,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Bot-managed sync branch is exempt — see header comment.
-          if [ "$HEAD_REF" = "automated/sync-skills" ]; then
-            echo "DCO check exempt for bot-managed branch '$HEAD_REF'."
-            exit 0
-          fi
+          # Bot-managed branches are exempt — see header comment.
+          case "$HEAD_REF" in
+            automated/sync-skills|bot/regenerate-skill-metadata)
+              echo "DCO check exempt for bot-managed branch '$HEAD_REF'."
+              exit 0
+              ;;
+          esac
 
           unsigned=()
           while read -r sha; do


### PR DESCRIPTION
## Summary
The `bot/regenerate-skill-metadata` branch (the skill-metadata regenerator bot) commits an auto-generated `metadata.json` **without a `Signed-off-by` trailer** — same shape as the `automated/sync-skills` mirror bot. But only `automated/sync-skills` was in the DCO exemption, so every metadata-regen PR fails the DCO check on what is downstream plumbing, not contributed content.

**Example:** #310 (`chore(metadata): regenerate metadata.json and skills.sh.json`) — all other checks green (Verify Content Integrity, Verify Authors, Generate Skill Metadata), DCO red purely because of this.

## Change
- Extend the DCO exemption in `.github/workflows/dco.yml` from a single-branch check to a `case` covering both bot-managed branches: `automated/sync-skills` and `bot/regenerate-skill-metadata`.
- Update the header comment to reflect both.

No change to DCO enforcement for human contributor PRs.

## After merge
#310 can be re-run and will pass DCO without an `--admin` override, and future metadata regens stop hitting this.