### PR TITLE
feat: register NeMo Relay skills

### DIFF
--- a/components.d/nemo-relay.yml
+++ b/components.d/nemo-relay.yml
@@ -1,0 +1,24 @@
+name: NeMo Relay
+repo: NVIDIA/NeMo-Relay
+description: Skills to help get started and use NeMo Relay - a runtime for instrumenting and controlling AI agents across harnesses, applications, and frameworks.
+skills:
+  - path: skills/nemo-relay-install/
+    catalog_dir: nemo-relay-install
+  - path: skills/nemo-relay-get-started/
+    catalog_dir: nemo-relay-get-started
+  - path: skills/nemo-relay-instrument-calls/
+    catalog_dir: nemo-relay-instrument-calls
+  - path: skills/nemo-relay-instrument-context-isolation/
+    catalog_dir: nemo-relay-instrument-context-isolation
+  - path: skills/nemo-relay-instrument-typed-wrappers/
+    catalog_dir: nemo-relay-instrument-typed-wrappers
+  - path: skills/nemo-relay-plugin-adaptive-tuning/
+    catalog_dir: nemo-relay-plugin-adaptive-tuning
+  - path: skills/nemo-relay-plugin-build/
+    catalog_dir: nemo-relay-plugin-build
+  - path: skills/nemo-relay-plugin-observability/
+    catalog_dir: nemo-relay-plugin-observability
+  - path: skills/nemo-relay-migrate-from-flow/
+    catalog_dir: nemo-relay-migrate-from-flow
+  - path: skills/nemo-relay-debug-runtime-integration/
+    catalog_dir: nemo-relay-debug-runtime-integration


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

Not applicable; this is a new product onboarding.

## Registration details

Registers the ten release-facing NeMo Relay skills from `NVIDIA/NeMo-Relay` as individual top-level catalog entries. The entries are ordered by the expected developer flow: install, get started, instrument, configure plugins, migrate, and debug.

## Validation

- Parsed `components.d/nemo-relay.yml` as YAML and verified all required fields.
- Confirmed every `catalog_dir` is unique across `components.d`.
- Confirmed every registered source directory exists and contains `SKILL.md`.
- Confirmed each skill's frontmatter name matches its catalog directory and includes a description.
- Confirmed the source and catalog branches were current with their respective upstream `main` branches before committing.
