### PR TITLE
docs: replace missing DICOM make target

### DIFF
--- a/skills/dicom-metadata-extract/AGENTS.md
+++ b/skills/dicom-metadata-extract/AGENTS.md
@@ -12,7 +12,9 @@ Rules:
 Run:
 
 ```bash
-make run-skill SKILL=dicom_metadata_extract \
-  FIXTURE=skills/dicom-metadata-extract/fixtures/sample_ct.dcm \
-  OUT=runs/dicom_metadata_demo
+python skills/dicom-metadata-extract/fixtures/generate_sample.py
+mkdir -p runs/dicom_metadata_demo
+python skills/dicom-metadata-extract/scripts/extract_metadata.py \
+  skills/dicom-metadata-extract/fixtures/sample_ct.dcm \
+  --output runs/dicom_metadata_demo/result.json
 ```


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Replace the undocumented `make run-skill` command with the repository-contained fixture generator and metadata extractor flow. Both scripts were run end to end: the fixture was generated and metadata extraction returned modality `CT` with the expected path. The modified guide reports zero broken bindings under attest.

This docs-only correction was found with the attest static instruction-binding scan.
