### PR TITLE
Revert "Rename People Attribute Search skill to Image Attribute Augmentation"

### DIFF
--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -6,7 +6,7 @@ skills:
     catalog_dir: physical-ai-defect-image-generation
   - path: skills/physical-ai-video-data-augmentation/
     catalog_dir: physical-ai-video-data-augmentation
-  - path: skills/physical-ai-image-attribute-augmentation/
-    catalog_dir: physical-ai-image-attribute-augmentation
+  - path: skills/physical-ai-people-attribute-search/
+    catalog_dir: physical-ai-people-attribute-search
 links:
   discussions: false


### PR DESCRIPTION
Reverts #410 until the source repo is re-signed.

The rename itself is correct and should go back in. The problem is upstream: `skill.oms.sig` in `physical-ai-data-factory` does not cover the current `SKILL.md` and `skill-card.md`. 20 of 22 signed files match, those two do not.

The sync run at 12:46 PM CT dropped the new directory for that mismatch and pruned the old one, which would have removed the skill from the catalog entirely:

```
✗ skills/physical-ai-image-attribute-augmentation — sig mismatch: dropped
  (2 signed file(s) do not match skill.oms.sig — new skill, no prior version)
✂ pruned skills/physical-ai-people-attribute-search (no components.d registration)
```

That never landed, because creating the sync PR failed on the 256-character title limit, which is the bug #412 fixes. So the only thing currently keeping the skill in the catalog is an unrelated failure, and merging #412 would remove that protection.

Reverting puts the registration back on `physical-ai-people-attribute-search`, which I verified is fully consistent with its signature, 22 of 22 files. The skill stays live and correctly signed, the sync stops retrying a drop-and-prune every hour, and #412 can be judged on its own merits.

Saurav has been asked to re-run `/nvskills-ci` at source. Once that lands I will re-apply #410 as-is.
