### PR TITLE
fix(ci): scope statuses:read to require-nvskills-ci job (unbreak outbound /nvskills-ci)

### DIFF
--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -9,12 +9,15 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  statuses: read
 
 jobs:
   require-nvskills-ci:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: read
     concurrency:
       group: nvskills-ci-required-${{ github.repository }}-${{ github.event.pull_request.number || github.event.sha || github.sha }}
       cancel-in-progress: true


### PR DESCRIPTION
**Problem:** #372 added `statuses: read` to `team-request.yml`'s **workflow-level** permissions. Outbound repos (NeMo-RL, cuPyNumeric, …) call this reusable workflow granting only `contents`+`pull-requests`; a reusable workflow can't request more than its caller grants, so **every `/nvskills-ci` comment and signature-push on those repos has failed at startup since #372 merged** (07-27 15:06 UTC), spamming failure emails.

**Fix:** move `statuses: read` from the workflow-level `permissions` to the `require-nvskills-ci` **job** (its only consumer — it runs on NVIDIA/skills' own `pull_request` events, where our caller already grants `statuses`). Workflow-level perms return to `contents`+`pull-requests`, matching outbound callers, so they stop startup-failing. Guard `run:` script is unchanged.

**Verify after merge:** next `/nvskills-ci` on NeMo-RL should run (not `startup_failure`), and the guard should still report correctly on NVIDIA/skills skill PRs.