### PR TITLE
Revert "feat(ci): support fork pull requests" (#416)

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -30,7 +30,8 @@ jobs:
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
           SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
           SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
-          SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
+          SIGNATURE_COMMITTER_NAME: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_NAME || 'nvskills-svc-account' }}
+          SIGNATURE_COMMITTER_EMAIL: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_EMAIL || 'svc-nvskills-signing@nvidia.com' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
           MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
@@ -139,10 +140,7 @@ jobs:
                   "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
                 );
               any(.files[]?; .filename | endswith("/skill.oms.sig")) and
-              all(.files[]?;
-                ((.previous_filename? // "") | length) == 0 and
-                (.filename | generated_artifact)
-              )
+              all(.files[]?; .filename | generated_artifact)
             ' >/dev/null
           }
 
@@ -152,15 +150,15 @@ jobs:
             is_generated_signature_artifact_commit "${commit_json}" || return 1
             printf '%s' "${commit_json}" | jq -e \
               --arg actor "${SIGNATURE_PUSH_ACTOR}" \
-              --arg service_login "${SIGNATURE_SERVICE_ACCOUNT_LOGIN}" '
-                ((.author.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
-                ((.committer.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+              --arg name "${SIGNATURE_COMMITTER_NAME}" \
+              --arg email "${SIGNATURE_COMMITTER_EMAIL}" '
+                (.author.login? == $actor) or
+                (.committer.login? == $actor) or
                 (
-                  ($service_login | length) > 0 and
-                  (
-                    ((.author.login? // "") | ascii_downcase) == ($service_login | ascii_downcase) or
-                    ((.committer.login? // "") | ascii_downcase) == ($service_login | ascii_downcase)
-                  )
+                  .commit.author.name == $name and
+                  .commit.author.email == $email and
+                  .commit.committer.name == $name and
+                  .commit.committer.email == $email
                 )
               ' >/dev/null
           }
@@ -361,7 +359,7 @@ jobs:
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "For a fork pull request, add the NVSkills signing service account as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+            "For a fork pull request, install the NVSkills GitHub App on the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -33,7 +33,7 @@ jobs:
           SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
-          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3300' }}
+          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
         run: |
           set -euo pipefail
 
@@ -51,25 +51,6 @@ jobs:
               ''|*[!0-9]*|0) printf '%s' "$2" ;;
               *) printf '%s' "$1" ;;
             esac
-          }
-
-          bounded_positive_integer() {
-            local value
-            local maximum="$3"
-
-            value="$(positive_integer "$1" "$2")"
-            while [ "${value#0}" != "${value}" ]; do
-              value="${value#0}"
-            done
-            if [ -z "${value}" ] || [ "${value}" = "0" ]; then
-              value="$2"
-            fi
-            if [ "${#value}" -gt "${#maximum}" ] ||
-              { [ "${#value}" -eq "${#maximum}" ] && [[ "${value}" > "${maximum}" ]]; }; then
-              echo "::warning::Configured wait value ${value}s exceeds the safe maximum ${maximum}s; clamping it." >&2
-              value="${maximum}"
-            fi
-            printf '%s' "${value}"
           }
 
           case "${HEAD_REF}" in
@@ -293,9 +274,9 @@ jobs:
             status_floor_sha="${latest_generated_signature_sha}"
           fi
 
-          poll_seconds="$(bounded_positive_integer "${STATUS_POLL_SECONDS}" 30 300)"
-          missing_grace_seconds="$(bounded_positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120 600)"
-          max_wait_seconds="$(bounded_positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3300 3300)"
+          poll_seconds="$(positive_integer "${STATUS_POLL_SECONDS}" 30)"
+          missing_grace_seconds="$(positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120)"
+          max_wait_seconds="$(positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3600)"
           elapsed_seconds=0
           status_sha=""
           status_state="missing"

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -28,10 +28,6 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
-          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
-          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
-          SIGNATURE_COMMITTER_NAME: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_NAME || 'nvskills-svc-account' }}
-          SIGNATURE_COMMITTER_EMAIL: ${{ vars.NVSKILLS_SIGNATURE_COMMITTER_EMAIL || 'svc-nvskills-signing@nvidia.com' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
           MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
@@ -124,44 +120,6 @@ jobs:
             '
           }
 
-          is_generated_signature_artifact_commit() {
-            local commit_json="$1"
-            local commit_title
-
-            commit_title="$(printf '%s' "${commit_json}" | jq -r '.commit.message | split("\n")[0]')"
-            [ "${commit_title}" = "${SIGNATURE_COMMIT_TITLE}" ] || return 1
-
-            printf '%s' "${commit_json}" | jq -e '
-              def generated_artifact:
-                test(
-                  "^(skills/[^/]+|team-skills/[^/]+/[^/]+|" +
-                  "plugins/[^/]+|plugins/[^/]+/skills/[^/]+)/" +
-                  "(BENCHMARK\\.md|skill-card\\.md|skill\\.oms\\.sig|" +
-                  "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
-                );
-              any(.files[]?; .filename | endswith("/skill.oms.sig")) and
-              all(.files[]?; .filename | generated_artifact)
-            ' >/dev/null
-          }
-
-          is_service_generated_signature_commit() {
-            local commit_json="$1"
-
-            is_generated_signature_artifact_commit "${commit_json}" || return 1
-            printf '%s' "${commit_json}" | jq -e \
-              --arg actor "${SIGNATURE_PUSH_ACTOR}" \
-              --arg name "${SIGNATURE_COMMITTER_NAME}" \
-              --arg email "${SIGNATURE_COMMITTER_EMAIL}" '
-                (.author.login? == $actor) or
-                (.committer.login? == $actor) or
-                (
-                  .commit.author.name == $name and
-                  .commit.author.email == $email and
-                  .commit.committer.name == $name and
-                  .commit.committer.email == $email
-                )
-              ' >/dev/null
-          }
           if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
             echo "Pull request metadata is incomplete."
             exit 1
@@ -230,19 +188,12 @@ jobs:
 
           latest_watched_sha=""
           latest_watched_path=""
-          latest_generated_signature_sha=""
           for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
             commit_sha="${commit_shas[idx]}"
             if [ "${commit_sha}" = "${head_sha}" ]; then
               commit_json="${head_commit_json}"
             else
               commit_json="$(get_commit_json "${commit_sha}")"
-            fi
-            if is_service_generated_signature_commit "${commit_json}"; then
-              if [ -z "${latest_generated_signature_sha}" ]; then
-                latest_generated_signature_sha="${commit_sha}"
-              fi
-              continue
             fi
             watched_path="$(first_watched_path "${commit_json}")"
             if [ -n "${watched_path}" ]; then
@@ -253,23 +204,11 @@ jobs:
           done
 
           if [ -z "${latest_watched_sha}" ]; then
-            if [ -n "${latest_generated_signature_sha}" ]; then
-              append_summary \
-                "## NVSkills CI required status" \
-                "" \
-                "Failed: generated signature commit \`${latest_generated_signature_sha}\` has no preceding watched-path content commit to validate."
-              exit 1
-            fi
             append_summary \
               "## NVSkills CI required status" \
               "" \
               "Skipped: PR #${pr_number} has no commits that changed watched NVSkills paths."
             exit 0
-          fi
-
-          status_floor_sha="${latest_watched_sha}"
-          if [ -n "${latest_generated_signature_sha}" ]; then
-            status_floor_sha="${latest_generated_signature_sha}"
           fi
 
           poll_seconds="$(positive_integer "${STATUS_POLL_SECONDS}" 30)"
@@ -298,7 +237,7 @@ jobs:
                   '[.[] | select(.context == $context)][0].target_url // ""')"
                 break
               fi
-              if [ "${commit_sha}" = "${status_floor_sha}" ]; then
+              if [ "${commit_sha}" = "${latest_watched_sha}" ]; then
                 break
               fi
             done
@@ -324,7 +263,7 @@ jobs:
                 ;;
             esac
 
-            echo "Waiting for ${STATUS_CONTEXT} at or after ${status_floor_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
+            echo "Waiting for ${STATUS_CONTEXT} at or after ${latest_watched_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
             sleep "${poll_seconds}"
             elapsed_seconds=$((elapsed_seconds + poll_seconds))
           done
@@ -336,11 +275,6 @@ jobs:
               "Passed: \`${STATUS_CONTEXT}\` succeeded for validation evidence commit \`${status_sha}\`." \
               "" \
               "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
-            if [ -n "${latest_generated_signature_sha}" ]; then
-              append_summary \
-                "" \
-                "Latest generated signature commit: \`${latest_generated_signature_sha}\`."
-            fi
             if [ "${status_sha}" != "${head_sha}" ]; then
               append_summary \
                 "" \
@@ -352,14 +286,15 @@ jobs:
           append_summary \
             "## NVSkills CI required status" \
             "" \
-            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after required evidence commit \`${status_floor_sha}\` (state: \`${status_state}\`)." \
+            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after latest watched commit \`${latest_watched_sha}\` (state: \`${status_state}\`)." \
             "" \
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "For a fork pull request, install the NVSkills GitHub App on the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+            "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
+            "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -380,7 +380,7 @@ jobs:
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "For a fork pull request, add \`${SIGNATURE_SERVICE_ACCOUNT_LOGIN}\`, the configured NVSkills signing service account, as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
+            "For a fork pull request, add the NVSkills signing service account as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -33,31 +33,8 @@ jobs:
       group: nvskills-ci-request-${{ github.repository }}-${{ github.event.issue.number || github.sha }}
       cancel-in-progress: true
     steps:
-      - name: Check dispatch availability
-        id: dispatch
-        env:
-          DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-          if [ -n "${DISPATCH_TOKEN}" ]; then
-            echo "enabled=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          if [ "${EVENT_NAME}" = "push" ]; then
-            {
-              echo "## NVSkills CI request"
-              echo
-              echo "Skipped: this trusted signature push has no dispatch secret. The originating central run verifies the generated signature commit."
-            } >> "${GITHUB_STEP_SUMMARY}"
-            echo "enabled=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          echo "Missing NVSKILLS_CI_DISPATCH_TOKEN secret."
-          exit 1
-
       - name: Validate requester permission
-        if: ${{ steps.dispatch.outputs.enabled == 'true' && github.event_name == 'issue_comment' }}
+        if: ${{ github.event_name == 'issue_comment' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -76,7 +53,6 @@ jobs:
 
       - name: Resolve request context
         id: context
-        if: ${{ steps.dispatch.outputs.enabled == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -177,7 +153,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Dispatch NVSkills CI
-        if: steps.dispatch.outputs.enabled == 'true' && steps.context.outputs.should_dispatch == 'true'
+        if: steps.context.outputs.should_dispatch == 'true'
         env:
           DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Reverts the four commits merged in #416.

| Commit | Reverted |
|---|---|
| `cd5892d1` | feat(ci): support fork pull requests |
| `344a55b8` | fix(ci): recognize service account signatures |
| `24955ac4` | fix(ci): bound required status polling |
| `19bba972` | fix(ci): name fork signing account in failures |

Requested by @yashrajp22.

## Scope

Net effect is 11 insertions, 121 deletions across `require-nvskills-status.yml` and `team-request.yml`. Verified after reverting:

- `NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN` and the fork-path guidance are gone
- `workflow_call` from #398 is intact — the reusable-gate and validation-evidence work (`b0a9f306`, `b7d7834c`) is untouched

## Consequence

Fork-PR support is removed. `/nvskills-ci` will again reject fork pull requests, so contributors must move work to a branch in this repository before signing. NVIDIA/Megatron-LM#6163 is currently blocked on exactly this path.

Each revert carries a DCO sign-off.