### PR TITLE
Add DOCA routing to NVIDIA skill finder

### DIFF
--- a/plugins/nvidia-skills/skills/nvidia-skill-finder/references/taxonomy-routing.md
+++ b/plugins/nvidia-skills/skills/nvidia-skill-finder/references/taxonomy-routing.md
@@ -47,8 +47,13 @@ Quantum Computing: CUDA-Q and hybrid quantum-classical development.
 Infrastructure: accelerated workload setup, cluster/runtime/service operations,
 GPU-enabled deployment, Holoscan setup, Jetson host setup, and TAO platform runs.
 
-Networking: accelerated infrastructure networking, data center or edge network
-configuration, Jetson MGBE workflows, and cluster network troubleshooting.
+Networking: DOCA, BlueField DPUs, ConnectX NICs, DPA, GPUNetIO, RDMA, Ethernet
+packet processing, DOCA Flow, host/DPU communication, accelerated
+infrastructure networking, data center or edge network configuration, Jetson
+MGBE workflows, and cluster network troubleshooting.
+
+For DOCA, BlueField, DPU, or ConnectX requests, search the live catalog for the
+`doca-` skill family together with the user's task verb or subsystem.
 
 ## Matching Heuristic
 

--- a/skills/nvidia-skill-finder/references/taxonomy-routing.md
+++ b/skills/nvidia-skill-finder/references/taxonomy-routing.md
@@ -47,8 +47,13 @@ Quantum Computing: CUDA-Q and hybrid quantum-classical development.
 Infrastructure: accelerated workload setup, cluster/runtime/service operations,
 GPU-enabled deployment, Holoscan setup, Jetson host setup, and TAO platform runs.
 
-Networking: accelerated infrastructure networking, data center or edge network
-configuration, Jetson MGBE workflows, and cluster network troubleshooting.
+Networking: DOCA, BlueField DPUs, ConnectX NICs, DPA, GPUNetIO, RDMA, Ethernet
+packet processing, DOCA Flow, host/DPU communication, accelerated
+infrastructure networking, data center or edge network configuration, Jetson
+MGBE workflows, and cluster network troubleshooting.
+
+For DOCA, BlueField, DPU, or ConnectX requests, search the live catalog for the
+`doca-` skill family together with the user's task verb or subsystem.
 
 ## Matching Heuristic
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Summary

- Add DOCA, BlueField DPU, ConnectX NIC, DPA, GPUNetIO, RDMA, Ethernet, DOCA Flow, and host/DPU communication signals to the Networking routing lane.
- Tell the finder to search the live `doca-` skill family with the user's task verb or subsystem.
- Regenerate the `nvidia-skills` plugin copy so it remains byte-aligned with the canonical finder.

## Why

The catalog currently contains 60 `doca-*` skills, but `nvidia-skill-finder` has no DOCA, BlueField, DPU, or ConnectX routing terms. As a result, product-specific requests can miss the existing DOCA skill family.

## Validation

- `.github/scripts/build-plugins.sh --check`
- `python3 .github/scripts/marketplace/generate-skill-metadata.py --check --no-ai`
- `python3 .github/scripts/aggregate_benchmarks.py --check`

## Signature follow-up

This content change requires a fresh OMS signature. A maintainer/admin needs to trigger `/nvskills-ci` after review. PR #340 records that the signing service could not push signature commits to fork branches; if that limitation remains, please copy/cherry-pick this commit to an in-repo branch and run `/nvskills-ci` there.

cc @mosheabr @jasonnvidia