### PR TITLE
fix(sync): recompute changed components after reverts

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -821,6 +821,68 @@ jobs:
       - name: Regenerate README tables
         run: .github/scripts/regenerate-readme.sh
 
+      # The rsync loop records a component as changed the moment rsync
+      # produces a diff, but the drift, compliance and prune steps that run
+      # after it can revert those files. Nothing ever removed the component
+      # from the list, so a component whose skills were all held came out
+      # labelled "updated" — contradicting the held list printed directly
+      # below it in the same PR body, and inflating the title that GitHub
+      # rejects past 256 characters. Recompute from the working tree now
+      # that every step which can mutate it has run.
+      - name: Recompute changed components after reverts
+        run: |
+          set -euo pipefail
+
+          CONFIG=/tmp/components.aggregated.yml
+          recomputed=/tmp/changed-components.recomputed.txt
+          : > "$recomputed"
+
+          if [ -f "$CONFIG" ]; then
+            component_count=$(yq -r '.components | length' "$CONFIG")
+            for ((i = 0; i < component_count; i++)); do
+              name=$(yq -r ".components[$i].name" "$CONFIG")
+              skill_count=$(yq -r ".components[$i].skills | length" "$CONFIG")
+              for ((j = 0; j < skill_count; j++)); do
+                catalog_dir=$(yq -r ".components[$i].skills[$j].catalog_dir" "$CONFIG")
+                if [ -n "$(git status --porcelain "skills/$catalog_dir" 2>/dev/null)" ]; then
+                  echo "- $name" >> "$recomputed"
+                  break
+                fi
+              done
+            done
+          fi
+
+          # Entries that are not components describe changes outside
+          # skills/, so they are re-established from their own evidence
+          # rather than carried over from the pre-revert list.
+          if [ -s /tmp/pruned-orphans.txt ]; then
+            echo "- orphan pruning" >> "$recomputed"
+          fi
+          if [ -n "$(git status --porcelain plugins .agents/plugins .claude-plugin .cursor-plugin 2>/dev/null)" ]; then
+            echo "- plugin catalog" >> "$recomputed"
+          fi
+
+          sort -u -o "$recomputed" "$recomputed"
+
+          # A sync can legitimately change only README tables or generated
+          # catalog files. Those still warrant a PR, so never let the
+          # recompute turn a dirty tree into "no changes".
+          if [ ! -s "$recomputed" ] && [ -n "$(git status --porcelain)" ]; then
+            echo "- catalog maintenance" >> "$recomputed"
+          fi
+
+          before=$(wc -l < /tmp/changed-components.txt | tr -d ' ')
+          after=$(wc -l < "$recomputed" | tr -d ' ')
+          echo "changed components: ${before} recorded during rsync -> ${after} after reverts"
+          if [ "${before}" -ne "${after}" ]; then
+            echo "Dropped from the list (rsynced then reverted or removed):"
+            comm -23 \
+              <(sort -u /tmp/changed-components.txt) \
+              <(sort -u "$recomputed") | sed 's/^/  /'
+          fi
+
+          mv "$recomputed" /tmp/changed-components.txt
+
       - name: Build sync summary
         id: summary
         run: |


### PR DESCRIPTION
## The problem

The rsync loop records a component as changed the moment rsync produces a diff (line 129). The drift, compliance and prune steps run *after* it and revert those files, but nothing ever removed the component from the list — every later write is an append, and line 844 only dedupes.

So a component whose skills were all held for signature drift still comes out labelled "updated", contradicting the held list printed directly below it in the same PR body.

This is not a one-off. Measured across four syncs:

| sync PR | listed as "Components updated" | skill dirs actually changed |
|---|---|---|
| #417 | ~90 | **1** |
| #409 | 29 | **3** |
| #403 | 29 | **1** |
| #396 | 31 | **2** |

#417 named AIQ, CUDA-Q, DeepStream, Megatron-Core, NeMo MBridge, NeMo Relay, NeMo Retriever, TAO Toolkit and cuDF while changing exactly 8 files, all under `skills/doca-telemetry-exporter`. Every other component on that list appears in the held section.

It also explains the title length that #412 had to cap — the title is built from this same list, so it was long because it named components that were never updated.

## The fix

One new step after `Regenerate README tables`, before `Build sync summary`, that rebuilds the list from the working tree once every mutating step has run.

Two guards worth calling out:

- Entries that are not components (`orphan pruning`, `plugin catalog`) describe changes outside `skills/`, so they are re-established from their own evidence rather than carried over.
- A dirty tree can never recompute to "no changes". A sync that only touches README tables or generated files still opens a PR, via a `catalog maintenance` entry.

The step also logs what it dropped, so the reverted-vs-updated distinction is visible in the run output.

## Verification

Extracted the step and ran it against the real `components.d` set (36 components) with a working tree manipulated per case:

| Case | Expected | Result |
|---|---|---|
| #417 replay: 10 listed, only DOCA dirty | `DOCA` only | 10 → 1 ✅ |
| All reverted, clean tree | empty, no PR | empty ✅ |
| README-only change | PR still opens | `catalog maintenance` ✅ |
| Orphan pruning ran | reported | `orphan pruning` ✅ |
| Two components dirty | both listed | `CUDA-Q, DOCA` ✅ |
| Skill dir deleted by compliance | still reported | `CUDA-Q` ✅ |
