### PR TITLE
docs(fern): surface SkillEvaluator docs in the skills navigation

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -42,3 +42,20 @@ navigation:
       - page: Advanced Installation
         path: ../docs/advanced-install.mdx
         slug: advanced-install
+  - section: SkillEvaluator
+    skip-slug: true
+    contents:
+      - link: Overview
+        href: https://docs.nvidia.com/skills/skillevaluator
+      - link: Quickstart
+        href: https://docs.nvidia.com/skills/skillevaluator/quickstart
+      - link: Installation
+        href: https://docs.nvidia.com/skills/skillevaluator/installation
+      - link: "Tier 1: Validation"
+        href: https://docs.nvidia.com/skills/skillevaluator/tier1-validation
+      - link: "Tier 2: Deduplication"
+        href: https://docs.nvidia.com/skills/skillevaluator/tier2-deduplication
+      - link: "Tier 3: Live Evaluation"
+        href: https://docs.nvidia.com/skills/skillevaluator/tier3-live-evaluation
+      - link: CLI Reference
+        href: https://docs.nvidia.com/skills/skillevaluator/cli-reference


### PR DESCRIPTION
## What

The SkillEvaluator documentation is live at [docs.nvidia.com/skills/skillevaluator](https://docs.nvidia.com/skills/skillevaluator), but nothing on this site links to it. Readers landing on the skills docs have no path to the evaluator.

This adds a **SkillEvaluator** section to the sidebar, directly below Documentation.

## How

Seven `link:` entries pointing at the SkillEvaluator Fern instance. Fern renders each with an external-link marker, so it is clear the reader is leaving this site.

Nothing else changes — same pages, same order, same slugs. SkillEvaluator keeps its own instance, its own URLs, and its own publish pipeline.

## Validation

`fern check` passes with 0 errors (the single warning is the pre-existing unauthenticated redirect-check notice, identical on `main`). Rendered locally with `fern docs dev` to confirm the section appears as intended.

## Known tradeoff

These are hardcoded links. If SkillEvaluator renames or adds a page, this list will drift silently — nothing fails, the links just stop matching its nav. Worth re-checking after NVIDIA/SkillEvaluator#27 lands, since that PR restructures those docs.

The drift-free alternative is merging both repos into a single Fern instance so navigation is generated rather than transcribed, but that moves SkillEvaluator's URLs and couples the two publish pipelines — not something to do in launch week.