### PR TITLE
Add Cortex to the per-agent install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent cl
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent codex
 ```
 
+**Cortex**
+
+```bash
+npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent cortex
+```
+
 **Cursor**
 
 ```bash


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## What

Adds a Cortex block to the README's "Install for a Specific Agent" section, between Codex and Cursor (alphabetical, matching the section's order).

Requested by the ISV partner team (Snowflake). No engineering involved: the `skills` CLI already supports `--agent cortex` (project path `.cortex/skills/`, global `~/.snowflake/cortex/skills/`, per the CLI's Supported Agents table). The exact command was verified end-to-end against the live catalog: it installs cuopt-numerical-optimization-api into `.cortex/skills/` cleanly.

Static README section (outside the auto-generated table markers), so this edit survives syncs.