### PR TITLE
docs: sharpen README opening and add discoverability checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,18 @@ Avoid agent-specific paths in the repo (`.claude/skills/`, `.codex/skills/`, `.c
 
 At install time, your tooling or packaging can copy or symlink from `skills/` into the appropriate agent discovery locations (for example `.agents/skills/`, `.claude/skills/`, `.codex/skills/`) as required by each tool.
 
+## Discoverability Checklist (Source Repos)
+
+GitHub search ranks repositories on metadata and engagement, not just content. Before (or right after) onboarding your skills to the catalog, check your source repo:
+
+- [ ] **Repo description** names what developers search for: the product, the workflow, and "agent skills" (for example, "Agent skills for video search and summarization with VLMs and RAG"), not just the product name.
+- [ ] **GitHub topics** are set (Settings → edit topics): include `agent-skills` plus your domain terms (`robotics`, `video-understanding`, `synthetic-data`, ...). Repos with no topics do not surface in topic browsing or filtered search.
+- [ ] **README opens with a two-sentence value proposition** using those same search terms, before badges or tables of contents.
+- [ ] **License is detected by GitHub**: the repo sidebar should show your license name. If it shows "Other" or "View license", GitHub could not parse your license file and the repo is excluded from license-filtered searches.
+- [ ] **Social preview image** is set (Settings → Social preview, 1280×640) so shared links render a card instead of a blank tile.
+
+These apply to the *source* repo; the catalog repo's own metadata is maintained by the catalog team.
+
 ## IP Review and License (External Skills)
 
 For skills published to `github.com/nvidia/skills`, NVIDIA contributors confirm three things per onboarding PR:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # NVIDIA Agent Skills
 
-**Official, NVIDIA-verified skills for AI agents.**
+**Official, NVIDIA-verified Agent Skills for Claude Code, Codex, and other coding agents.**
 
 [![NVIDIA](https://img.shields.io/badge/NVIDIA-Verified-76B900?style=flat&logo=nvidia&logoColor=white)](https://nvidia.com)
 [![Agent Skills Spec](https://img.shields.io/badge/Agent%20Skills-Specification-blue)](https://agentskills.io)
@@ -15,7 +15,7 @@
 
 ---
 
-Skills are portable instruction sets that teach AI agents how to use NVIDIA software optimally, including CUDA-X libraries, AI Blueprints, and platform tools. This repository is a catalog: skills are maintained in their respective product repos, and mirrored here daily via an automated sync pipeline. Skills are being added continuously, so check back for updates. We are building this infrastructure in the open, and contributions are welcome. See the [Roadmap](#roadmap) for what is planned next.
+Skills are portable instruction sets that teach AI agents how to use NVIDIA software optimally: Physical AI and robotics workflows, simulation, CUDA-X libraries, RAG and AI Blueprints, and platform tools. This repository is a catalog: skills are maintained in their respective product repos, and mirrored here daily via an automated sync pipeline. Skills are being added continuously, so check back for updates. We are building this infrastructure in the open, and contributions are welcome. See the [Roadmap](#roadmap) for what is planned next.
 
 ---
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Part of the GitHub discoverability work: surface the search terms developers actually use (coding agents, Physical AI, robotics, RAG) in the README opening, and add a discoverability checklist to CONTRIBUTING.md so source repos ship with search-friendly metadata (description, topics, README opening, license detection, social preview).

Only the static README header changes; the auto-generated table blocks are untouched. Repo topics and description were updated in settings alongside this PR.