### PR TITLE
chore(cuopt): point at consolidated numerical-optimization-api skill

### DIFF
--- a/components.d/cuopt.yml
+++ b/components.d/cuopt.yml
@@ -8,12 +8,8 @@ skills:
     catalog_dir: cuopt-install
   - path: skills/cuopt-multi-objective-exploration/
     catalog_dir: cuopt-multi-objective-exploration
-  - path: skills/cuopt-numerical-optimization-api-c/
-    catalog_dir: cuopt-numerical-optimization-api-c
-  - path: skills/cuopt-numerical-optimization-api-cli/
-    catalog_dir: cuopt-numerical-optimization-api-cli
-  - path: skills/cuopt-numerical-optimization-api-python/
-    catalog_dir: cuopt-numerical-optimization-api-python
+  - path: skills/cuopt-numerical-optimization-api/
+    catalog_dir: cuopt-numerical-optimization-api
   - path: skills/cuopt-numerical-optimization-formulation/
     catalog_dir: cuopt-numerical-optimization-formulation
   - path: skills/cuopt-routing-api-python/


### PR DESCRIPTION
## Summary
- cuOpt PR NVIDIA/cuopt#1489 (merged) consolidated the `cuopt-numerical-optimization-api-python`, `-c`, and `-cli` skills into a single `cuopt-numerical-optimization-api` skill.
- Update `components.d/cuopt.yml` to point the sync bot at the new consolidated path instead of the three removed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)