### PR TITLE
(OLD)Add nvidia-skill-finder as catalog-only router skill

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "source": "skills/*/BENCHMARK.md",
-  "skill_count": 229,
+  "skill_count": 230,
   "result_row_count": 2070,
   "skills_without_results": [
     "deepstream-generate-pipeline",
@@ -18,6 +18,7 @@
     "mcore-run-on-slurm",
     "mcore-split-pr",
     "mcore-testing",
+    "nvidia-skill-finder",
     "omniverse-cad-to-simready",
     "omniverse-realtime-viewer",
     "omniverse-usd-performance-tuning",
@@ -2469,6 +2470,21 @@
       "component": "Medical AI Skills",
       "has_results": true,
       "average_uplift_pct": 29.5
+    },
+    {
+      "skill": "skill",
+      "evaluation_date": "2026-06-25",
+      "profile": "external",
+      "environment": null,
+      "tasks": null,
+      "attempts_per_task": null,
+      "pass_threshold_pct": null,
+      "verdict": "PASS",
+      "agents": [],
+      "catalog_dir": "nvidia-skill-finder",
+      "component": "NVIDIA Skills",
+      "has_results": false,
+      "average_uplift_pct": null
     },
     {
       "skill": "omniverse-cad-to-simready",

--- a/catalog-exceptions.yml
+++ b/catalog-exceptions.yml
@@ -11,3 +11,7 @@ exceptions:
     reason: Contributor-facing skill, intentionally uncataloged (per cuOpt team, 2026-06-01)
     owner: rgsl888prabhu
     component: cuOpt
+  - dir: nvidia-skill-finder
+    reason: Catalog infrastructure router skill; maintained via direct PR (no components.d upstream)
+    owner: jdudash
+    component: NVIDIA Skills

--- a/skills/nvidia-skill-finder/BENCHMARK.md
+++ b/skills/nvidia-skill-finder/BENCHMARK.md
@@ -1,0 +1,58 @@
+# Evaluation Report
+
+Evaluation of the `skill` skill before publication through NVSkills-Eval.
+
+This benchmark summarizes 3-Tier Evaluation from NVSkills-Eval results for the skill. The goal is to document whether the skill is safe, discoverable, effective, and useful for agents before it is published for broader workflow use.
+
+## Evaluation Summary
+
+- Skill: `skill`
+- Evaluation date: 2026-06-25
+- NVSkills-Eval profile: `external`
+- Overall verdict: PASS
+- Tier 3 live agent evaluation: not available in this report
+
+## Agents Used
+
+- Tier 3 agent details were not available in this report.
+
+## Metrics Used
+
+Reported benchmark dimensions:
+
+- Security: checks whether skill-assisted execution avoids unsafe behavior such as secret leakage, destructive commands, or unauthorized access.
+- Correctness: checks whether the agent follows the expected workflow and produces the correct final output.
+- Discoverability: checks whether the agent loads the skill when relevant and avoids using it when irrelevant.
+- Effectiveness: checks whether the agent performs measurably better with the skill than without it.
+- Efficiency: checks whether the agent uses fewer tokens and avoids redundant work.
+
+Underlying evaluation signals used in this run:
+
+- No Tier 3 evaluation signal details were available in this report.
+
+## Test Tasks
+
+Tier 3 evaluation task details were not available in this report.
+
+## Results
+
+Tier 3 dimension rollup was not available in this report.
+
+## Tier 1: Static Validation Summary
+
+Tier 1 validation passed with observations. NVSkills-Eval ran 9 checks and found 4 total findings.
+
+Top findings:
+
+- LOW QUALITY/quality_discoverability: Description very long (718 chars, recommend 50-150) (`[nvidia-skill-finder] skills/nvidia-skill-finder/SKILL.md`)
+- LOW QUALITY/quality_reliability: No prerequisites/requirements documented (`[nvidia-skill-finder] skills/nvidia-skill-finder/SKILL.md`)
+- LOW QUALITY/quality_reliability: No limitations documented (`[nvidia-skill-finder] skills/nvidia-skill-finder/SKILL.md`)
+- LOW QUALITY/quality_reliability: No troubleshooting section documented (`[nvidia-skill-finder] skills/nvidia-skill-finder/SKILL.md`)
+
+## Tier 2: Deduplication Summary
+
+This tier was not run or did not produce findings in this report.
+
+## Publication Recommendation
+
+The skill is suitable to proceed toward NVSkills-Eval publication based on this benchmark. Skill owners should keep this file with the skill and refresh it when the evaluation dataset, skill behavior, or target agents materially change.

--- a/skills/nvidia-skill-finder/SKILL.md
+++ b/skills/nvidia-skill-finder/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: nvidia-skill-finder
+description: >-
+  Use for NVIDIA-related requests where an NVIDIA skill might help, even if the user did not ask for a skill. Trigger on NVIDIA products, hardware, software, SDKs, GPUs, Jetson/JetPack/L4T/BSP/SDK Manager/driver/flashing/setup, CUDA, NIM, NeMo, Omniverse/OpenUSD/SimReady, RAPIDS/cuDF, cuPyNumeric, cuOpt, Dynamo, Holoscan, TensorRT, DeepStream, VSS, TAO, NGC/NVCF. Do not use for generic non-NVIDIA route, optimize, deploy, AI, video, data, or infrastructure tasks.
+license: CC-BY-4.0 AND Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - nvidia
+    - skills
+    - discovery
+    - catalog
+    - router
+  domain: agent-skills
+---
+
+# NVIDIA Skill Finder
+
+## Purpose
+
+Help users discover, install, and start using NVIDIA skills that may not be
+installed yet. Treat this skill as a stable NVIDIA capability detector and
+catalog router, not as a mirror of every external skill's trigger text.
+
+Use the live catalog as the source of truth for specific skill names,
+descriptions, and availability. Keep only stable taxonomy guidance here.
+
+## When to Use this Skill 
+Use this skill to find the best NVIDIA skill for a product, task, or workflow.
+The user does not need to explicitly ask for a skill. If the request is about
+NVIDIA hardware, software, SDKs, drivers, setup, troubleshooting, or an
+NVIDIA-adjacent workflow, check whether the live catalog has a skill that could
+help before proceeding too far with general guidance.
+
+Typical triggers:
+
+- Asks "how do I do X" where X might be a common task that an NVIDIA skill can help with.
+- Says "find a skill for X" or "is there a skill for X".
+- Expresses interest in extending agent capabilities in NVIDIA domains.
+- Mentions they need help with a specific NVIDIA catalog domain covered below.
+- Asks about installing, configuring, troubleshooting, or using an NVIDIA
+  product, device, SDK, or service.
+
+Continue with this skill only when the request is plausibly related to an NVIDIA product area or taxonomy category.
+
+Strong signals:
+
+- The user mentions NVIDIA, CUDA, GPU acceleration, NIM, NeMo, Omniverse, OpenUSD,
+  SimReady, cuOpt, RAPIDS/cuDF, cuPyNumeric, Dynamo, Holoscan, TensorRT, VSS,
+  DeepStream, Jetson, JetPack, L4T, BSP, SDK Manager, TAO, NGC, NVCF, or another
+  NVIDIA product.
+- The task maps strongly to an NVIDIA catalog lane such as Agentic AI, Physical
+  AI, Robotics, Vision AI, Conversational AI, Simulation and Modeling, Data
+  Science, Training AI, Inference AI, Decision Optimization, GPU Development,
+  Quantum Computing, Infrastructure, or Networking.
+- The task uses distinctive phrases such as RAG/deep research, vehicle routing,
+  LP/MILP/QP, GPU DataFrames, multi-GPU NumPy/SciPy, KV-aware routing,
+  Jetson driver install, JetPack flashing, BSP download, SDK Manager setup,
+  CAD-to-SimReady, OpenUSD optimization, VSS/video search/summarization, DICOM
+  workflows, robotics simulation, Holoscan setup, or synthetic data generation.
+
+Read [references/taxonomy-routing.md](references/taxonomy-routing.md) only when
+the request is taxonomy-only, ambiguous, or needs browse/domain mapping. For
+obvious product-name matches, go directly to live catalog lookup.
+
+## When Not to Use this Skill
+Stay quiet when the request is generic:
+
+- "route" means an HTTP route, Express route, file route, or request routing.
+- "optimize" means ordinary web performance, CSS, bundle size, SQL tuning, or
+  generic code cleanup.
+- "deploy" means generic Kubernetes, cloud, CI/CD, or web hosting.
+- "AI", "data science", or "infrastructure" appears without NVIDIA, GPU,
+  accelerated-computing, or one of the distinctive intent signals above.
+- "video" means ordinary trimming, captions, export, or social-media editing.
+
+If relevance is uncertain, do not interrupt the user's main task. Mention the
+NVIDIA catalog only as an optional aside after answering, or ask one concise
+clarifying question if the choice materially changes the work.
+
+## Instructions
+How to Help Users Find Skills - a Discovery Workflow
+
+This skill's first job is skill discovery. For NVIDIA-related requests, do a
+catalog check before using general web search, NVIDIA product docs, or general
+product knowledge as the main answer. Product documentation can help after the
+catalog check, but it is not a substitute for checking the NVIDIA skills catalog.
+
+Catalog check means one of:
+
+- `npx skills add nvidia/skills --list`
+- `https://github.com/NVIDIA/skills/tree/main/skills`
+- `https://build.nvidia.com/skills`
+- `https://raw.githubusercontent.com/NVIDIA/skills/main/skills.sh.json`
+
+1. Check whether the relevant NVIDIA skill is already installed or already in context. If it is, hand off to that skill instead of recommending install.
+2. Query the live catalog before naming a specific install target or giving the
+   main product answer. When shell access is available, attempt this command first:
+
+```bash
+npx skills add nvidia/skills --list
+```
+
+Use the fallback catalog sources only if the CLI is unavailable, blocked, or fails:
+- https://github.com/NVIDIA/skills/tree/main/skills
+- https://build.nvidia.com/skills
+- https://raw.githubusercontent.com/NVIDIA/skills/main/skills.sh.json
+
+Do not count a general web search, developer.nvidia.com product documentation,
+or docs.nvidia.com product documentation as the catalog check.
+
+3. Match the request against current skill names, descriptions, product groups, and skill cards. Prefer NVIDIA-verified catalog entries over memory.
+4. If a current catalog skill strongly matches, recommend it before continuing
+   with general product guidance. Recommend at most three skills, ordered by
+   confidence. For each, include: skill name, why it fits, install command, and
+   first useful prompt.
+5. Ask before installing. Do not run `npx skills add` unless the user approves.
+
+## Recommendation Format
+
+For a strong match that is not installed:
+
+```text
+The NVIDIA <product or skill family> skill could help with this. Would you like me to install <skill-name>?
+```
+
+Use the active agent target when known:
+
+```bash
+npx skills add nvidia/skills --skill <skill-name> --agent codex --global --yes
+npx skills add nvidia/skills --skill <skill-name> --agent claude-code --global --yes
+```
+
+If the agent target is unknown, omit `--agent` and let the CLI prompt:
+
+```bash
+npx skills add nvidia/skills --skill <skill-name> --global --yes
+```
+
+After install, tell the user to restart or reload the agent if their client
+does not pick up newly installed skills immediately.
+
+## Confidence Rules
+
+- High confidence: product name or distinctive intent maps cleanly to one
+  current catalog skill or skill family.
+- Medium confidence: taxonomy lane matches but several skills may apply. Offer
+  a short shortlist and ask which direction matches the user's task.
+- Low confidence: only generic wording matches. Do the user's task without
+  recommending an NVIDIA skill.
+
+Do not fabricate catalog entries or guess at skill names. If catalog lookup
+fails, say the catalog could not be checked and do not name a concrete slug or
+emit an `npx skills add ... --skill <name>` install command. Offer to share the
+catalog URL, retry lookup, or continue with general help.
+
+## When No Skills are Found
+
+Say that no strong NVIDIA catalog match was found, then either:
+1. search the broader ecosystem with npx skills find <query>, or
+2. offer to help directly without a skill, or
+3. suggest creating a new skill if the workflow is recurring.

--- a/skills/nvidia-skill-finder/agents/openai.yaml
+++ b/skills/nvidia-skill-finder/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "NVIDIA Skill Finder"
+  short_description: "Find and install relevant NVIDIA skills."
+  default_prompt: "Use $nvidia-skill-finder to find the right NVIDIA agent skill for my task."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/nvidia-skill-finder/evals/evals.json
+++ b/skills/nvidia-skill-finder/evals/evals.json
@@ -1,0 +1,223 @@
+[
+  {
+    "id": "nvidia-skill-finder-pos-vehicle-routing",
+    "question": "I need to solve a vehicle routing problem with time windows and capacity constraints. Is there an NVIDIA skill that can help?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies Decision Optimization as a strong NVIDIA taxonomy match, checks the live NVIDIA skills catalog, and recommends a current cuOpt routing skill rather than implementing a routing solver from memory.",
+    "expected_behavior": [
+      "Treats vehicle routing as a strong NVIDIA Decision Optimization signal",
+      "Checks the live NVIDIA catalog (e.g. `npx skills add nvidia/skills --list`) before naming a specific skill",
+      "Recommends a cuOpt routing-related skill if present in the catalog",
+      "Asks before installing the skill",
+      "Does not implement a routing solver before offering the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-gpu-pandas",
+    "question": "Can you help me accelerate my pandas ETL on GPUs?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies GPU DataFrames / Data Science as a strong NVIDIA taxonomy match, checks the live catalog, and recommends the current cuDF or RAPIDS-related skill if available.",
+    "expected_behavior": [
+      "Treats GPU pandas acceleration as a strong NVIDIA Data Science signal",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends a cuDF or accelerated-computing-cudf skill if present",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-openusd-optimization",
+    "question": "This OpenUSD scene loads slowly and uses too much VRAM. Is there a skill for optimizing it?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies OpenUSD performance tuning as a strong Physical AI / Omniverse signal, checks the live catalog, and recommends the current USD performance tuning skill if available \u2014 distinct from CAD-to-SimReady.",
+    "expected_behavior": [
+      "Treats OpenUSD scene optimization as a strong NVIDIA Physical AI signal",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends an Omniverse / OpenUSD performance tuning skill (e.g. omniverse-usd-performance-tuning) if present",
+      "Does not confuse this with CAD-to-SimReady conversion"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-dynamo-kv",
+    "question": "I want to set up KV-aware routing for an LLM serving endpoint.",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies KV-aware LLM routing as a strong NVIDIA Inference AI / Dynamo signal, checks the live catalog, and recommends a current Dynamo router skill if available.",
+    "expected_behavior": [
+      "Treats KV-aware LLM routing as a strong NVIDIA Inference AI signal",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends a Dynamo router skill (e.g. dynamo-router-starter) if present",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-dicom",
+    "question": "I need to convert a DICOM series into a volume and then run segmentation. Does NVIDIA have skills for that?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies DICOM and medical imaging segmentation as a strong Vision AI signal, checks the live catalog, and recommends current DICOM / NVIDIA medical AI skills if available.",
+    "expected_behavior": [
+      "Treats DICOM and segmentation as a strong NVIDIA Vision AI signal",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends current DICOM or medical imaging segmentation skills (e.g. dicom-series-to-volume, nv-segment-ct, nv-segment-ctmr) if present",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-cad-to-simready",
+    "question": "I have a CAD assembly that needs to become a SimReady OpenUSD asset for simulation.",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies CAD-to-SimReady as a strong Physical AI / Omniverse signal, checks the live NVIDIA catalog, and recommends the current SimReady or Omniverse CAD workflow skill if available.",
+    "expected_behavior": [
+      "Treats CAD-to-SimReady as a strong NVIDIA Physical AI signal",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends a SimReady or Omniverse CAD workflow skill (e.g. omniverse-cad-to-simready) if present",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-multigpu-training",
+    "question": "Help me train a large language model across multiple GPUs with NeMo or Megatron.",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent identifies multi-GPU LLM training and NeMo/Megatron as strong NVIDIA Training AI signals, checks the live catalog, and recommends a current training workflow skill if available.",
+    "expected_behavior": [
+      "Treats NeMo, Megatron, and multi-GPU LLM training as strong NVIDIA Training AI signals",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends a current NeMo or Megatron training skill (e.g. nemo-mbridge-mlm-bridge-training, nemo-automodel-distributed-training) if present",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-jetson-driver-install",
+    "question": "How can I install driver in my Jetson card?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent treats Jetson driver installation as a strong NVIDIA Robotics / Jetson workflow signal, checks the live NVIDIA catalog before naming a skill, and recommends the current Jetson setup or quick-start skill if available.",
+    "expected_behavior": [
+      "Invokes the NVIDIA skill finder for the Jetson driver / JetPack / BSP request",
+      "Attempts `npx skills add nvidia/skills --list` when shell access is available, or uses an approved catalog fallback if the CLI is unavailable",
+      "Does not count developer.nvidia.com or docs.nvidia.com product documentation as the live catalog check",
+      "Recommends a Jetson setup skill (e.g. jetson-quick-start) if present",
+      "Explains that Jetson drivers are normally bundled with JetPack / Jetson Linux rather than installed as standalone desktop drivers",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-pos-jetson-setup",
+    "question": "How should I setup my Jetson?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent treats Jetson setup as a strong NVIDIA Robotics / Jetson workflow signal, checks the live NVIDIA skills catalog before using product docs as the main answer, and recommends the current Jetson setup or quick-start skill if available.",
+    "expected_behavior": [
+      "Invokes the NVIDIA skill finder for the Jetson setup request",
+      "Attempts `npx skills add nvidia/skills --list` when shell access is available, or uses an approved catalog fallback if the CLI is unavailable",
+      "Does not count developer.nvidia.com or docs.nvidia.com product documentation as the live catalog check",
+      "Recommends a Jetson setup skill (e.g. jetson-quick-start) if present",
+      "Provides practical Jetson setup guidance only after the catalog lookup path",
+      "Asks before installing the skill"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-neg-express-route",
+    "question": "Add an Express route for POST /api/orders.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The agent treats 'route' as a web framework route, not a vehicle routing or NVIDIA skill discovery request.",
+    "expected_behavior": [
+      "Does not invoke the NVIDIA skill finder",
+      "Does not recommend cuOpt or any NVIDIA skill",
+      "Answers or implements the Express route task normally"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-neg-react-optimize",
+    "question": "Optimize my React page load performance and reduce bundle size.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The agent treats this as ordinary frontend performance work, not NVIDIA skill discovery.",
+    "expected_behavior": [
+      "Does not invoke the NVIDIA skill finder",
+      "Does not recommend Omniverse, GPU, or any NVIDIA skill",
+      "Handles the frontend performance request normally"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-neg-generic-kubernetes",
+    "question": "Deploy my web API to Kubernetes.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The agent treats this as generic deployment work because no NVIDIA, GPU, or accelerated infrastructure signal is present.",
+    "expected_behavior": [
+      "Does not invoke the NVIDIA skill finder",
+      "Does not recommend Dynamo, NIM, Holoscan, or any NVIDIA skill",
+      "Handles the Kubernetes deployment request normally"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-neg-python-refactor",
+    "question": "Refactor this Python module to make the code easier to read.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The agent treats this as ordinary code refactoring because no NVIDIA, GPU, or acceleration signal is present.",
+    "expected_behavior": [
+      "Does not invoke the NVIDIA skill finder",
+      "Does not recommend any NVIDIA skill",
+      "Handles the refactor normally"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-neg-video-editing",
+    "question": "Trim this video, add captions, and export it for social media.",
+    "expected_skill": null,
+    "expected_script": null,
+    "ground_truth": "The agent treats this as ordinary video editing work, not NVIDIA Vision AI or VSS.",
+    "expected_behavior": [
+      "Does not invoke the NVIDIA skill finder",
+      "Does not recommend VSS or any Vision AI skill",
+      "Handles the video editing request normally"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-diff-browse-no-keywords",
+    "question": "Show me what NVIDIA skills exist. I want to browse what's available.",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent treats this as a no-keyword browse request: it offers to list NVIDIA skill domains or fetches the catalog index, rather than dumping every skill or refusing.",
+    "expected_behavior": [
+      "Invokes the NVIDIA skill finder",
+      "Lists NVIDIA skill domains or asks which domain the user wants",
+      "Optionally fetches the catalog index (e.g. skills.sh.json)",
+      "Does not dump every skill at once"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-diff-deep-research",
+    "question": "I want to do deep research on a technical topic and synthesize what's known. Any NVIDIA skill for that?",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent routes 'deep research and synthesize' to the AI-Q research skill rather than to RAG or retrieval skills.",
+    "expected_behavior": [
+      "Invokes the NVIDIA skill finder",
+      "Checks the live NVIDIA catalog before naming a specific skill",
+      "Recommends an AI-Q research skill (e.g. aiq-research) for technical synthesis",
+      "Does not recommend rag-blueprint, nemo-retriever, or nemo-rl-auto-research as the primary fit"
+    ]
+  },
+  {
+    "id": "nvidia-skill-finder-diff-bare-invocation",
+    "question": "Help me find an NVIDIA skill.",
+    "expected_skill": "nvidia-skill-finder",
+    "expected_script": null,
+    "ground_truth": "The agent treats the bare invocation as low-signal: it asks a clarifying question about the user's task or offers to browse domains, rather than dumping the catalog or refusing.",
+    "expected_behavior": [
+      "Invokes the NVIDIA skill finder",
+      "Asks a clarifying question about the user's task, or offers domain browse as a path",
+      "Does not dump every skill at once",
+      "Does not install a skill without consent"
+    ]
+  }
+]

--- a/skills/nvidia-skill-finder/references/taxonomy-routing.md
+++ b/skills/nvidia-skill-finder/references/taxonomy-routing.md
@@ -1,0 +1,83 @@
+# NVIDIA Taxonomy Routing
+
+Use this reference after `nvidia-skill-finder` loads. It is a stable routing
+lens, not a full skill catalog. Always check the live catalog before naming a
+specific skill to install.
+
+## Stable Catalog Lanes
+
+Agentic AI: RAG, evaluation, tool use, policy, sandboxing, agent workflow
+automation, AI-Q, NemoClaw, NeMo Retriever.
+
+Physical AI: autonomy, simulation, synthetic data, embodied AI, OpenUSD,
+Omniverse, CAD-to-SimReady, neural reconstruction, defect image generation,
+video data augmentation, and infrastructure for physical-world AI workloads.
+
+Robotics: Jetson driver/JetPack setup, Jetson Linux/L4T, board support packages
+(BSPs), image flashing, SDK Manager, Force Recovery Mode, camera/fan/pinmux/
+PCIe/custom hardware configuration, carrier derivation, image validation, and
+robot development workflows.
+
+Vision AI: video analytics, visual search, summarization, alerts, real-time
+understanding, DeepStream, VSS, TAO vision/model workflows, DICOM and medical
+imaging workflows.
+
+Conversational AI: speech, voice agents, clinical ASR, ASR/TTS/NMT workflows.
+
+Simulation and Modeling: weather, climate, physics ML, physical systems, and
+scientific simulation workflows.
+
+Data Science: GPU DataFrames, pandas acceleration, RAPIDS/cuDF, multi-GPU
+NumPy/SciPy with cuPyNumeric, parallel data loading.
+
+Training AI: distributed training, model onboarding, Megatron-Core, NeMo,
+large-scale LLM/VLM training, recipe selection, training performance tuning.
+
+Inference AI: serving, router modes, LLM inference, Dynamo, NIM, runtime
+performance, disaggregated serving, KV-aware routing.
+
+Decision Optimization: vehicle routing, routing formulation, scheduling,
+resource allocation, LP, MILP, QP, optimization APIs, optimization servers.
+
+GPU Development: CUDA-adjacent development, kernel authoring, autotuning,
+profiling, framework integration.
+
+Quantum Computing: CUDA-Q and hybrid quantum-classical development.
+
+Infrastructure: accelerated workload setup, cluster/runtime/service operations,
+GPU-enabled deployment, Holoscan setup, Jetson host setup, and TAO platform runs.
+
+Networking: accelerated infrastructure networking, data center or edge network
+configuration, Jetson MGBE workflows, and cluster network troubleshooting.
+
+## Matching Heuristic
+
+1. Identify whether the user's task has a product signal, taxonomy signal, or
+   distinctive intent signal.
+2. If the signal is product-specific, search the catalog using the product
+   name and task verb.
+3. If the signal is taxonomy-only, search the catalog by taxonomy lane plus the
+   user's concrete artifact or workflow.
+4. If multiple skills match, prefer the skill whose description matches the
+   user's interface and phase: install, formulate, implement, deploy,
+   validate, troubleshoot, or optimize.
+5. If the catalog search returns no strong match, say no matching NVIDIA skill
+   was found and continue with general help.
+
+## False-Positive Checks
+
+Do not route generic software tasks to NVIDIA only because they contain common
+words:
+
+- route: HTTP routes, web framework routes, load balancer routes without GPU or
+  NVIDIA context
+- optimize: React, CSS, SQL, bundle size, generic Python speedups without GPU
+  or accelerated-computing context
+- deploy: ordinary Kubernetes, cloud service, web app, or CI/CD deployment
+- AI: generic chatbot, generic prompt engineering, or non-NVIDIA model use
+- video: ordinary trimming, captions, export, or social-media editing
+- data science: local pandas cleanup, plotting, or sklearn work without GPU,
+  scale, RAPIDS, cuDF, or accelerated-computing context
+
+When in doubt, answer the user's task first and offer NVIDIA skill discovery as
+an optional next step.

--- a/skills/nvidia-skill-finder/skill-card.md
+++ b/skills/nvidia-skill-finder/skill-card.md
@@ -1,0 +1,58 @@
+## Description: <br>
+Finds and installs relevant NVIDIA agent skills from the live NVIDIA skills catalog. Uses stable NVIDIA product and taxonomy categories as the implicit trigger surface, then checks the remote catalog for current skill-level matches. <br>
+
+This skill is ready for commercial/non-commercial use after NVIDIA signing and release validation. <br>
+
+## Owner
+NVIDIA <br>
+
+### License/Terms of Use: <br>
+CC-BY-4.0 <br>
+
+## Use Case: <br>
+Developers, researchers, and operators who are working in NVIDIA-adjacent areas and may benefit from an NVIDIA skill that is not installed yet. The skill routes from broad user intent such as GPU acceleration, Decision Optimization, Physical AI, Vision AI, Training AI, Inference AI, Data Science on GPUs, Quantum, and accelerated infrastructure to live catalog lookup and installation guidance. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Over-triggering could interrupt generic software tasks that use broad words such as route, optimize, deploy, AI, data science, or infrastructure. <br>
+Mitigation: The skill requires NVIDIA, GPU/accelerated-computing, or distinctive catalog intent signals before recommending a skill. Negative eval cases cover common false positives. <br>
+
+Risk: Recommending stale or renamed skills could frustrate users or install the wrong capability. <br>
+Mitigation: The skill instructs agents to query the live NVIDIA skills catalog before naming a specific install target and treats the local taxonomy reference only as fallback guidance. <br>
+
+Risk: Installing a skill changes the user's agent behavior. <br>
+Mitigation: The skill asks for explicit user approval before running `npx skills add`. <br>
+
+## Reference(s): <br>
+- [NVIDIA Skills Catalog](https://github.com/NVIDIA/skills) <br>
+- [NVIDIA Skills on build.nvidia.com](https://build.nvidia.com/skills) <br>
+- [skills.sh grouping config](https://raw.githubusercontent.com/NVIDIA/skills/main/skills.sh.json) <br>
+- [Taxonomy Routing Reference](references/taxonomy-routing.md) <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Skill recommendation, installation instructions, clarification question] <br>
+**Output Format:** [Markdown with inline bash code blocks] <br>
+**Output Parameters:** [1D] <br>
+**Other Properties Related to Output:** [No files or external systems are modified unless the user approves installation.] <br>
+
+## Evaluation Tasks: <br>
+Evaluation dataset covers positive discovery for vehicle routing, GPU pandas acceleration, OpenUSD optimization, Dynamo/KV-aware routing, DICOM workflows, CAD-to-SimReady, and multi-GPU LLM training, plus negative cases for Express routes, React performance, generic Kubernetes deployment, ordinary video editing, and generic Python refactoring. <br>
+
+## Evaluation Metrics Used: <br>
+Reported benchmark dimensions: <br>
+- Discoverability: Checks that the skill activates for stable NVIDIA taxonomy/product signals. <br>
+- False-positive avoidance: Checks that generic route, optimize, deploy, video editing, and refactor tasks do not trigger NVIDIA skill recommendations. <br>
+- Correctness: Checks that recommendations are based on live catalog lookup before naming a skill. <br>
+- Safety: Checks that installation is proposed but not run without explicit user approval. <br>
+- Efficiency: Checks that the skill does not mirror the full remote catalog in context. <br>
+
+## Skill Version(s): <br>
+1.0.0 (source: frontmatter/catalog submission) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and has established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with applicable terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). <br>


### PR DESCRIPTION
## Summary

- Adds `skills/nvidia-skill-finder/` directly to the catalog as a router/discovery skill (no `components.d` upstream)
- Registers the directory in `catalog-exceptions.yml` so the current orphan-pruning sync logic preserves this catalog-only skill
- Updates `benchmarks.json` from the staged `BENCHMARK.md`

This follows Moshe's guidance that the skill belongs in the catalog itself rather than as a synced component. Because newer sync logic prunes unregistered `skills/` directories, this PR explicitly adds `nvidia-skill-finder` to `catalog-exceptions.yml`. Future updates are direct PRs here plus a fresh `/nvskills-ci` run.

## Sync and signing notes

- No `components.d` entry is added, so normal rsync sync will not overwrite this skill.
- `catalog-exceptions.yml` protects it from orphan pruning.
- The exception does not bypass compliance: the skill still needs `skill.oms.sig`, `skill-card.md`, and eval data.
- `/nvskills-ci` should generate the signature commit and refresh generated artifacts. Before merge, verify that commit landed and that no unsigned content commit came after it.
- `benchmarks.json` is regenerated from `BENCHMARK.md`. If `/nvskills-ci` rewrites `BENCHMARK.md`, re-run `aggregate_benchmarks.py` so `benchmarks.json` still matches and the metadata check stays green.

## Follow-up

- Once all `/nvskills-ci` checks pass and this merges, we will create a separate PR to include `nvidia-skill-finder` in the plugin bundle.

## Post-merge checklist

1. Comment `/nvskills-ci` on this PR (maintainer/admin) to generate `skill.oms.sig`, refresh `skill-card.md`, and regenerate `BENCHMARK.md`
2. Verify the bot's signature commit lands on the PR branch
3. Confirm no unsigned commits land after the signature commit
4. Merge once CI is green and signatures are in place

## Test plan

- [ ] `/nvskills-ci` completes and pushes signature commit
- [ ] `skill.oms.sig`, `skill-card.md`, and `evals/evals.json` present after CI
- [ ] `benchmarks.json` re-verified against the post-`/nvskills-ci` `BENCHMARK.md`
- [ ] Content integrity check passes after signature commit
- [ ] `npx skills add nvidia/skills --skill nvidia-skill-finder --list` shows the skill after merge