### PR TITLE
ci: require nvskills status for skill changes

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -5,13 +5,7 @@ on:
     types: [created]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - "skills/**"
-      - "team-skills/**"
-      - "rules/team-rules/**"
-      - "plugins/**"
   push:
-  status:
 
 jobs:
   request:
@@ -22,9 +16,7 @@ jobs:
       (github.event_name == 'push' &&
         github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
         startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures')) ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'status' &&
-        github.event.context == (vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI'))
+      github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,7 +3,15 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - "skills/**"
+      - "team-skills/**"
+      - "rules/team-rules/**"
+      - "plugins/**"
   push:
+  status:
 
 jobs:
   request:
@@ -13,10 +21,14 @@ jobs:
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
       (github.event_name == 'push' &&
         github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
-        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures')) ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'status' &&
+        github.event.context == (vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI'))
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -13,12 +13,7 @@ permissions:
 
 jobs:
   require-nvskills-ci:
-    if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' &&
-        !startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures')) ||
-      (github.event_name == 'status' &&
-        github.event.context == (vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI'))
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     concurrency:
       group: nvskills-ci-required-${{ github.repository }}-${{ github.event.pull_request.number || github.event.sha || github.sha }}
@@ -28,8 +23,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
         run: |
@@ -44,6 +39,16 @@ jobs:
             printf '%s\n' "$@" | tee -a "${GITHUB_STEP_SUMMARY}"
           }
 
+          case "${HEAD_REF}" in
+            automated/sync-skills|bot/regenerate-skill-metadata)
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Skipped: bot-managed branch \`${HEAD_REF}\` is exempt from this check."
+              exit 0
+              ;;
+          esac
+
           github_get() {
             curl -fsSL \
               -H "Authorization: Bearer ${GH_TOKEN}" \
@@ -51,20 +56,6 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "$1"
           }
-
-          if [ "${EVENT_NAME}" != "pull_request" ]; then
-            prs_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${head_sha}/pulls?per_page=100")"
-            pr_number="$(printf '%s' "${prs_json}" | jq -r \
-              --arg sha "${head_sha}" \
-              '[.[] | select(.state == "open" and (.head.sha | ascii_downcase) == $sha)][0].number // empty')"
-            if [ -z "${pr_number}" ]; then
-              append_summary \
-                "## NVSkills CI required status" \
-                "" \
-                "Skipped: no open pull request is associated with this event."
-              exit 0
-            fi
-          fi
 
           if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
             echo "Pull request metadata is incomplete."
@@ -122,7 +113,10 @@ jobs:
             "Failed: \`${STATUS_CONTEXT}\` status is \`${status_state}\` for \`${head_sha}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
-            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
+            "" \
+            "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
+            "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
           if [ -n "${target_url}" ]; then
             append_summary "" "Current NVSkills CI run: ${target_url}"
           fi

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -9,8 +9,125 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  statuses: read
 
 jobs:
+  require-nvskills-ci:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures')) ||
+      (github.event_name == 'status' &&
+        github.event.context == (vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: nvskills-ci-required-${{ github.repository }}-${{ github.event.pull_request.number || github.event.sha || github.sha }}
+      cancel-in-progress: true
+    steps:
+      - name: Require NVSkills CI for watched changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
+          STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
+        run: |
+          set -euo pipefail
+
+          owner="${REPO%%/*}"
+          repo="${REPO#*/}"
+          head_sha="$(printf '%s' "${HEAD_SHA}" | tr '[:upper:]' '[:lower:]')"
+          pr_number="${PR_NUMBER}"
+
+          append_summary() {
+            printf '%s\n' "$@" | tee -a "${GITHUB_STEP_SUMMARY}"
+          }
+
+          github_get() {
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1"
+          }
+
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            prs_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${head_sha}/pulls?per_page=100")"
+            pr_number="$(printf '%s' "${prs_json}" | jq -r \
+              --arg sha "${head_sha}" \
+              '[.[] | select(.state == "open" and (.head.sha | ascii_downcase) == $sha)][0].number // empty')"
+            if [ -z "${pr_number}" ]; then
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Skipped: no open pull request is associated with this event."
+              exit 0
+            fi
+          fi
+
+          if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
+            echo "Pull request metadata is incomplete."
+            exit 1
+          fi
+
+          has_watched_change=false
+          page=1
+          while true; do
+            files_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=100&page=${page}")"
+            if printf '%s' "${files_json}" | jq -e '
+              any(.[]; .filename |
+                startswith("skills/") or
+                startswith("team-skills/") or
+                startswith("rules/team-rules/") or
+                startswith("plugins/")
+              )
+            ' >/dev/null; then
+              has_watched_change=true
+              break
+            fi
+            if [ "$(printf '%s' "${files_json}" | jq 'length')" -lt 100 ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          if [ "${has_watched_change}" != "true" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Skipped: PR #${pr_number} has no changes under watched NVSkills paths."
+            exit 0
+          fi
+
+          statuses_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${head_sha}/statuses?per_page=100")"
+          status_state="$(printf '%s' "${statuses_json}" | jq -r \
+            --arg context "${STATUS_CONTEXT}" \
+            '[.[] | select(.context == $context)][0].state // "missing"')"
+          target_url="$(printf '%s' "${statuses_json}" | jq -r \
+            --arg context "${STATUS_CONTEXT}" \
+            '[.[] | select(.context == $context)][0].target_url // ""')"
+
+          if [ "${status_state}" = "success" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Passed: \`${STATUS_CONTEXT}\` succeeded for \`${head_sha}\`."
+            exit 0
+          fi
+
+          append_summary \
+            "## NVSkills CI required status" \
+            "" \
+            "Failed: \`${STATUS_CONTEXT}\` status is \`${status_state}\` for \`${head_sha}\`." \
+            "" \
+            "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
+            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+          if [ -n "${target_url}" ]; then
+            append_summary "" "Current NVSkills CI run: ${target_url}"
+          fi
+          exit 1
+
   request:
     if: >
       (github.event_name == 'issue_comment' &&

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -67,12 +67,13 @@ jobs:
           while true; do
             files_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=100&page=${page}")"
             if printf '%s' "${files_json}" | jq -e '
-              any(.[]; .filename |
+              def watched:
+                (. // "") |
                 startswith("skills/") or
                 startswith("team-skills/") or
                 startswith("rules/team-rules/") or
-                startswith("plugins/")
-              )
+                startswith("plugins/");
+              any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
               break
@@ -91,32 +92,110 @@ jobs:
             exit 0
           fi
 
-          statuses_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${head_sha}/statuses?per_page=100")"
-          status_state="$(printf '%s' "${statuses_json}" | jq -r \
-            --arg context "${STATUS_CONTEXT}" \
-            '[.[] | select(.context == $context)][0].state // "missing"')"
-          target_url="$(printf '%s' "${statuses_json}" | jq -r \
-            --arg context "${STATUS_CONTEXT}" \
-            '[.[] | select(.context == $context)][0].target_url // ""')"
+          commit_shas_file="$(mktemp)"
+          trap 'rm -f "${commit_shas_file}"' EXIT
+
+          page=1
+          while true; do
+            commits_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/commits?per_page=100&page=${page}")"
+            printf '%s' "${commits_json}" | jq -r '.[].sha | ascii_downcase' >> "${commit_shas_file}"
+            if [ "$(printf '%s' "${commits_json}" | jq 'length')" -lt 100 ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          mapfile -t commit_shas < "${commit_shas_file}"
+          if [ "${#commit_shas[@]}" -eq 0 ]; then
+            echo "Pull request commits could not be resolved."
+            exit 1
+          fi
+
+          latest_watched_sha=""
+          latest_watched_path=""
+          for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
+            commit_sha="${commit_shas[idx]}"
+            commit_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${commit_sha}")"
+            watched_path="$(printf '%s' "${commit_json}" | jq -r '
+              def watched:
+                (. // "") |
+                startswith("skills/") or
+                startswith("team-skills/") or
+                startswith("rules/team-rules/") or
+                startswith("plugins/");
+              [
+                .files[]? |
+                select((.filename | watched) or (.previous_filename? | watched)) |
+                (.filename // .previous_filename)
+              ][0] // empty
+            ')"
+            if [ -n "${watched_path}" ]; then
+              latest_watched_sha="${commit_sha}"
+              latest_watched_path="${watched_path}"
+              break
+            fi
+          done
+
+          if [ -z "${latest_watched_sha}" ]; then
+            append_summary \
+              "## NVSkills CI required status" \
+              "" \
+              "Skipped: PR #${pr_number} has no commits that changed watched NVSkills paths."
+            exit 0
+          fi
+
+          status_sha=""
+          status_state="missing"
+          target_url=""
+          for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
+            commit_sha="${commit_shas[idx]}"
+            statuses_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${commit_sha}/statuses?per_page=100")"
+            candidate_state="$(printf '%s' "${statuses_json}" | jq -r \
+              --arg context "${STATUS_CONTEXT}" \
+              '[.[] | select(.context == $context)][0].state // "missing"')"
+            if [ "${candidate_state}" != "missing" ]; then
+              status_sha="${commit_sha}"
+              status_state="${candidate_state}"
+              target_url="$(printf '%s' "${statuses_json}" | jq -r \
+                --arg context "${STATUS_CONTEXT}" \
+                '[.[] | select(.context == $context)][0].target_url // ""')"
+              break
+            fi
+            if [ "${commit_sha}" = "${latest_watched_sha}" ]; then
+              break
+            fi
+          done
 
           if [ "${status_state}" = "success" ]; then
             append_summary \
               "## NVSkills CI required status" \
               "" \
-              "Passed: \`${STATUS_CONTEXT}\` succeeded for \`${head_sha}\`."
+              "Passed: \`${STATUS_CONTEXT}\` succeeded for \`${status_sha}\`." \
+              "" \
+              "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
+            if [ "${status_sha}" != "${head_sha}" ]; then
+              append_summary \
+                "" \
+                "PR head \`${head_sha}\` has only trailing changes that do not require a fresh NVSkills CI status."
+            fi
             exit 0
           fi
 
           append_summary \
             "## NVSkills CI required status" \
             "" \
-            "Failed: \`${STATUS_CONTEXT}\` status is \`${status_state}\` for \`${head_sha}\`." \
+            "Failed: \`${STATUS_CONTEXT}\` status is \`${status_state}\` for the latest relevant commit." \
+            "" \
+            "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
             "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
             "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
+          if [ -n "${status_sha}" ]; then
+            append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
+          fi
           if [ -n "${target_url}" ]; then
             append_summary "" "Current NVSkills CI run: ${target_url}"
           fi


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->


## Summary
- Add a reusable workflow guard that fails when watched skill paths changed but the current PR head SHA does not have a successful `NVSkills CI` status.
- The guard covers `skills/`, `team-skills/`, `rules/team-rules/`, and `plugins/`.
- Keeps the existing `/nvskills-ci` dispatch flow unchanged.

## Validation
- Parsed `.github/workflows/team-request.yml` as YAML
- Ran `bash -n` on the inline guard script
- Ran `git diff --check`
