### PR TITLE
Add physical-ai-people-attribute-search to Physical AI component

### DIFF
--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -6,5 +6,7 @@ skills:
     catalog_dir: physical-ai-defect-image-generation
   - path: skills/physical-ai-video-data-augmentation/
     catalog_dir: physical-ai-video-data-augmentation
+  - path: skills/physical-ai-people-attribute-search/
+    catalog_dir: physical-ai-people-attribute-search
 links:
   discussions: false


### PR DESCRIPTION
## Summary

- Registers the **People Attribute Search (PAS)** skill in `components.d/physical-ai-data-factory.yml`, so it is synced into the catalog alongside the existing Defect Image Generation (DIG) and Video Data Augmentation (VDA) skills.
- Follows the flat layout documented in `components.d/README.md` (one `path` + `catalog_dir` entry per skill).

The skill source lives at `skills/physical-ai-people-attribute-search/` in [NVIDIA/physical-ai-data-factory](https://github.com/NVIDIA/physical-ai-data-factory) and ships the required `skill.oms.sig`, `skill-card.md`, `evals/evals.json`, and `BENCHMARK.md`.

## Change

```yaml
  - path: skills/physical-ai-people-attribute-search/
    catalog_dir: physical-ai-people-attribute-search
```

## Test plan

- [ ] Component config parses and the sync workflow picks up the new skill.
- [ ] `physical-ai-people-attribute-search` appears as a top-level catalog directory under `skills/` after sync.