### PR TITLE
docs: Clarify fork-based contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This repository is a catalog of NVIDIA-verified agent skills. Skills are maintai
 
 To contribute to a skill or propose a new one, use the contributing guidelines in the relevant source repo. See the [Skill Catalog](README.md#skill-catalog) and [Getting Help & Contributing](README.md#getting-help--contributing) sections in the README for links.
 
-For changes to the catalog itself (fixing links, adding a new product listing), open a [pull request](../../pulls). For catalog-level bug reports, feature proposals, or documentation problems, file an [issue](../../issues/new/choose) using one of the catalog issue templates (Bug Report, Feature Request, Documentation Request or Correction). Questions and general discussion belong in [Discussions](../../discussions); security vulnerabilities follow the disclosure process in [SECURITY.md](SECURITY.md).
+For changes to the catalog itself (fixing links, adding a new product listing), fork the repository and open a [pull request](../../pulls) from your fork. For catalog-level bug reports, feature proposals, or documentation problems, file an [issue](../../issues/new/choose) using one of the catalog issue templates (Bug Report, Feature Request, Documentation Request or Correction). Questions and general discussion belong in [Discussions](../../discussions); security vulnerabilities follow the disclosure process in [SECURITY.md](SECURITY.md).
 
 ## Recommended Skill Directory Path
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

Not applicable; this is a documentation-only catalog change.

## Reviewer checklist (OSS Skills PIC)

Not applicable; this PR does not onboard or modify a skill.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Clarify that catalog contributors should fork the repository and open a pull request from their fork. This avoids implying that contributors need direct push access to `NVIDIA/skills`.

### Validation

- `git diff --check`