### PR TITLE
Add orphan pruning to the skills sync

### DIFF
--- a/.github/scripts/prune-orphans.sh
+++ b/.github/scripts/prune-orphans.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Prune catalog skill dirs whose components.d registration was removed.
+#
+# The sync only writes to dirs declared in components.d/*.yml — it never
+# deletes a dir whose registration disappeared, so deregistered skills
+# linger in the catalog (and downstream surfaces) indefinitely. Teams
+# consistently assume deregistration removes the catalog copy (Dynamo,
+# TAO/tao-run-on-lepton, and cuOpt all hit this), so this step makes that
+# assumption true: any top-level skills/ dir that is neither declared in
+# components.d nor listed in components.d/catalog-exceptions.yml is
+# removed as part of the sync commit, where the deletion is visible in
+# the sync PR diff.
+#
+# Safety rails:
+#   - If any components.d file fails to parse, pruning is skipped for
+#     the whole run — a parse error would make that component's skills
+#     look unregistered and mass-delete them.
+#   - If more than PRUNE_CAP dirs would be pruned in one run, nothing is
+#     deleted; the list is written to /tmp/pruned-orphans-overflow.txt
+#     and surfaced as a workflow warning for human triage.
+#
+# Outputs:
+#   /tmp/pruned-orphans.txt          one pruned dir per line
+#   /tmp/pruned-orphans-overflow.txt cap exceeded — dirs NOT deleted
+
+set -euo pipefail
+
+PRUNE_CAP="${PRUNE_CAP:-5}"
+EXCEPTIONS_FILE="components.d/catalog-exceptions.yml"
+pruned="${PRUNED_OUT:-/tmp/pruned-orphans.txt}"
+overflow="${PRUNED_OVERFLOW_OUT:-/tmp/pruned-orphans-overflow.txt}"
+: > "$pruned"
+rm -f "$overflow"
+
+expected=$(mktemp "${PRUNE_TMPDIR:-/tmp}/prune-expected.XXXXXX")
+
+# 1. Declared set — every catalog_dir across components.d/*.yml.
+for f in components.d/*.yml; do
+  case "$f" in *catalog-exceptions.yml) continue ;; esac
+  if ! yq e 'true' "$f" > /dev/null 2>&1; then
+    echo "::warning::${f} failed to parse — skipping orphan pruning this run"
+    exit 0
+  fi
+  yq -r '.skills[]?.catalog_dir // ""' "$f" | grep -v '^$' >> "$expected" || true
+done
+
+# 2. Exceptions — dirs allowed to exist without a registration.
+if [ -f "$EXCEPTIONS_FILE" ]; then
+  if ! yq e 'true' "$EXCEPTIONS_FILE" > /dev/null 2>&1; then
+    echo "::warning::${EXCEPTIONS_FILE} failed to parse — skipping orphan pruning this run"
+    exit 0
+  fi
+  yq -r '.exceptions[]?.dir // ""' "$EXCEPTIONS_FILE" | grep -v '^$' >> "$expected" || true
+fi
+
+if [ ! -s "$expected" ]; then
+  echo "::warning::declared skill set is empty — skipping orphan pruning this run"
+  exit 0
+fi
+
+# 3. Collect orphans: top-level skills/ dirs not in the expected set.
+orphans=$(mktemp "${PRUNE_TMPDIR:-/tmp}/prune-orphans.XXXXXX")
+for d in skills/*/; do
+  dir=$(basename "$d")
+  if ! grep -qxF "$dir" "$expected"; then
+    echo "$dir" >> "$orphans"
+  fi
+done
+
+count=$(wc -l < "$orphans" | tr -d ' ')
+if [ "$count" -eq 0 ]; then
+  echo "No orphaned skill dirs."
+  exit 0
+fi
+
+# 4. Cap check.
+if [ "$count" -gt "$PRUNE_CAP" ]; then
+  cp "$orphans" "$overflow"
+  echo "::warning::${count} orphaned skill dirs exceed the prune cap (${PRUNE_CAP}) — nothing deleted. Dirs:"
+  cat "$orphans"
+  exit 0
+fi
+
+# 5. Prune.
+while read -r dir; do
+  git rm -rq "skills/$dir"
+  echo "$dir" >> "$pruned"
+  echo "  ✂ pruned skills/$dir (no components.d registration)"
+done < "$orphans"

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -354,6 +354,19 @@ jobs:
             done < "$dropped"
           fi
 
+      - name: Prune orphaned skill dirs
+        # Remove skills/ dirs whose components.d registration was removed.
+        # Teams consistently assume deregistering also removes the catalog
+        # copy (Dynamo, TAO, cuOpt all hit this) — this step makes that
+        # true. Capped + parse-guarded; see the script header for the
+        # safety rails, and components.d/catalog-exceptions.yml for dirs
+        # that are intentionally unregistered.
+        run: |
+          bash .github/scripts/prune-orphans.sh
+          if [ -s /tmp/pruned-orphans.txt ]; then
+            echo "- orphan pruning" >> /tmp/changed-components.txt
+          fi
+
       - name: Resolve skill contacts
         # For each dropped/reverted skill, resolve the original onboarder
         # via git blame on the owning components.d/<slug>.yml and emit a
@@ -844,6 +857,20 @@ jobs:
                   emit_with_contact "$dir" "$reason"
                 done
               fi
+            fi
+            if [ -s /tmp/pruned-orphans.txt ]; then
+              echo ""
+              echo "**Pruned — deregistered from components.d (dir removed from catalog):**"
+              while read -r dir; do
+                echo "- \`skills/$dir\`"
+              done < /tmp/pruned-orphans.txt
+            fi
+            if [ -s /tmp/pruned-orphans-overflow.txt ]; then
+              echo ""
+              echo "**⚠ Orphan pruning skipped — count exceeds safety cap; needs human triage:**"
+              while read -r dir; do
+                echo "- \`skills/$dir\`"
+              done < /tmp/pruned-orphans-overflow.txt
             fi
             if [ -s /tmp/failed-components.txt ]; then
               echo ""

--- a/components.d/README.md
+++ b/components.d/README.md
@@ -83,3 +83,7 @@ yq ea '[.] | {"components": .}' components.d/*.yml > /tmp/components.aggregated.
 ```
 
 Then iterates the resulting `components` list. Files are read in alphabetical order; the README regenerator sorts the result by display name independently.
+
+## Removal and orphan pruning
+
+Removing a skill entry from a component file removes its `skills/<catalog_dir>/` copy from the catalog on the next sync — the sync's orphan-pruning step (`.github/scripts/prune-orphans.sh`) deletes any top-level `skills/` dir with no `components.d` registration. Dirs that intentionally exist without a registration (e.g. contributor-facing or manually curated skills) must be listed in `catalog-exceptions.yml` in this directory, with a reason and owner. Pruning is skipped for the whole run if any component file fails to parse, and refuses to act (flagging for human triage instead) if more than 5 dirs would be removed at once.

--- a/components.d/catalog-exceptions.yml
+++ b/components.d/catalog-exceptions.yml
@@ -1,0 +1,25 @@
+# Catalog exceptions — skills/ dirs allowed to exist WITHOUT a
+# components.d registration. Everything else in skills/ must be declared
+# by a components.d/<slug>.yml entry, or the hourly sync prunes it
+# (see .github/scripts/prune-orphans.sh).
+#
+# Add an entry only with a documented reason and an owner.
+exceptions:
+  - dir: cuopt-developer
+    reason: Contributor-facing skill, intentionally uncataloged (per cuOpt team, 2026-06-01)
+    owner: rgsl888prabhu
+  - dir: omniverse-cad-to-simready
+    reason: Physical AI Hub skill, manually curated outside the sync workflow
+    owner: alex-qi
+  - dir: omniverse-realtime-viewer
+    reason: Physical AI Hub skill, manually curated outside the sync workflow
+    owner: alex-qi
+  - dir: omniverse-usd-performance-tuning
+    reason: Physical AI Hub skill, manually curated outside the sync workflow
+    owner: alex-qi
+  - dir: physical-ai-infrastructure-setup-and-resilient-scaling
+    reason: Physical AI Hub skill, manually curated outside the sync workflow
+    owner: alex-qi
+  - dir: physical-ai-neural-reconstruction
+    reason: Physical AI Hub skill, manually curated outside the sync workflow
+    owner: alex-qi


### PR DESCRIPTION
## Problem

Deregistering a skill from `components.d` does not remove its catalog copy — the sync only writes declared paths. Three teams (Dynamo, TAO/tao-run-on-lepton, cuOpt ×5) independently assumed deregistration removes the dir, leaving stale skills live on the catalog and every downstream surface. This makes the assumption true.

## What

- **`.github/scripts/prune-orphans.sh`** — after the sync loop, any top-level `skills/` dir with no components.d registration and no exceptions entry is `git rm`'d as part of the sync commit (deletion visible in the sync PR diff).
- **Safety rails:** pruning skips the whole run if any component yml fails to parse (a parse error would make that component's skills look unregistered → mass-delete); if more than `PRUNE_CAP=5` dirs would prune at once, nothing is deleted and the list is surfaced for human triage (workflow warning + PR-body section).
- **`components.d/catalog-exceptions.yml`** — explicit allowlist for intentionally unregistered dirs, each with reason + owner. Seeded with `cuopt-developer` (contributor-facing) and the five manually curated Physical AI Hub skills.
- **Sync PR body** lists pruned dirs; a prune-only sync still opens a PR.
- **Docs:** components.d/README.md now states the removal contract.

## Local test results (against live repo state)

- Found all **11 current orphans** — incl. the 5 Physical AI skills (why the exceptions file exists) and `cuopt-user-rules`, a 5th cuOpt leftover #330 missed
- Default cap: refused to delete (11 > 5) ✔
- With exceptions + raised cap: pruned exactly the 6 deregistered dirs, exceptions honored ✔
- Idempotent after prune ✔; safe on parse errors, empty declared set, missing exceptions file ✔

## Sequencing

After #328 + #330 merge, the only remaining orphan is `cuopt-user-rules` (1 ≤ cap) — the first sync after this merges prunes it automatically, a clean live validation.

cc @sayalinvidia @jasonnvidia

🤖 Generated with [Claude Code](https://claude.com/claude-code)