### PR TITLE
docs: add CLI-version requirement + install troubleshooting (VDR item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ npx skills add nvidia/skills
 
 The CLI runs through `npx` and prompts you to choose a skill and install destination. You do not need to clone this repo or copy skill folders by hand.
 
-The skill is available the next time your agent loads skills and encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API.
+> **Requires a current `skills` CLI (v1.5.16 or newer).** Installing via `npx skills@latest add nvidia/skills` always uses the latest. On older CLIs (v1.5.15 and earlier), skills may install but not appear in Claude Code — see [Troubleshooting](docs/advanced-install.mdx#troubleshooting).
+
+The skill is available the next time your agent loads skills and encounters a relevant task. For example, ask your agent to "solve a linear programming problem with cuOpt" and the skill guides it through the cuOpt Python API. In Claude Code, run `/reload-skills` to load newly installed skills in your current session.
 
 ### Install One Skill Without Prompts
 

--- a/docs/advanced-install.mdx
+++ b/docs/advanced-install.mdx
@@ -8,6 +8,7 @@ Use this guide when you need more control than the root README quickstart: non-i
 ## Requirements
 
 - Node.js and npm available on your PATH. The examples use `npx`, which ships with npm.
+- A current `skills` CLI — **version 1.5.16 or newer**. Running via `npx skills@latest` always uses the latest. Versions 1.5.15 and earlier do not create the Claude Code skills link, so installed skills won't appear in Claude Code (Codex and other agents that read `.agents/skills/` directly are unaffected).
 - Access to `https://github.com/NVIDIA/skills`.
 - An AI agent that supports Agent Skills, such as Claude Code, Codex, Cursor, OpenCode, Windsurf, Gemini CLI, or another compatible agent.
 
@@ -106,3 +107,21 @@ Common global locations are:
 | Cursor | `~/.cursor/skills/` |
 
 Manual installs do not participate in `npx skills update`, so use them only as a fallback.
+
+## Troubleshooting
+
+### Installed skills don't appear in your agent
+
+1. **Check your CLI version first.** Run `npx skills --version`. If it is older than **1.5.16**, upgrade by installing via `npx skills@latest ...`. Versions 1.5.15 and earlier fail to link skills into Claude Code's `.claude/skills/` directory, so the files install but the agent never sees them.
+2. **Reload skills in your session.** In Claude Code, run `/reload-skills` (or restart the session) so newly installed skills are picked up.
+
+### Verify your agent can see an installed skill
+
+After installing `<skill-name>`, confirm it landed where your agent looks:
+
+| Agent | Check |
+|-------|-------|
+| Claude Code | `.claude/skills/<skill-name>/SKILL.md` resolves (project) or `~/.claude/skills/<skill-name>/SKILL.md` (global); the skill also appears in `/skills`. |
+| Codex | `.agents/skills/<skill-name>/SKILL.md` resolves — Codex reads `.agents/skills/` directly, so no per-agent link is needed. |
+
+If `.claude/skills/<skill-name>` is missing or empty on Claude Code, it is almost always the stale-CLI issue above — upgrade to 1.5.16+ and re-run the install.


### PR DESCRIPTION
## What & why

The Verified Skills VDR flagged that skills install but do not appear in **Claude Code**. Root cause was an **upstream `skills` CLI bug, fixed in v1.5.16**: CLIs ≤ 1.5.15 skip creating the `.claude/skills` link, so files land in `.agents/skills/` but Claude Code never sees them. Codex reads `.agents/skills/` directly and was unaffected — which is why the VDR saw "works for Codex, not Claude Code."

No code/repo change is needed (the fix is upstream); the gap is **docs telling users to be on a current CLI**.

## Changes

**`README.md`**
- Quickstart callout: requires `skills` CLI **≥ 1.5.16** (use `npx skills@latest`), with a pointer to Troubleshooting.
- `/reload-skills` tip to load newly installed skills in-session.

**`docs/advanced-install.mdx`**
- New Requirements bullet for the ≥ 1.5.16 CLI floor.
- New **Troubleshooting** section: check CLI version first, reload tip, and a per-agent "verify your agent can see the skill" table (Claude Code vs Codex).

## Notes
- Addresses VDR action-plan **item 2** (docs). Item 1 (the symlink failure) is fixed upstream in CLI 1.5.16 — verified on macOS + x86_64 Linux.
- Docs-only; no skill content touched, so no re-sign needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)