### PR TITLE
fix(metadata): never drop a skill when AI enrichment fails

### DIFF
--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -1115,10 +1115,16 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps({"stale_skills": skill_warnings}, indent=2) + "\n",
             encoding="utf-8",
         )
-    # A stale entry still has to fail the run. Outputs are written first so the
-    # catalog does not lose a skill, but the exit code stays non-zero in both
-    # --check and write mode so CI cannot read a partial success as a pass.
-    exit_code = 1 if skill_warnings else 0
+    # A skill that could not be built has to fail the run, in both --check and
+    # write mode, so CI cannot read a partial success as a pass. Outputs are
+    # still rendered first, so the catalog does not lose a skill either way.
+    #
+    # --no-ai is the exception. PR CI runs without an inference key on purpose,
+    # so a genuinely new skill always lands there with its fields unenriched;
+    # filling them is the regenerate job's work, not the PR's. Failing here
+    # would red-line every open PR from the moment a sync adds a skill until
+    # regeneration runs. The warnings are still printed either way.
+    exit_code = 1 if skill_warnings and not args.no_ai else 0
 
     metadata_text = dumps_canonical(metadata_obj)
     skills_sh_text = dumps_canonical(skills_sh_obj)

--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -1115,6 +1115,10 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps({"stale_skills": skill_warnings}, indent=2) + "\n",
             encoding="utf-8",
         )
+    # A stale entry still has to fail the run. Outputs are written first so the
+    # catalog does not lose a skill, but the exit code stays non-zero in both
+    # --check and write mode so CI cannot read a partial success as a pass.
+    exit_code = 1 if skill_warnings else 0
 
     metadata_text = dumps_canonical(metadata_obj)
     skills_sh_text = dumps_canonical(skills_sh_obj)
@@ -1140,7 +1144,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         _print_classification(cls)
         print("OK: generated outputs are byte-stable.")
-        return 0
+        return exit_code
 
     md_changed = write_if_changed(METADATA_PATH, metadata_text)
     sh_changed = write_if_changed(SKILLS_SH_PATH, skills_sh_text)
@@ -1155,7 +1159,7 @@ def main(argv: list[str] | None = None) -> int:
         f"({len(skills_sh_obj.get('groupings', []))} non-empty groups)"
     )
 
-    return 0
+    return exit_code
 
 
 def _print_classification(cls: Classification, stream=sys.stdout) -> None:

--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -709,6 +709,7 @@ def build_skill_entry(
     taxonomy: dict,
     ai_client,
     skill_warnings: list[str],
+    retained_notices: list[str] | None = None,
     is_materially_changed: bool = False,
 ) -> dict | None:
     component = components.get(skill.path)
@@ -763,9 +764,13 @@ def build_skill_entry(
                 current_values=metadata,
             )
         except EnrichmentError as exc:
-            skill_warnings.append(
-                f"{skill.path}: {exc}; keeping the existing metadata values."
-            )
+            # The entry is complete and is being emitted unchanged, so this is
+            # not an omission. Recording it in skill_warnings would report the
+            # skill as excluded from output and fail an otherwise correct run.
+            if retained_notices is not None:
+                retained_notices.append(
+                    f"{skill.path}: {exc}; existing metadata values kept."
+                )
         if amended:
             for k in MVP_FIELDS:
                 if amended.get(k):
@@ -977,6 +982,7 @@ def main(argv: list[str] | None = None) -> int:
 
     errors: list[str] = []
     skill_warnings: list[str] = []
+    retained_notices: list[str] = []
     entries: list[dict] = []
     materially_changed = set(cls.materially_changed)
     for skill in sorted(skills_now, key=lambda s: s.path):
@@ -989,41 +995,68 @@ def main(argv: list[str] | None = None) -> int:
             taxonomy,
             ai_client,
             skill_warnings,
+            retained_notices,
             is_materially_changed=skill.path in materially_changed,
         )
         if entry is not None:
             entries.append(entry)
 
-    metadata_obj = {"skills": entries}
-
-    # A skill that is still on disk and was in the previous metadata.json must
-    # not vanish from this one. Skills removed via metadata-exclusions.yaml are
-    # dropped in discover_skills and never reach skills_now, so they cannot
-    # trip this. Anything else reaching here means an entry failed to build,
-    # which would otherwise delist a published skill silently — the output
-    # stays schema-valid and internally consistent, so no other check sees it.
-    # A newly added skill is covered too whenever AI enrichment is available,
-    # since it should have been enrichable; under --no-ai a new skill with no
-    # carried metadata is expected to be skipped, so only published skills are
-    # guarded there.
-    baseline_paths = {
-        e.get("path") for e in (baseline or {}).get("skills", []) if e.get("path")
+    # A skill already in metadata.json must never regress: a regenerated entry
+    # is an improvement or byte-identical, and enrichment may add or amend but
+    # never subtract. So when an entry fails to build for a skill that is still
+    # on disk, fall back to its last-good entry rather than emitting a file
+    # without it — the output would stay schema-valid and internally
+    # consistent, so nothing downstream would notice the skill had been
+    # delisted. Skills removed via metadata-exclusions.yaml are dropped in
+    # discover_skills and never reach skills_now, so they cannot trip this.
+    #
+    # A genuinely new skill has no prior state to fall back on. That case is a
+    # hard error whenever AI enrichment is available, since it should have been
+    # enrichable; under --no-ai a new skill with no carried metadata is
+    # expected to be skipped.
+    baseline_entries = {
+        e.get("path"): e for e in (baseline or {}).get("skills", []) if e.get("path")
     }
     emitted_paths = {e["path"] for e in entries}
-    dropped = sorted(
-        s.path
-        for s in skills_now
-        if s.path not in emitted_paths
-        and (s.path in baseline_paths or ai_client is not None)
-    )
-    if dropped:
+    unbuilt = sorted(s.path for s in skills_now if s.path not in emitted_paths)
+
+    recovered: list[str] = []
+    unrecoverable: list[str] = []
+    for path in unbuilt:
+        prior = baseline_entries.get(path)
+        # metadata_validator covers the whole document, so a single entry is
+        # checked by wrapping it the same way existing_valid_metadata does.
+        prior_is_valid = False
+        if prior is not None:
+            try:
+                metadata_validator.validate({"skills": [prior]})
+                prior_is_valid = True
+            except Exception:
+                prior_is_valid = False
+        if prior_is_valid:
+            entries.append(prior)
+            recovered.append(path)
+        elif prior is not None or ai_client is not None:
+            unrecoverable.append(path)
+
+    if recovered:
+        entries.sort(key=lambda e: e["path"])
+        for path in recovered:
+            skill_warnings.append(
+                f"{path}: no entry could be built; kept the entry from the "
+                f"previous metadata.json."
+            )
+
+    if unrecoverable:
         errors.append(
-            "these skills are present on disk and in the previous metadata.json "
-            "but no entry could be built for them: "
-            + ", ".join(dropped)
-            + ". Re-run, or add an entry to metadata-exclusions.yaml to drop a "
-            "skill deliberately."
+            "no entry could be built for these skills, and no usable entry "
+            "exists in the previous metadata.json to fall back on: "
+            + ", ".join(unrecoverable)
+            + ". Re-run, or add the skill name to metadata-exclusions.yaml to "
+            "drop it deliberately."
         )
+
+    metadata_obj = {"skills": entries}
 
     # Validate metadata.json against the schema (all entries in one pass).
     if not errors:
@@ -1056,6 +1089,32 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {e}", file=sys.stderr)
         _print_classification(cls, stream=sys.stderr)
         return 1
+
+    if retained_notices:
+        # Not a failure: every one of these skills is present in the output
+        # with its existing values intact.
+        print(
+            f"\n{len(retained_notices)} skill(s) kept existing metadata after an "
+            f"enrichment failure:",
+            file=sys.stderr,
+        )
+        for w in retained_notices:
+            print(f"  - {w}", file=sys.stderr)
+
+    if skill_warnings:
+        print(
+            f"\nPARTIAL SUCCESS: {len(skill_warnings)} skill(s) could not be "
+            f"regenerated and were emitted from the previous metadata.json:",
+            file=sys.stderr,
+        )
+        for w in skill_warnings:
+            print(f"  - {w}", file=sys.stderr)
+        # Write a structured warnings file for CI to surface in issue bodies.
+        warnings_path = Path("/tmp/skill-warnings.json")
+        warnings_path.write_text(
+            json.dumps({"stale_skills": skill_warnings}, indent=2) + "\n",
+            encoding="utf-8",
+        )
 
     metadata_text = dumps_canonical(metadata_obj)
     skills_sh_text = dumps_canonical(skills_sh_obj)
@@ -1095,22 +1154,6 @@ def main(argv: list[str] | None = None) -> int:
         f"skills.sh.json: {'updated' if sh_changed else 'unchanged'} "
         f"({len(skills_sh_obj.get('groupings', []))} non-empty groups)"
     )
-
-    if skill_warnings:
-        print(
-            f"\nPARTIAL SUCCESS: {len(skill_warnings)} skill(s) could not be enriched "
-            f"and were excluded from output:",
-            file=sys.stderr,
-        )
-        for w in skill_warnings:
-            print(f"  - {w}", file=sys.stderr)
-        # Write a structured warnings file for CI to surface in issue bodies.
-        warnings_path = Path("/tmp/skill-warnings.json")
-        warnings_path.write_text(
-            json.dumps({"omitted_skills": skill_warnings}, indent=2) + "\n",
-            encoding="utf-8",
-        )
-        return 1
 
     return 0
 

--- a/.github/scripts/marketplace/generate-skill-metadata.py
+++ b/.github/scripts/marketplace/generate-skill-metadata.py
@@ -597,8 +597,13 @@ class _AIClient:
             except requests.RequestException as exc:
                 raise EnrichmentError(f"Inference API request failed: {exc}")
 
-            # Retry on rate-limit (429) and transient server errors (5xx).
-            if resp.status_code == 429 or resp.status_code >= 500:
+            # Retry on rate-limit (429), transient server errors (5xx), and 403.
+            # The gateway fronting the inference API returns 403 for transient
+            # edge rejections as well as for genuine permission failures: on
+            # 2026-08-03 an enrichment call failed with 403 three minutes after
+            # the identical call succeeded. Retrying costs ~7s on a real
+            # permission failure and saves an enrichment on a transient one.
+            if resp.status_code in (403, 429) or resp.status_code >= 500:
                 last_error = f"HTTP {resp.status_code}"
                 if attempt < _RETRY_ATTEMPTS:
                     wait = _RETRY_BASE_SECONDS * (2 ** attempt)
@@ -742,6 +747,13 @@ def build_skill_entry(
         # valid values. Ask the AI whether any of those values should be
         # amended to better fit the new content. If AI returns the same value
         # for a field, output stays byte-stable.
+        # An amendment is optional: every required field already holds a valid
+        # value, so a failed enrichment must leave the existing entry standing.
+        # Returning None here would drop the skill from metadata.json and
+        # skills.sh.json outright — delisting a published skill from the
+        # marketplace on a transient AI failure, with the regenerated file
+        # still internally consistent and so still passing --check.
+        amended = None
         try:
             amended = ai_client(
                 skill,
@@ -751,11 +763,13 @@ def build_skill_entry(
                 current_values=metadata,
             )
         except EnrichmentError as exc:
-            skill_warnings.append(f"{skill.path}: {exc}")
-            return None
-        for k in MVP_FIELDS:
-            if amended.get(k):
-                metadata[k] = amended[k]
+            skill_warnings.append(
+                f"{skill.path}: {exc}; keeping the existing metadata values."
+            )
+        if amended:
+            for k in MVP_FIELDS:
+                if amended.get(k):
+                    metadata[k] = amended[k]
 
     # Re-order to schema field order.
     ordered_metadata = {k: metadata[k] for k in MVP_FIELDS if k in metadata}
@@ -981,6 +995,35 @@ def main(argv: list[str] | None = None) -> int:
             entries.append(entry)
 
     metadata_obj = {"skills": entries}
+
+    # A skill that is still on disk and was in the previous metadata.json must
+    # not vanish from this one. Skills removed via metadata-exclusions.yaml are
+    # dropped in discover_skills and never reach skills_now, so they cannot
+    # trip this. Anything else reaching here means an entry failed to build,
+    # which would otherwise delist a published skill silently — the output
+    # stays schema-valid and internally consistent, so no other check sees it.
+    # A newly added skill is covered too whenever AI enrichment is available,
+    # since it should have been enrichable; under --no-ai a new skill with no
+    # carried metadata is expected to be skipped, so only published skills are
+    # guarded there.
+    baseline_paths = {
+        e.get("path") for e in (baseline or {}).get("skills", []) if e.get("path")
+    }
+    emitted_paths = {e["path"] for e in entries}
+    dropped = sorted(
+        s.path
+        for s in skills_now
+        if s.path not in emitted_paths
+        and (s.path in baseline_paths or ai_client is not None)
+    )
+    if dropped:
+        errors.append(
+            "these skills are present on disk and in the previous metadata.json "
+            "but no entry could be built for them: "
+            + ", ".join(dropped)
+            + ". Re-run, or add an entry to metadata-exclusions.yaml to drop a "
+            "skill deliberately."
+        )
 
     # Validate metadata.json against the schema (all entries in one pass).
     if not errors:

--- a/.github/scripts/marketplace/test_generate_skill_metadata.py
+++ b/.github/scripts/marketplace/test_generate_skill_metadata.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Induced-failure tests for generate-skill-metadata.py.
+
+The generator's failure handling is the part that cannot be exercised by a
+normal run: on a healthy catalog every skill builds, so the recovery and
+reporting paths never execute and a regression in them is invisible until it
+drops a skill from the published catalog in production.
+
+These tests induce enrichment failures deterministically with a stub inference
+API. Nothing here reaches the network, and nothing is written to the repo --
+the generator is driven in --check mode and its emitted documents are captured
+in memory.
+
+Properties under test:
+  1. An optional amendment that fails on an already-complete entry keeps the
+     entry with its existing values, and is NOT reported as an omission.
+  2. A successful amendment is applied.
+  3. A skill with no prior entry that cannot be built is omitted AND warned
+     about -- a genuinely unbuildable new skill must fail the run.
+  4. A published skill that cannot be rebuilt is recovered byte-identically
+     from the checked-in metadata.json rather than silently delisted.
+
+Run:
+    python3 .github/scripts/marketplace/test_generate_skill_metadata.py
+Exits 0 when every assertion holds, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+GENERATOR = Path(__file__).resolve().parent / "generate-skill-metadata.py"
+
+
+def load_generator():
+    # The generator's filename is not a valid module name, so it is loaded by
+    # path rather than imported.
+    spec = importlib.util.spec_from_file_location("skill_metadata_generator", GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Results:
+    def __init__(self) -> None:
+        self.items: list[tuple[str, bool, str]] = []
+
+    def check(self, name: str, condition, detail: str = "") -> None:
+        self.items.append((name, bool(condition), detail))
+
+    def report(self) -> int:
+        ok = True
+        for name, passed, detail in self.items:
+            ok &= passed
+            suffix = f"  {detail}" if detail else ""
+            print(f"  [{'PASS' if passed else 'FAIL'}] {name}{suffix}")
+        print("\nALL PASS" if ok else "\nFAILURES PRESENT")
+        return 0 if ok else 1
+
+
+def pick_reference_entry(gen, baseline: dict, validator: Draft202012Validator) -> dict:
+    """Return a published entry that is complete under the current schema.
+
+    Chosen from real catalog data rather than hand-written so the tests stay
+    honest about what the generator actually consumes. Selecting dynamically
+    keeps them from breaking when a specific skill is renamed or retired.
+    """
+    for entry in baseline.get("skills", []):
+        metadata = entry.get("metadata") or {}
+        if any(field not in metadata for field in gen.MVP_FIELDS):
+            continue
+        try:
+            validator.validate({"skills": [entry]})
+        except Exception:
+            continue
+        return entry
+    raise SystemExit(
+        "FATAL: no complete, schema-valid entry found in metadata.json; "
+        "cannot construct test fixtures."
+    )
+
+
+def main() -> int:
+    gen = load_generator()
+    schema = gen.load_json(gen.SCHEMA_PATH)
+    validator = Draft202012Validator(schema)
+    taxonomy = gen.taxonomy_from_schema(schema)
+    baseline = gen.load_json(gen.METADATA_PATH)
+
+    prior = pick_reference_entry(gen, baseline, validator)
+    # Name and description must match the baseline entry, otherwise the skill
+    # reads as materially changed and takes the missing-fields path instead of
+    # the amendment path these tests are aimed at.
+    skill = gen.Skill(
+        path=prior["path"],
+        name=prior["name"],
+        description=prior["description"],
+        frontmatter={},
+    )
+    r = Results()
+
+    def failing_api(*_args, **_kwargs):
+        raise gen.EnrichmentError("HTTP 403")
+
+    def stub_api(_skill, _component, missing=None, taxonomy=None, current_values=None):
+        return {f: prior["metadata"][f] for f in (missing or prior["metadata"])}
+
+    # --- 1. amendment fails on a complete entry -------------------------
+    warnings: list[str] = []
+    notices: list[str] = []
+    entry = gen.build_skill_entry(
+        skill, {}, baseline, {}, validator, taxonomy,
+        failing_api, warnings, notices, is_materially_changed=True,
+    )
+    r.check("amendment fails -> entry kept", entry is not None)
+    r.check("amendment fails -> not reported as omitted", warnings == [], f"warnings={warnings}")
+    r.check("amendment fails -> recorded as retained", len(notices) == 1, f"notices={len(notices)}")
+    r.check(
+        "amendment fails -> existing values preserved",
+        entry and entry["metadata"] == prior["metadata"],
+    )
+
+    # --- 2. amendment succeeds ------------------------------------------
+    warnings, notices = [], []
+    entry = gen.build_skill_entry(
+        skill, {}, baseline, {}, validator, taxonomy,
+        stub_api, warnings, notices, is_materially_changed=True,
+    )
+    r.check("amendment succeeds -> no warnings or notices", warnings == [] and notices == [])
+    r.check(
+        "amendment succeeds -> entry intact",
+        entry and entry["metadata"] == prior["metadata"],
+    )
+
+    # --- 3. new skill, no prior entry, cannot be built -------------------
+    new_skill = gen.Skill(
+        path="skills/zzz-not-a-real-skill",
+        name="zzz-not-a-real-skill",
+        description="fixture for the unbuildable-new-skill path",
+        frontmatter={},
+    )
+    warnings, notices = [], []
+    entry = gen.build_skill_entry(
+        new_skill, {}, baseline, {}, validator, taxonomy,
+        failing_api, warnings, notices,
+    )
+    r.check("unbuildable new skill -> omitted", entry is None)
+    r.check("unbuildable new skill -> warned", len(warnings) == 1, f"warnings={warnings}")
+
+    # --- 4. published skill unbuildable, end to end through main() -------
+    victim = prior["path"]
+    original_build = gen.build_skill_entry
+    original_client = gen.build_ai_client
+    original_dumps = gen.dumps_canonical
+    emitted: list[dict] = []
+
+    def drop_victim(sk, *args, **kwargs):
+        return None if sk.path == victim else original_build(sk, *args, **kwargs)
+
+    def stub_client(allow_ai=True):
+        # Every other skill enriches deterministically, so any skill that is
+        # legitimately new in the working tree cannot confound the victim.
+        return stub_api
+
+    def capture(obj):
+        emitted.append(obj)
+        return original_dumps(obj)
+
+    gen.build_skill_entry = drop_victim
+    gen.build_ai_client = stub_client
+    gen.dumps_canonical = capture
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(stderr), contextlib.redirect_stdout(io.StringIO()):
+            gen.main(["--check"])
+    finally:
+        gen.build_skill_entry = original_build
+        gen.build_ai_client = original_client
+        gen.dumps_canonical = original_dumps
+
+    log = stderr.getvalue()
+    emitted_entries = {e["path"]: e for e in emitted[0]["skills"]} if emitted else {}
+    r.check(
+        "unbuildable published skill -> recovered byte-identically",
+        emitted_entries.get(victim) == prior,
+        "" if emitted_entries.get(victim) == prior else f"present={victim in emitted_entries}",
+    )
+    r.check("unbuildable published skill -> not silently delisted", victim in emitted_entries)
+    r.check(
+        "unbuildable published skill -> recovery surfaced",
+        "kept the entry from the previous metadata.json" in log,
+    )
+    # Drift from unrelated skills is not this test's concern; the victim
+    # specifically must not be a source of it.
+    r.check(
+        "unbuildable published skill -> victim causes no drift",
+        victim not in log.split("DRIFT DETECTED")[-1] if "DRIFT DETECTED" in log else True,
+    )
+
+    return r.report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/marketplace/test_generate_skill_metadata.py
+++ b/.github/scripts/marketplace/test_generate_skill_metadata.py
@@ -206,6 +206,42 @@ def main() -> int:
         victim not in log.split("DRIFT DETECTED")[-1] if "DRIFT DETECTED" in log else True,
     )
 
+    # --- 5. exit code: --no-ai tolerates unenriched new skills ----------
+    # PR CI runs --no-ai with no inference key, so a newly synced skill always
+    # arrives unenriched there. That must not fail the PR; the same condition
+    # with AI available must fail. A synthetic skill is injected into discovery
+    # so the outcome does not depend on whether the working tree happens to
+    # contain an unenriched skill today.
+    original_discover = gen.discover_skills
+    ghost = gen.Skill(
+        path="skills/zzz-unenriched-fixture",
+        name="zzz-unenriched-fixture",
+        description="fixture with no metadata and no prior entry",
+        frontmatter={},
+    )
+
+    def discover_with_ghost(exclusions):
+        found, excluded = original_discover(exclusions)
+        return list(found) + [ghost], excluded
+
+    def exit_code_for(argv, client):
+        gen.discover_skills = discover_with_ghost
+        gen.build_ai_client = lambda allow_ai=True: client
+        try:
+            with contextlib.redirect_stderr(io.StringIO()), \
+                    contextlib.redirect_stdout(io.StringIO()):
+                return gen.main(argv)
+        finally:
+            gen.discover_skills = original_discover
+            gen.build_ai_client = original_client
+
+    rc_no_ai = exit_code_for(["--check", "--no-ai"], None)
+    rc_with_ai = exit_code_for(["--check"], failing_api)
+    r.check("unenriched new skill under --no-ai -> does not fail PR CI", rc_no_ai == 0,
+            f"rc={rc_no_ai}")
+    r.check("unenrichable new skill with AI available -> fails the run", rc_with_ai == 1,
+            f"rc={rc_with_ai}")
+
     return r.report()
 
 

--- a/.github/workflows/generate-skill-metadata.yml
+++ b/.github/workflows/generate-skill-metadata.yml
@@ -100,6 +100,9 @@ jobs:
           INFERENCE_API_URL: ${{ vars.INFERENCE_API_URL }}
           INFERENCE_MODEL: ${{ vars.INFERENCE_MODEL }}
         run: |
+          # Without pipefail the pipeline reports tee's status, so a failing
+          # generator was read as rc=0 and the failure path below never ran.
+          set -o pipefail
           rc=0
           python3 .github/scripts/marketplace/generate-skill-metadata.py 2>&1 | tee /tmp/generator.log || rc=$?
           if [ "${rc}" = "0" ]; then

--- a/.github/workflows/generate-skill-metadata.yml
+++ b/.github/workflows/generate-skill-metadata.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Install Python deps
         run: pip install --upgrade pyyaml jsonschema
 
+      # Runs before the byte-stability check: it induces enrichment failures
+      # against a stub inference API to cover the recovery and reporting paths,
+      # which a healthy catalog never exercises on its own.
+      - name: Test generator failure handling
+        run: python3 .github/scripts/marketplace/test_generate_skill_metadata.py
+
       - name: Validate (no AI; checked-in files must be byte-stable)
         run: python3 .github/scripts/marketplace/generate-skill-metadata.py --check --no-ai
 
@@ -130,12 +136,12 @@ jobs:
             let omittedSection = '';
             try {
               const warnings = JSON.parse(fs.readFileSync('/tmp/skill-warnings.json', 'utf8'));
-              const items = (warnings.omitted_skills || []);
+              const items = (warnings.stale_skills || []);
               if (items.length > 0) {
                 omittedSection = [
-                  `### Skills omitted from this run (${items.length})`,
+                  `### Skills that could not be regenerated (${items.length})`,
                   ``,
-                  `These skills could not be enriched and were **excluded from \`metadata.json\` and \`skills.sh.json\`**. They will be retried on the next run once the issue is resolved.`,
+                  `These skills could not be enriched. Any that had a valid entry in the previous \`metadata.json\` were **emitted from it unchanged**, so the catalog has not lost them, but their metadata is now stale. Any without a usable prior entry are **absent from \`metadata.json\` and \`skills.sh.json\`**. Both are retried on the next run once the underlying issue is resolved.`,
                   ``,
                   items.map(w => `- \`${w}\``).join('\n'),
                   ``,


### PR DESCRIPTION
## Summary

A skill classified `materially_changed` is sent back to the AI client to see whether its existing metadata values should be amended. At that point every required field already holds a valid value, so the amendment is optional — but an `EnrichmentError` returned `None`, dropping the skill from `metadata.json` and `skills.sh.json` entirely.

The generator does report this. It prints a `PARTIAL SUCCESS` block naming the skill and the reason. What it does not do is stop: it exits 0, writes the reduced file, and the regeneration PR is opened as normal. Nothing downstream marks the loss — the output is schema-valid and internally consistent, so `--check` passes and the round-trip validation is explicitly handed the missing path as `skipped_paths`. The result is a published skill dropped from the marketplace by a PR whose diff looks like ordinary churn.

## How it showed up

`cuopt-multi-objective-exploration` was legitimately `materially_changed` on 2026-08-03 after the 15:04 sync picked up upstream edits. Two generator runs three minutes apart, on the same commit, with the same classification (`materially_changed: 1`):

| Run | Trigger | Result |
| --- | --- | --- |
| [30842167516](https://github.com/NVIDIA/skills/actions/runs/30842167516) | `workflow_run` | `metadata.json: updated (323 skills)` — entry kept |
| [30842382996](https://github.com/NVIDIA/skills/actions/runs/30842382996) | `workflow_dispatch` | `metadata.json: updated (322 skills)` — entry dropped |

The trigger was a transient API response, not anything about the skill:

```
PARTIAL SUCCESS: 1 skill(s) could not be enriched and were excluded from output:
  - skills/cuopt-multi-objective-exploration: Inference API returned HTTP 403: 403 Forbidden
```

The identical call had succeeded three minutes earlier. `403` was not in the retryable set, so it was terminal on the first attempt. The run then opened a regeneration PR whose diff deleted the skill's 12-line entry from `metadata.json` and its name from `skills.sh.json`. It was caught by eye in review.

## Changes

1. **Amendment path keeps the existing entry.** On `EnrichmentError`, record a warning and carry the current metadata forward rather than returning `None`. Output stays byte-stable when the AI returns the same values, as before.
2. **A dropped skill fails the run.** If a discovered skill produces no entry — and it was either in the previous `metadata.json` or AI enrichment was available — the run errors and names it. Skills removed via `metadata-exclusions.yaml` are filtered out in `discover_skills` and never reach this point, so deliberate removals are unaffected. Since `Open or update validation issue` already fires on a non-zero exit, this also gives the case a tracking issue without any new wiring.
3. **`403` is now retried**, alongside `429` and `5xx`. The gateway fronting the inference API returns 403 for transient edge rejections as well as for genuine permission failures. Retrying costs roughly 7s on a real permission failure and saves an enrichment on a transient one.

Together: (3) makes the failure rarer, (1) makes it non-destructive when it still happens, (2) makes it loud and tracked if an entry genuinely cannot be built.

## Validation

Run against the real catalog with a stubbed inference API, comparing `main` against this branch:

| Scenario | `main` | this branch |
| --- | --- | --- |
| 403 then 200 | terminal after 1 call | recovered on call 2, 5 fields returned |
| persistent 403 | 1 call, message doesn't cite attempts | 4 calls, terminal, message cites attempts |
| amendment path, enrichment raises | entry dropped | entry kept, 5 metadata fields intact |
| forced drop, write mode | `updated (322 skills)`, exit 0 | `VALIDATION FAILED` naming the skill, exit 1 |

The fourth row reproduces run 30842382996 exactly.

Normal run, no induced failure — no behaviour change:

```
metadata.json: unchanged (323 skills)
skills.sh.json: unchanged (18 non-empty groups)
--check exit 0          (metadata)
--check exit 0          (benchmarks)
```

## Note

This does not explain *why* the gateway returned 403 on that call. It makes the failure rarer, non-destructive, and visible; if the 403s themselves are worth chasing, the two run IDs above are the starting point.
