### PR TITLE
feat(ci): support fork pull requests

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -30,8 +30,7 @@ jobs:
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
           SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
           SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
-          SIGNATURE_COMMITTER_NAME: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_NAME || 'nvskills-svc-account' }}
-          SIGNATURE_COMMITTER_EMAIL: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_EMAIL || 'svc-nvskills-signing@nvidia.com' }}
+          SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
           MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
@@ -140,7 +139,10 @@ jobs:
                   "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
                 );
               any(.files[]?; .filename | endswith("/skill.oms.sig")) and
-              all(.files[]?; .filename | generated_artifact)
+              all(.files[]?;
+                ((.previous_filename? // "") | length) == 0 and
+                (.filename | generated_artifact)
+              )
             ' >/dev/null
           }
 
@@ -150,15 +152,15 @@ jobs:
             is_generated_signature_artifact_commit "${commit_json}" || return 1
             printf '%s' "${commit_json}" | jq -e \
               --arg actor "${SIGNATURE_PUSH_ACTOR}" \
-              --arg name "${SIGNATURE_COMMITTER_NAME}" \
-              --arg email "${SIGNATURE_COMMITTER_EMAIL}" '
-                (.author.login? == $actor) or
-                (.committer.login? == $actor) or
+              --arg service_login "${SIGNATURE_SERVICE_ACCOUNT_LOGIN}" '
+                ((.author.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                ((.committer.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
                 (
-                  .commit.author.name == $name and
-                  .commit.author.email == $email and
-                  .commit.committer.name == $name and
-                  .commit.committer.email == $email
+                  ($service_login | length) > 0 and
+                  (
+                    ((.author.login? // "") | ascii_downcase) == ($service_login | ascii_downcase) or
+                    ((.committer.login? // "") | ascii_downcase) == ($service_login | ascii_downcase)
+                  )
                 )
               ' >/dev/null
           }
@@ -359,7 +361,7 @@ jobs:
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "For a fork pull request, install the NVSkills GitHub App on the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+            "For a fork pull request, add the NVSkills signing service account as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -33,7 +33,7 @@ jobs:
           SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
-          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
+          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3300' }}
         run: |
           set -euo pipefail
 
@@ -51,6 +51,25 @@ jobs:
               ''|*[!0-9]*|0) printf '%s' "$2" ;;
               *) printf '%s' "$1" ;;
             esac
+          }
+
+          bounded_positive_integer() {
+            local value
+            local maximum="$3"
+
+            value="$(positive_integer "$1" "$2")"
+            while [ "${value#0}" != "${value}" ]; do
+              value="${value#0}"
+            done
+            if [ -z "${value}" ] || [ "${value}" = "0" ]; then
+              value="$2"
+            fi
+            if [ "${#value}" -gt "${#maximum}" ] ||
+              { [ "${#value}" -eq "${#maximum}" ] && [[ "${value}" > "${maximum}" ]]; }; then
+              echo "::warning::Configured wait value ${value}s exceeds the safe maximum ${maximum}s; clamping it." >&2
+              value="${maximum}"
+            fi
+            printf '%s' "${value}"
           }
 
           case "${HEAD_REF}" in
@@ -274,9 +293,9 @@ jobs:
             status_floor_sha="${latest_generated_signature_sha}"
           fi
 
-          poll_seconds="$(positive_integer "${STATUS_POLL_SECONDS}" 30)"
-          missing_grace_seconds="$(positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120)"
-          max_wait_seconds="$(positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3600)"
+          poll_seconds="$(bounded_positive_integer "${STATUS_POLL_SECONDS}" 30 300)"
+          missing_grace_seconds="$(bounded_positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120 600)"
+          max_wait_seconds="$(bounded_positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3300 3300)"
           elapsed_seconds=0
           status_sha=""
           status_state="missing"

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -28,6 +28,10 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
+          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
+          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
+          SIGNATURE_COMMITTER_NAME: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_NAME || 'nvskills-svc-account' }}
+          SIGNATURE_COMMITTER_EMAIL: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_EMAIL || 'svc-nvskills-signing@nvidia.com' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
           MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
@@ -120,6 +124,44 @@ jobs:
             '
           }
 
+          is_generated_signature_artifact_commit() {
+            local commit_json="$1"
+            local commit_title
+
+            commit_title="$(printf '%s' "${commit_json}" | jq -r '.commit.message | split("\n")[0]')"
+            [ "${commit_title}" = "${SIGNATURE_COMMIT_TITLE}" ] || return 1
+
+            printf '%s' "${commit_json}" | jq -e '
+              def generated_artifact:
+                test(
+                  "^(skills/[^/]+|team-skills/[^/]+/[^/]+|" +
+                  "plugins/[^/]+|plugins/[^/]+/skills/[^/]+)/" +
+                  "(BENCHMARK\\.md|skill-card\\.md|skill\\.oms\\.sig|" +
+                  "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
+                );
+              any(.files[]?; .filename | endswith("/skill.oms.sig")) and
+              all(.files[]?; .filename | generated_artifact)
+            ' >/dev/null
+          }
+
+          is_service_generated_signature_commit() {
+            local commit_json="$1"
+
+            is_generated_signature_artifact_commit "${commit_json}" || return 1
+            printf '%s' "${commit_json}" | jq -e \
+              --arg actor "${SIGNATURE_PUSH_ACTOR}" \
+              --arg name "${SIGNATURE_COMMITTER_NAME}" \
+              --arg email "${SIGNATURE_COMMITTER_EMAIL}" '
+                (.author.login? == $actor) or
+                (.committer.login? == $actor) or
+                (
+                  .commit.author.name == $name and
+                  .commit.author.email == $email and
+                  .commit.committer.name == $name and
+                  .commit.committer.email == $email
+                )
+              ' >/dev/null
+          }
           if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
             echo "Pull request metadata is incomplete."
             exit 1
@@ -188,12 +230,19 @@ jobs:
 
           latest_watched_sha=""
           latest_watched_path=""
+          latest_generated_signature_sha=""
           for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
             commit_sha="${commit_shas[idx]}"
             if [ "${commit_sha}" = "${head_sha}" ]; then
               commit_json="${head_commit_json}"
             else
               commit_json="$(get_commit_json "${commit_sha}")"
+            fi
+            if is_service_generated_signature_commit "${commit_json}"; then
+              if [ -z "${latest_generated_signature_sha}" ]; then
+                latest_generated_signature_sha="${commit_sha}"
+              fi
+              continue
             fi
             watched_path="$(first_watched_path "${commit_json}")"
             if [ -n "${watched_path}" ]; then
@@ -204,11 +253,23 @@ jobs:
           done
 
           if [ -z "${latest_watched_sha}" ]; then
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Failed: generated signature commit \`${latest_generated_signature_sha}\` has no preceding watched-path content commit to validate."
+              exit 1
+            fi
             append_summary \
               "## NVSkills CI required status" \
               "" \
               "Skipped: PR #${pr_number} has no commits that changed watched NVSkills paths."
             exit 0
+          fi
+
+          status_floor_sha="${latest_watched_sha}"
+          if [ -n "${latest_generated_signature_sha}" ]; then
+            status_floor_sha="${latest_generated_signature_sha}"
           fi
 
           poll_seconds="$(positive_integer "${STATUS_POLL_SECONDS}" 30)"
@@ -237,7 +298,7 @@ jobs:
                   '[.[] | select(.context == $context)][0].target_url // ""')"
                 break
               fi
-              if [ "${commit_sha}" = "${latest_watched_sha}" ]; then
+              if [ "${commit_sha}" = "${status_floor_sha}" ]; then
                 break
               fi
             done
@@ -263,7 +324,7 @@ jobs:
                 ;;
             esac
 
-            echo "Waiting for ${STATUS_CONTEXT} at or after ${latest_watched_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
+            echo "Waiting for ${STATUS_CONTEXT} at or after ${status_floor_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
             sleep "${poll_seconds}"
             elapsed_seconds=$((elapsed_seconds + poll_seconds))
           done
@@ -275,6 +336,11 @@ jobs:
               "Passed: \`${STATUS_CONTEXT}\` succeeded for validation evidence commit \`${status_sha}\`." \
               "" \
               "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "" \
+                "Latest generated signature commit: \`${latest_generated_signature_sha}\`."
+            fi
             if [ "${status_sha}" != "${head_sha}" ]; then
               append_summary \
                 "" \
@@ -286,15 +352,14 @@ jobs:
           append_summary \
             "## NVSkills CI required status" \
             "" \
-            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after latest watched commit \`${latest_watched_sha}\` (state: \`${status_state}\`)." \
+            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after required evidence commit \`${status_floor_sha}\` (state: \`${status_state}\`)." \
             "" \
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
-            "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
+            "For a fork pull request, install the NVSkills GitHub App on the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -380,7 +380,7 @@ jobs:
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "For a fork pull request, add the NVSkills signing service account as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+            "For a fork pull request, add \`${SIGNATURE_SERVICE_ACCOUNT_LOGIN}\`, the configured NVSkills signing service account, as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -33,8 +33,31 @@ jobs:
       group: nvskills-ci-request-${{ github.repository }}-${{ github.event.issue.number || github.sha }}
       cancel-in-progress: true
     steps:
+      - name: Check dispatch availability
+        id: dispatch
+        env:
+          DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_TOKEN}" ]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [ "${EVENT_NAME}" = "push" ]; then
+            {
+              echo "## NVSkills CI request"
+              echo
+              echo "Skipped: this trusted signature push has no dispatch secret. The originating central run verifies the generated signature commit."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "Missing NVSKILLS_CI_DISPATCH_TOKEN secret."
+          exit 1
+
       - name: Validate requester permission
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: ${{ steps.dispatch.outputs.enabled == 'true' && github.event_name == 'issue_comment' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -53,6 +76,7 @@ jobs:
 
       - name: Resolve request context
         id: context
+        if: ${{ steps.dispatch.outputs.enabled == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -153,7 +177,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Dispatch NVSkills CI
-        if: steps.context.outputs.should_dispatch == 'true'
+        if: steps.dispatch.outputs.enabled == 'true' && steps.context.outputs.should_dispatch == 'true'
         env:
           DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Replaces #402, which was closed by accident. All commits here are @yashrajp22's, unchanged.

## Why this PR exists

#402 was stacked on `yashraj/reusable-nvskills-status`, the branch behind #398, rather than on `main`. When I merged #398 with `--delete-branch`, GitHub deleted that base branch and auto-closed #402. I then force-pushed a rebase onto the head branch, which makes the closure permanent: the API refuses to reopen a PR whose head was force-pushed after closing. That was my mistake, not the author's, and this PR is the only way to land the work.

The branch has been rebased onto current `main` (post-#398). The file content is byte-identical to what was reviewed on #402; only the commit SHAs changed.

## What the change does

Adds fork pull request support to the NVSkills signing gate, and restores a signature-commit exemption that #398 removed, in a stricter form:

- A commit is exempt only if the title matches, every file is a generated artifact, no file is a rename, and the **author or committer login** is the signing bot or the configured service account. Matching on GitHub's resolved account identity rather than git metadata means it cannot be forged by local git config.
- Rejecting renames closes a path where a renamed file could ride along inside an otherwise generated-looking commit.
- `status_floor_sha` moves up to the signature commit, so validation evidence must exist at or after it.
- Wait values are clamped (`bounded_positive_integer`), capping the gate at 55 minutes.
- The failure message now tells fork authors exactly what to do instead of "forks are not supported".

## Review notes

Fork PRs cannot auto-dispatch signing. The `require-nvskills-ci` job runs on `pull_request` and only calls the status gate, with no secrets. The `request` job that holds `NVSKILLS_CI_DISPATCH_TOKEN` still fires only on a maintainer's `/nvskills-ci` comment or a bot push, and the requester-permission check is intact. I verified `svc-nvskills-signing` exists.

One thing to know before validating: skill signing is currently down org-wide (Harbor Claude Code sandbox pool failing to start, blocking `gate:content:v1` for all teams). The fork path cannot be tested end to end until that is fixed.
