### PR TITLE
docs: rename Cortex to Snowflake CoCo in agent install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent cl
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent codex
 ```
 
-**Cortex**
+**Snowflake CoCo**
 
 ```bash
 npx skills add nvidia/skills --skill cuopt-numerical-optimization-api --agent cortex


### PR DESCRIPTION
Renames the **Cortex** heading to **Snowflake CoCo** in the "Install for a Specific Agent" list.

The `--agent cortex` slug is intentionally left unchanged: it is the identifier defined by the upstream `skills` CLI (install path `~/.snowflake/cortex/skills/`), so renaming it would break the documented install command. Only the human-facing label changes.

Signed-off-by: Moshe Abramovitch <moshea@nvidia.com>