### PR TITLE
Add Holoscan Sensor Bridge IP skill metadata

### DIFF
--- a/components.d/holoscan-sensor-bridge.yml
+++ b/components.d/holoscan-sensor-bridge.yml
@@ -3,7 +3,7 @@
 
 name: Holoscan Sensor Bridge
 repo: nvidia-holoscan/holoscan-sensor-bridge
-description: Agent-ready skills for Holoscan Sensor Bridge devkit workflows, covering demo environment bring-up, FPGA flashing for Lattice and VB1940 hardware, example application execution, and QA test-plan automation.
+description: Agent-ready skills for Holoscan Sensor Bridge devkit workflows, including demo environment bring-up, FPGA flashing for Lattice and VB1940 hardware, example application execution, QA test-plan automation, and support for configuring and using the Holoscan Sensor Bridge FPGA intellectual property (IP) core.
 links:
   discussions: false
   security: false
@@ -16,3 +16,10 @@ skills:
     catalog_dir: hsb-app
   - path: skills/hsb-test/
     catalog_dir: hsb-test
+  - path: skills/hsb-ip-def/
+    catalog_dir: hsb-ip-def
+  - path: skills/hsb-ip-packetizer/
+    catalog_dir: hsb-ip-packetizer
+  - path: skills/hsb-ip-create-top/
+    catalog_dir: hsb-ip-create-top
+


### PR DESCRIPTION
Carries @tslassit-work's fix from #387 onto a branch in this repository. The content is entirely his; only the branch changed.

## Why a new PR

#387 is from a fork, and a rebase there replayed roughly 20 commits from `main` onto the branch as new commits. That left it at 225 files and 11k additions, and — more importantly — the branch no longer contained current `main`, so merging it would have rolled back today's sync and the benchmarks parser fix. Rebuilding on current `main` and carrying the single changed file across was simpler than untangling the history.

Being a branch in this repository also means CI runs. #387 showed `no checks reported`, which is why the original YAML error went unnoticed for five days.

## What changed

Registers three new skills in `components.d/holoscan-sensor-bridge.yml` and updates the component description to cover the FPGA IP core workflows:

- `hsb-ip-def`
- `hsb-ip-packetizer`
- `hsb-ip-create-top`

## Verification

- `yaml.safe_load` parses the file; the `description` key is present and all seven skills map correctly
- All three skills exist upstream at `nvidia-holoscan/holoscan-sensor-bridge` with `SKILL.md`, `skill.oms.sig`, `skill-card.md`, `evals/` and a `BENCHMARK.md` reporting `Overall verdict: PASS`
- Skill names match their directories
- Diff against `main` is one file, 8 insertions, 1 deletion

Closes #387 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)