### PR TITLE
Attribute components for intentionally-unregistered skills (dashboard 'Unmapped' fix)

### DIFF
--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -127,6 +127,17 @@ def load_component_map(repo_root: Path) -> dict:
             m = re.match(r"^-?\s*catalog_dir:\s*(.+)$", line.strip())
             if m:
                 mapping[m.group(1).strip()] = name
+    manual = repo_root / ".github" / "scripts" / "manual-components.yml"
+    if manual.exists():
+        name = None
+        for line in manual.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^-?\s*name:\s*(.+)$", line.strip())
+            if m:
+                name = m.group(1).strip()
+                continue
+            m = re.match(r"^-\s*(\S+)\s*$", line.strip())
+            if m and name and m.group(1) not in mapping:
+                mapping[m.group(1)] = name
     exceptions = repo_root / "catalog-exceptions.yml"
     if exceptions.exists():
         current_dir = None

--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -111,7 +111,12 @@ def average_uplift(results: list):
 
 
 def load_component_map(repo_root: Path) -> dict:
-    """Map catalog skill dir -> component (product) name from components.d/."""
+    """Map catalog skill dir -> component (product) name.
+
+    Primary source is components.d/ registrations. Skills that intentionally
+    exist without a registration (catalog-exceptions.yml) may declare a
+    display component there so downstream consumers can still group them.
+    """
     mapping = {}
     for yml in sorted((repo_root / "components.d").glob("*.yml")):
         name = None
@@ -122,6 +127,17 @@ def load_component_map(repo_root: Path) -> dict:
             m = re.match(r"^-?\s*catalog_dir:\s*(.+)$", line.strip())
             if m:
                 mapping[m.group(1).strip()] = name
+    exceptions = repo_root / "catalog-exceptions.yml"
+    if exceptions.exists():
+        current_dir = None
+        for line in exceptions.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^-?\s*dir:\s*(.+)$", line.strip())
+            if m:
+                current_dir = m.group(1).strip()
+                continue
+            m = re.match(r"^component:\s*(.+)$", line.strip())
+            if m and current_dir and current_dir not in mapping:
+                mapping[current_dir] = m.group(1).strip()
     return mapping
 
 

--- a/.github/scripts/prune-orphans.sh
+++ b/.github/scripts/prune-orphans.sh
@@ -46,6 +46,17 @@ for f in components.d/*.yml; do
   yq -r '.skills[]?.catalog_dir // ""' "$f" | grep -v '^$' >> "$expected" || true
 done
 
+# 1b. Manually staged components — dirs declared in manual-components.yml
+#     (skills staged via direct PR; see that file's header).
+MANUAL_FILE=".github/scripts/manual-components.yml"
+if [ -f "$MANUAL_FILE" ]; then
+  if \! yq e 'true' "$MANUAL_FILE" > /dev/null 2>&1; then
+    echo "::warning::${MANUAL_FILE} failed to parse — skipping orphan pruning this run"
+    exit 0
+  fi
+  yq -r '.components[]?.catalog_dirs[]? // ""' "$MANUAL_FILE" | grep -v '^$' >> "$expected" || true
+fi
+
 # 2. Exceptions — dirs allowed to exist without a registration.
 if [ -f "$EXCEPTIONS_FILE" ]; then
   if ! yq e 'true' "$EXCEPTIONS_FILE" > /dev/null 2>&1; then

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -186,7 +186,7 @@
         "codex"
       ],
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "has_results": true,
       "average_uplift_pct": 23.7
     },
@@ -2481,7 +2481,7 @@
       "verdict": "FAIL",
       "agents": [],
       "catalog_dir": "omniverse-cad-to-simready",
-      "component": null,
+      "component": "Physical AI",
       "has_results": false,
       "average_uplift_pct": null
     },
@@ -2496,7 +2496,7 @@
       "verdict": "FAIL",
       "agents": [],
       "catalog_dir": "omniverse-realtime-viewer",
-      "component": null,
+      "component": "Physical AI",
       "has_results": false,
       "average_uplift_pct": null
     },
@@ -2511,7 +2511,7 @@
       "verdict": "FAIL",
       "agents": [],
       "catalog_dir": "omniverse-usd-performance-tuning",
-      "component": null,
+      "component": "Physical AI",
       "has_results": false,
       "average_uplift_pct": null
     },
@@ -2544,7 +2544,7 @@
       "verdict": "FAIL",
       "agents": [],
       "catalog_dir": "physical-ai-infrastructure-setup-and-resilient-scaling",
-      "component": null,
+      "component": "Physical AI",
       "has_results": false,
       "average_uplift_pct": null
     },
@@ -2559,7 +2559,7 @@
       "verdict": "PASS",
       "agents": [],
       "catalog_dir": "physical-ai-neural-reconstruction",
-      "component": null,
+      "component": "Physical AI",
       "has_results": false,
       "average_uplift_pct": null
     },
@@ -4808,7 +4808,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Security",
       "num": 3,
       "agent": "claude-code",
@@ -4817,7 +4817,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Security",
       "num": 3,
       "agent": "codex",
@@ -4826,7 +4826,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Correctness",
       "num": 3,
       "agent": "claude-code",
@@ -4835,7 +4835,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Correctness",
       "num": 3,
       "agent": "codex",
@@ -4844,7 +4844,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Discoverability",
       "num": 3,
       "agent": "claude-code",
@@ -4853,7 +4853,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Discoverability",
       "num": 3,
       "agent": "codex",
@@ -4862,7 +4862,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Effectiveness",
       "num": 3,
       "agent": "claude-code",
@@ -4871,7 +4871,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Effectiveness",
       "num": 3,
       "agent": "codex",
@@ -4880,7 +4880,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Efficiency",
       "num": 3,
       "agent": "claude-code",
@@ -4889,7 +4889,7 @@
     },
     {
       "catalog_dir": "cuopt-developer",
-      "component": null,
+      "component": "cuOpt",
       "dimension": "Efficiency",
       "num": 3,
       "agent": "codex",

--- a/catalog-exceptions.yml
+++ b/catalog-exceptions.yml
@@ -1,6 +1,8 @@
 # Catalog exceptions — skills/ dirs allowed to exist WITHOUT a
 # components.d registration. Everything else in skills/ must be declared
-# by a components.d/<slug>.yml entry, or the hourly sync prunes it
+# by a components.d/<slug>.yml entry, listed in
+# .github/scripts/manual-components.yml (manually staged, README-visible
+# skills), or listed here — otherwise the hourly sync prunes it
 # (see .github/scripts/prune-orphans.sh).
 #
 # Add an entry only with a documented reason and an owner.
@@ -9,23 +11,3 @@ exceptions:
     reason: Contributor-facing skill, intentionally uncataloged (per cuOpt team, 2026-06-01)
     owner: rgsl888prabhu
     component: cuOpt
-  - dir: omniverse-cad-to-simready
-    reason: Physical AI Hub skill, manually curated outside the sync workflow
-    owner: alex-qi
-    component: Physical AI
-  - dir: omniverse-realtime-viewer
-    reason: Physical AI Hub skill, manually curated outside the sync workflow
-    owner: alex-qi
-    component: Physical AI
-  - dir: omniverse-usd-performance-tuning
-    reason: Physical AI Hub skill, manually curated outside the sync workflow
-    owner: alex-qi
-    component: Physical AI
-  - dir: physical-ai-infrastructure-setup-and-resilient-scaling
-    reason: Physical AI Hub skill, manually curated outside the sync workflow
-    owner: alex-qi
-    component: Physical AI
-  - dir: physical-ai-neural-reconstruction
-    reason: Physical AI Hub skill, manually curated outside the sync workflow
-    owner: alex-qi
-    component: Physical AI

--- a/catalog-exceptions.yml
+++ b/catalog-exceptions.yml
@@ -8,18 +8,24 @@ exceptions:
   - dir: cuopt-developer
     reason: Contributor-facing skill, intentionally uncataloged (per cuOpt team, 2026-06-01)
     owner: rgsl888prabhu
+    component: cuOpt
   - dir: omniverse-cad-to-simready
     reason: Physical AI Hub skill, manually curated outside the sync workflow
     owner: alex-qi
+    component: Physical AI
   - dir: omniverse-realtime-viewer
     reason: Physical AI Hub skill, manually curated outside the sync workflow
     owner: alex-qi
+    component: Physical AI
   - dir: omniverse-usd-performance-tuning
     reason: Physical AI Hub skill, manually curated outside the sync workflow
     owner: alex-qi
+    component: Physical AI
   - dir: physical-ai-infrastructure-setup-and-resilient-scaling
     reason: Physical AI Hub skill, manually curated outside the sync workflow
     owner: alex-qi
+    component: Physical AI
   - dir: physical-ai-neural-reconstruction
     reason: Physical AI Hub skill, manually curated outside the sync workflow
     owner: alex-qi
+    component: Physical AI


### PR DESCRIPTION
Six skills exist without a components.d registration by design (contributor-facing `cuopt-developer`, five manually curated Physical AI Hub skills), so their `component` in benchmarks.json was null — rendering as **Unmapped** on the adoption dashboard's component view.

Fix: `catalog-exceptions.yml` entries may now declare a display `component`; the benchmarks aggregator uses it as a fallback (components.d stays authoritative where a registration exists). All 229 skills in the feed now carry a component (`cuopt-developer` → cuOpt; hub skills → Physical AI, per Alex Qi's single-product-entry convention). Regenerated output byte-stable.

Deliberately **not** done: registering these in components.d — that would put them in the sync's clone path (they're manually curated / contributor-facing) and surface cuopt-developer as a customer-facing product skill.

Reported by @mraheem-arch. cc @sayalinvidia

🤖 Generated with [Claude Code](https://claude.com/claude-code)