### PR TITLE
fix(sync): cap the sync PR title at GitHub's 256-character limit

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -842,8 +842,47 @@ jobs:
           # Dedupe before composing the title — the enforce step may have
           # re-added entries already present from the rsync loop.
           sort -u -o /tmp/changed-components.txt /tmp/changed-components.txt
-          changed=$(cat /tmp/changed-components.txt | tr '\n' ',' | sed 's/- //g;s/,$//')
-          echo "title=chore: sync skills ($changed)" >> "$GITHUB_OUTPUT"
+
+          # GitHub rejects a pull request title over 256 characters, and it
+          # rejects it on create as well as on update — so an over-long title
+          # stops the sync PR from existing at all, stranding synced content on
+          # the branch. Name as many components as fit and count the rest; the
+          # complete list is always in the body below, which has no limit.
+          sed 's/^- //' /tmp/changed-components.txt | sed '/^[[:space:]]*$/d' > /tmp/changed-names.txt
+          total=$(wc -l < /tmp/changed-names.txt | tr -d ' ')
+
+          title_limit=256
+          title_prefix="chore: sync skills ("
+          names=""
+          shown=0
+          while IFS= read -r name; do
+            if [ -z "${names}" ]; then candidate="${name}"; else candidate="${names},${name}"; fi
+            remaining=$((total - shown - 1))
+            if [ "${remaining}" -gt 0 ]; then more=" +${remaining} more"; else more=""; fi
+            if [ $(( ${#title_prefix} + ${#candidate} + ${#more} + 1 )) -le "${title_limit}" ]; then
+              names="${candidate}"
+              shown=$((shown + 1))
+            else
+              break
+            fi
+          done < /tmp/changed-names.txt
+
+          if [ "${total}" -eq 1 ]; then count_label="1 component"; else count_label="${total} components"; fi
+
+          omitted=$((total - shown))
+          if [ "${shown}" -eq 0 ]; then
+            # Even one name does not fit; fall back to a bare count.
+            title="chore: sync skills (${count_label})"
+          elif [ "${omitted}" -gt 0 ]; then
+            title="${title_prefix}${names} +${omitted} more)"
+          else
+            title="${title_prefix}${names})"
+          fi
+          # Belt and braces: never emit a title the API will reject.
+          if [ "${#title}" -gt "${title_limit}" ]; then
+            title="chore: sync skills (${count_label})"
+          fi
+          echo "title=${title}" >> "$GITHUB_OUTPUT"
           {
             echo 'body<<EOFBODY'
             echo "## Automated skills sync"


### PR DESCRIPTION
## Summary

The sync PR title names every changed component, so it grows with the catalog. It passed 256 characters and GitHub started rejecting it — first on update, then on create:

```
Validation Failed: {"resource":"Issue","code":"custom","field":"title",
"message":"title is too long (maximum is 256 characters)"}
```

Rejection on **create** is the damaging case: no sync PR exists at all, so synced content sits on `automated/sync-skills` unmerged and never reaches `main`, while the rolling failure tracker (#279) emails on every run.

That is the current state. Since 2026-08-04 11:47 UTC every sync run has failed, there are zero open sync PRs, and a `doca-telemetry-exporter` update — `SKILL.md`, `skill.oms.sig`, `BENCHMARK.md`, `evals/evals.json` and four more files — has been stranded on the branch. Every step before `Create pull request` succeeds; the sync itself is healthy.

## Change

Name as many components as fit, then count the remainder: `+N more`. The complete list is unchanged in the PR body, which has no length limit, so no information is lost. Falls back to a bare count if even a single name will not fit, with a final length guard so an over-long title can never be emitted.

## Validation

Composed title for each case, checked against the 256 limit:

| Case | Result | Length |
| --- | --- | ---: |
| 29 components — the list that broke #409 | `chore: sync skills (AIQ,CUDA-Q,DeepStream,… +14 more)` | 649 → **229** |
| 1 component — today's stranded sync | `chore: sync skills (doca-telemetry-exporter)` | 44 |
| 2 components | `chore: sync skills (cuOpt,AIQ)` | 30 |
| 200 components | `chore: sync skills (s1,s2,… +142 more)` | 253 |
| single 300-character name | `chore: sync skills (1 component)` | 32 |

`sync-skills.yml` still parses and the sync job's 17 steps are unchanged.

## After merge

The next scheduled sync builds a short title, opens the PR itself, and sweeps up the stranded `doca-telemetry-exporter` changes. Issue #279 closes automatically on the first clean run. No manual PR needed.
