### PR TITLE
fix(benchmarks): count ±0 uplift as zero, not missing

### DIFF
--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -48,11 +48,13 @@ AGENT_LINE = re.compile(r"^- `([^`]+)`\s*$")
 # v2 lists agents inline, e.g. "- Agents: Claude Code (`model/id`), Codex (`model/id`)"
 AGENTS_INLINE = re.compile(r"^- Agents: (.+)$")
 # v1 cell, e.g. "100% (+70%)" or "97%" — score with optional uplift vs. baseline
-CELL = re.compile(r"(\d+(?:\.\d+)?)%(?:\s*\(([+-]?\d+(?:\.\d+)?)%\))?")
-# v2 cell, e.g. "45% → 98% (+53 points)" — baseline, skill score, then uplift
+CELL = re.compile(r"(\d+(?:\.\d+)?)%(?:\s*\(([+-±]?\d+(?:\.\d+)?)%\))?")
+# v2 cell, e.g. "45% → 98% (+53 points)" — baseline, skill score, then uplift.
+# An unchanged dimension is written "±0 points", so ± must be accepted here
+# alongside + and -; see parse_uplift for why dropping it is not harmless.
 CELL_V2 = re.compile(
     r"(\d+(?:\.\d+)?)%\s*(?:→|->)\s*(\d+(?:\.\d+)?)%"
-    r"(?:\s*\(([+-]?\d+(?:\.\d+)?)\s*points?\))?"
+    r"(?:\s*\(([+-±]?\d+(?:\.\d+)?)\s*points?\))?"
 )
 RESULTS_SECTIONS = {"results", "results at a glance"}
 # v2 leads its table with an aggregate row; the per-dimension rows below it are
@@ -60,6 +62,21 @@ RESULTS_SECTIONS = {"results", "results at a glance"}
 SUMMARY_ROWS = {"overall"}
 INT_FIELDS = {"tasks", "attempts_per_task"}
 FLOAT_FIELDS = {"pass_threshold_pct"}
+
+
+def parse_uplift(raw):
+    """Convert an uplift cell capture to a float, or None when absent.
+
+    Reports write an unchanged dimension as "±0 points". ± carries no sign,
+    so strip it and keep the magnitude — the only value emitted in practice
+    is ±0, which must land as 0.0 rather than None: average_uplift() skips
+    None entries, so a dropped ±0 leaves the row out of the denominator and
+    inflates the average for any skill that scored the same with and without
+    the skill applied.
+    """
+    if raw is None:
+        return None
+    return float(raw.replace("±", ""))
 
 
 def normalize_agent(name: str) -> str:
@@ -137,7 +154,7 @@ def parse_benchmark(path: Path) -> dict:
                     # Record the skill-assisted score, matching v1 semantics.
                     scores[agent_cols[i]] = {
                         "score_pct": float(m2.group(2)),
-                        "uplift_pct": float(m2.group(3)) if m2.group(3) is not None else None,
+                        "uplift_pct": parse_uplift(m2.group(3)),
                     }
                     continue
                 m = CELL.search(cell)
@@ -145,7 +162,7 @@ def parse_benchmark(path: Path) -> dict:
                     continue
                 scores[agent_cols[i]] = {
                     "score_pct": float(m.group(1)),
-                    "uplift_pct": float(m.group(2)) if m.group(2) is not None else None,
+                    "uplift_pct": parse_uplift(m.group(2)),
                 }
             if scores:
                 entry["results"].append({


### PR DESCRIPTION
## Summary

v2 evaluation reports write an unchanged dimension as `±0 points`. The uplift capture in `CELL` / `CELL_V2` accepted only `+` and `-`, so those cells fell through as `None`. `average_uplift()` skips `None` entries, so the row dropped out of the *denominator* instead of counting as zero — inflating the published average for any skill that scored the same with and without the skill applied.

This accepts `±` in both cell patterns and routes the captures through a new `parse_uplift()`, which normalises `±0` to `0.0`.

## Impact

Re-running the aggregator over all 323 skills corrects six averages, all downward, and clears every null uplift row (7 → 0 of 3,000 dimension rows):

| skill | published | corrected |
| --- | ---: | ---: |
| `nemo-automodel-distributed-training` | 40.88 | 32.7 |
| `nemo-relay-plugin-observability` | 38.0 | 34.2 |
| `nemo-relay-get-started` | 36.89 | 33.2 |
| `nemo-relay-debug-runtime-integration` | 30.0 | 24.0 |
| `cuopt-multi-objective-exploration` | 29.3 | 28.2 |
| `portfolio-optimization` | 19.0 | 17.1 |

No other skill's figures change — 6 of 323.

Worked example, `cuopt-multi-objective-exploration`: its two Security rows read `100% → 100% (±0 points)`. Before this change both parsed as `None` and were skipped, so the average was taken over 8 dimensions instead of 10 — 35.25 rather than 28.2, published as an apparent rise from the previous report's 29.3 when the like-for-like figure had in fact slipped.

## Validation

- Ran `python3 .github/scripts/aggregate_benchmarks.py` against the full catalog before and after; diffed the output per skill.
- Confirmed the six changed entries are exactly the six whose `BENCHMARK.md` uses the `±0` form, and that all remaining skills are byte-identical.

## Notes

`benchmarks.json` is deliberately not included — the generator workflow regenerates it, and that run will correct all six entries at once.

Two related gaps are left alone here, since they are pre-existing and want a separate decision:

- `profile` and `pass_threshold_pct` come out `null` for v2 reports because v2 no longer emits the `NVSkills-Eval profile` or `Pass threshold` lines at all. Recovering them isn't a parsing fix — the fields are retired upstream, so the schema needs a decision. Same for `num`, which has no column in the v2 table.
- `aggregate_benchmarks.py` carries no SPDX header.
