### PR TITLE
Rename People Attribute Search skill to Image Attribute Augmentation

### DIFF
--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -6,7 +6,7 @@ skills:
     catalog_dir: physical-ai-defect-image-generation
   - path: skills/physical-ai-video-data-augmentation/
     catalog_dir: physical-ai-video-data-augmentation
-  - path: skills/physical-ai-people-attribute-search/
-    catalog_dir: physical-ai-people-attribute-search
+  - path: skills/physical-ai-image-attribute-augmentation/
+    catalog_dir: physical-ai-image-attribute-augmentation
 links:
   discussions: false


### PR DESCRIPTION
Renames the People Attribute Search skill to **Image Attribute Augmentation** in the catalog registration.

Only the manual `components.d` entry is changed:
- `components.d/physical-ai-data-factory.yml` — `path` + `catalog_dir` moved together to `physical-ai-image-attribute-augmentation`.

`skills/` and `metadata.json` are intentionally left untouched: the hourly sync copies in the renamed folder from the source repo and prunes the old one, then the regeneration bot updates `metadata.json` from what's on disk. Editing `metadata.json` here would point the index at a folder not yet present and trip the drift check.

Pairs with the source-repo rename in NVIDIA/physical-ai-data-factory.

