### PR TITLE
Register nemotron-asr-finetune skills

### DIFF
--- a/components.d/nemotron-speech.yml
+++ b/components.d/nemotron-speech.yml
@@ -6,3 +6,5 @@ links:
 skills:
   - path: skills/nemotron-speech/
     catalog_dir: nemotron-speech
+  - path: skills/nemotron-asr-finetune/
+    catalog_dir: nemotron-asr-finetune


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)
- [ ] Register new skills in existing components.d/nemotron-speech.yml

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
