### PR TITLE
Add jasonnvidia to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 
 # Default owners for all files in the repo
-* @mosheabr @sayalinvidia
+* @mosheabr @sayalinvidia @jasonnvidia


### PR DESCRIPTION
One-line governance change: adds @jasonnvidia as a default code owner alongside @mosheabr and @sayalinvidia.

Why: the branch-protection ruleset requires code-owner review with only two owners listed — and since PR authors can't self-approve, every catalog PR effectively bottlenecks on one person. Jason already does plugin/metadata housekeeping (#329) and PR review on the repo and holds admin access; this makes his approvals count toward the code-owner requirement (immediately relevant to #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)