### PR TITLE
docs: put evaluation in the trust pipeline

### DIFF
--- a/docs/agent-skill-trust-pipeline.mdx
+++ b/docs/agent-skill-trust-pipeline.mdx
@@ -17,7 +17,7 @@ A skill on its own is a set of statements about what it does and how safe it is.
 
 ## One Framework, Three Tiers
 
-**SkillSpector is part of SkillEvaluator.** It is the security scanner that runs as SkillEvaluator's first tier, not a separate step alongside it. Running SkillEvaluator runs SkillSpector.
+**[SkillSpector](https://github.com/NVIDIA/SkillSpector) is part of SkillEvaluator.** It is the security scanner that runs as SkillEvaluator's first tier, not a separate step alongside it. Running SkillEvaluator runs SkillSpector.
 
 - **Tier 1 — Validation.** Schema, license, PII, Unicode safety, and the full SkillSpector security scan. Deterministic, and it can fail a skill outright.
 - **Tier 2 — Deduplication.** Semantic overlap against skills already in the catalog, so the same capability is not published twice under two names.

--- a/docs/agent-skill-trust-pipeline.mdx
+++ b/docs/agent-skill-trust-pipeline.mdx
@@ -73,7 +73,7 @@ Before approval, reviewers should be able to answer:
 - Are permissions limited to what the skill actually needs?
 - Are network, shell, file, environment, and MCP capabilities declared in the `SKILL.md` frontmatter and justified by the skill's stated use case?
 - Are known risks and mitigations written in plain language?
-- Does the `BENCHMARK.md` verdict show the skill improving agent output, and is any negative result on a supported agent understood?
+- Does the `BENCHMARK.md` verdict show the skill improving agent output?
 - Does the signature verify against the released directory?
 
 If one of those answers is unclear, the skill is not ready for broad deployment.

--- a/docs/agent-skill-trust-pipeline.mdx
+++ b/docs/agent-skill-trust-pipeline.mdx
@@ -1,38 +1,54 @@
 ---
 title: "A Trust Pipeline for Agent Skills"
-description: "How scanning, signing, and skill cards work together to make AI agent skills easier to review and safer to deploy."
+description: "How scanning, evaluation, signing, and skill cards work together to make AI agent skills easier to review and safer to deploy."
 ---
 
 AI agent skills package instructions, code, references, and assets into a format agents can reuse. They are also a new supply-chain surface: a skill can ask an agent to run commands, read files, call tools, fetch remote content, or make decisions on a user's behalf.
 
-A practical release process should answer three questions before a skill is installed:
+A skill on its own is a set of statements about what it does and how safe it is. The pipeline exists to replace those statements with artifacts a reviewer can check without taking the author's word for it. Each stage answers one question and leaves behind one piece of evidence.
 
-- What does this skill claim to do?
-- What did automated review find?
-- Can users verify the reviewed artifact is the artifact they received?
+| Question | Evidence produced | Stage |
+|---|---|---|
+| Is this skill safe to run? | Scan report over the complete bundle | SkillSpector, inside SkillEvaluator Tier 1 |
+| Does it already exist in the catalog? | Semantic overlap report | SkillEvaluator Tier 2 |
+| Does it improve an agent's output? | `BENCHMARK.md` with per-dimension scores | SkillEvaluator Tier 3 |
+| What does it do, and who owns it? | Skill card | Author, reviewed |
+| Is this the artifact that was reviewed? | Detached signature over the directory | OMS signing |
 
-The combination of SkillSpector scanning, a completed skill card, and an OMS signature gives those questions a concrete place in the workflow.
+## One Framework, Three Tiers
+
+**SkillSpector is part of SkillEvaluator.** It is the security scanner that runs as SkillEvaluator's first tier, not a separate step alongside it. Running SkillEvaluator runs SkillSpector.
+
+- **Tier 1 — Validation.** Schema, license, PII, Unicode safety, and the full SkillSpector security scan. Deterministic, and it can fail a skill outright.
+- **Tier 2 — Deduplication.** Semantic overlap against skills already in the catalog, so the same capability is not published twice under two names.
+- **Tier 3 — Live evaluation.** The skill is exercised by real agents in a sandbox against a task set, with and without the skill loaded. Each dimension is scored in both conditions, and the difference is the skill's measured contribution.
+
+A skill can pass every security check and still make an agent worse. Tier 3 is where that shows up. See [Evaluate Agent Skills Before Publication](/skills/evaluating-agent-skills) for what to ship and how to read the result.
 
 ## The Release Gate
 
 Use this order for skills intended for enterprise deployment as **NVIDIA-Verified**:
 
 1. Author the skill with a narrow purpose, clear triggers, and explicit permissions.
-2. Run SkillSpector against the complete skill directory.
-3. Fix high-risk findings or record why a finding is accepted.
-4. Complete the skill card with owner, license, use case, deployment geography, output shape, risks, and references.
-5. Sign the skill directory and publish the detached `skill.oms.sig` file with the skill.
-6. Ask consumers or CI to verify the signature before installation.
+2. Ship an evaluation task set at `evals/evals.json` so Tier 3 has something to measure against.
+3. Run SkillEvaluator against the complete skill directory. Tier 1 includes the SkillSpector scan.
+4. Fix high-risk findings, or record why a finding is accepted.
+5. Review the `BENCHMARK.md` verdict. A skill that does not improve agent performance is not ready, regardless of how it scores on security.
+6. Complete the skill card with owner, license, use case, deployment geography, output shape, risks, and references.
+7. Sign the skill directory and publish the detached `skill.oms.sig` file with the skill.
+8. Ask consumers or CI to verify the signature before installation.
 
 <Note>
-Scanning and signing solve different problems. Scanning asks whether the content appears safe enough to ship. Signing asks whether the shipped content is the same content that was reviewed.
+Scanning, evaluation, and signing solve three different problems. Scanning asks whether the content appears safe to ship. Evaluation asks whether it does any good. Signing asks whether what shipped is what was reviewed.
 </Note>
 
 ## What Each Layer Catches
 
 | Layer | Primary job | Example evidence |
 |---|---|---|
-| SkillSpector scan | Detect risky behavior before installation | Markdown, JSON, SARIF, or terminal report |
+| SkillSpector scan (SkillEvaluator Tier 1) | Detect risky behavior before installation | Markdown, JSON, SARIF, or terminal report |
+| Semantic deduplication (Tier 2) | Prevent duplicate capability entering the catalog | Overlap report against catalog skills |
+| Live agent evaluation (Tier 3) | Measure whether the skill improves agent output | `BENCHMARK.md` with per-dimension scores and verdict |
 | Skill card | State human-readable intent, ownership, limits, and output behavior | `Skill Card.md` or equivalent release metadata |
 | OMS signature | Verify integrity and authenticity of the published skill directory | `skill.oms.sig` plus NVIDIA signing certificate |
 
@@ -43,7 +59,7 @@ Every released skill should ship or link to:
 - `SKILL.md`
 - Supporting `scripts/`, `references/`, and `assets/` as needed
 - A completed skill card (`skill-card.md`)
-- A SkillSpector report or CI link
+- A SkillEvaluator report or CI link
 - A Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
 - `BENCHMARK.md` capturing the benchmark report from the evaluation run
 - `skill.oms.sig`
@@ -57,6 +73,7 @@ Before approval, reviewers should be able to answer:
 - Are permissions limited to what the skill actually needs?
 - Are network, shell, file, environment, and MCP capabilities declared in the `SKILL.md` frontmatter and justified by the skill's stated use case?
 - Are known risks and mitigations written in plain language?
+- Does the `BENCHMARK.md` verdict show the skill improving agent output, and is any negative result on a supported agent understood?
 - Does the signature verify against the released directory?
 
 If one of those answers is unclear, the skill is not ready for broad deployment.

--- a/docs/evaluating-agent-skills.mdx
+++ b/docs/evaluating-agent-skills.mdx
@@ -9,7 +9,7 @@ Evaluation answers that second question by measurement rather than assertion: an
 
 ## What SkillEvaluator Runs
 
-**SkillSpector is part of SkillEvaluator.** It is the security scanner that runs as Tier 1, not a separate tool you run alongside it.
+SkillEvaluator runs three tiers over a skill: deterministic validation, semantic deduplication against the catalog, and live agent evaluation in a sandbox. The security checks in Tier 1 are run by [SkillSpector](https://github.com/NVIDIA/SkillSpector), which is part of SkillEvaluator rather than a separate tool you run alongside it.
 
 | Tier | What it does | Can it block publication? |
 |---|---|---|

--- a/docs/evaluating-agent-skills.mdx
+++ b/docs/evaluating-agent-skills.mdx
@@ -33,11 +33,6 @@ Scores are shown as `baseline → with skill (change)` for each agent, across fi
 
 **PASS** requires every configured dimension to pass for at least one supported agent. Measured change is reported as diagnostic evidence and does not by itself override that gate.
 
-### Two Things to Keep in Mind
-
-- **Change can be negative.** A skill may improve one agent and degrade another. That is a real result worth understanding, not noise to discard.
-- **A single run is directional, not precise.** Scores move between runs on the same skill. Treat a small difference as a range rather than a measurement.
-
 <Note>
 For installation and the commands to run an evaluation, see the [SkillEvaluator documentation](https://docs.nvidia.com/skills/skillevaluator).
 </Note>

--- a/docs/evaluating-agent-skills.mdx
+++ b/docs/evaluating-agent-skills.mdx
@@ -1,0 +1,43 @@
+---
+title: "Evaluate Agent Skills Before Publication"
+description: "How SkillEvaluator measures whether a skill improves an agent's output, what to ship so it can run, and how to read the result."
+---
+
+Scanning tells you whether a skill is safe to run. It does not tell you whether the skill is any good. A skill can be perfectly safe, well documented, correctly signed, and still leave an agent no better off than it was without it.
+
+Evaluation answers that second question by measurement rather than assertion: an agent attempts a fixed set of tasks twice, once with the skill loaded and once without, and the difference is recorded.
+
+## What SkillEvaluator Runs
+
+**SkillSpector is part of SkillEvaluator.** It is the security scanner that runs as Tier 1, not a separate tool you run alongside it.
+
+| Tier | What it does | Can it block publication? |
+|---|---|---|
+| **Tier 1 — Validation** | Schema, license, PII, Unicode safety, and the full SkillSpector security scan | Yes, on high-severity findings |
+| **Tier 2 — Deduplication** | Semantic overlap against skills already in the catalog | Advisory |
+| **Tier 3 — Live evaluation** | Real agents run the task set in a sandbox, with and without the skill | Yes, via the verdict |
+
+## What You Need to Ship
+
+Tier 3 cannot run without a task set. Provide one at `evals/evals.json`, next to your `SKILL.md`. Other accepted locations are `evals/*.json`, `eval/*.json`, and `benchmark/evals.json`.
+
+Without it, Tier 3 is skipped and the generated `BENCHMARK.md` reports no live results — which is treated the same as a missing report during review.
+
+Write tasks that reflect what the skill is actually for. Include negative cases, where the correct behavior is for the agent *not* to use the skill.
+
+## Reading a BENCHMARK.md
+
+Every evaluated skill publishes a `BENCHMARK.md` alongside it. It records the agents used, the evaluation date, per-dimension scores in both conditions, and an overall verdict.
+
+Scores are shown as `baseline → with skill (change)` for each agent, across five dimensions: security, correctness, discoverability, effectiveness, and efficiency.
+
+**PASS** requires every configured dimension to pass for at least one supported agent. Measured change is reported as diagnostic evidence and does not by itself override that gate.
+
+### Two Things to Keep in Mind
+
+- **Change can be negative.** A skill may improve one agent and degrade another. That is a real result worth understanding, not noise to discard.
+- **A single run is directional, not precise.** Scores move between runs on the same skill. Treat a small difference as a range rather than a measurement.
+
+<Note>
+For installation and the commands to run an evaluation, see the [SkillEvaluator documentation](https://docs.nvidia.com/skills/skillevaluator).
+</Note>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -73,7 +73,7 @@ Runtime controls govern what an agent can do during execution. Verified skills g
     icon="route"
     href="/skills/agent-skill-trust-pipeline"
   >
-    The end-to-end workflow that links scanning, skill cards, and cryptographic signing into a release gate.
+    The end-to-end workflow that links scanning, evaluation, skill cards, and cryptographic signing into a release gate.
   </Card>
   <Card
     title="Scan Agent Skills Before Installation"
@@ -81,6 +81,13 @@ Runtime controls govern what an agent can do during execution. Verified skills g
     href="/skills/scanning-agent-skills"
   >
     How SkillSpector checks skill bundles for security risks, malicious patterns, and supply-chain issues.
+  </Card>
+  <Card
+    title="Evaluate Agent Skills Before Publication"
+    icon="gauge"
+    href="/skills/evaluating-agent-skills"
+  >
+    How SkillEvaluator measures whether a skill improves an agent's output, and how to read the result.
   </Card>
   <Card
     title="Verify Signed Agent Skills"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -57,10 +57,11 @@ The catalogs group skills by the kind of work the user is trying to do, while th
 
 NVIDIA-verified skills are also release artifacts. Before a skill is published, the catalog expects the same discipline we expect from deployable software: security review, provenance, ownership, clear use boundaries, and verification instructions.
 
-Verified means the skill is cataloged, scanned, signed, and documented with a skill card:
+Verified means the skill is cataloged, scanned, evaluated, signed, and documented with a skill card:
 
 - **Cataloged** from the product team or source repository that owns the capability.
 - **Scanned** before publication for software risks and agent-native risks such as hidden instructions, prompt injection, trigger abuse, excessive agency, and mismatches between declared purpose and bundled behavior.
+- **Evaluated** against a task set to measure whether the skill improves an agent's output. An agent attempts the same tasks with and without the skill, and the difference is recorded per dimension — correctness, security, discoverability, effectiveness, and efficiency. The result is published as a `BENCHMARK.md` report carrying a verdict and the measured change.
 - **Signed** with a detached `skill.oms.sig` so users can verify that the downloaded skill is authentic and unchanged.
 - **Documented** with a skill card that records what the skill does, who owns it, how it is licensed, what it depends on, and what limitations or risks users should understand.
 

--- a/docs/release-checklist.mdx
+++ b/docs/release-checklist.mdx
@@ -13,17 +13,17 @@ Use this checklist when preparing a skill for review, publication, or internal d
 - Scripts and references are necessary for the stated use case.
 - Test fixtures, examples, and generated files are either intentionally included or excluded.
 
-## Scanning
+## Scanning and Evaluation
 
-- Run SkillSpector against the complete skill directory.
+- Ship an evaluation task set at `evals/evals.json` so Tier 3 can run.
+- Run SkillEvaluator against the complete skill directory. Tier 1 includes the SkillSpector scan.
 - Save a Markdown or SARIF report for review.
 - Resolve critical and high findings before release.
 - Review medium findings for policy or usability impact.
 - Confirm the skill description matches executable behavior.
+- Review the `BENCHMARK.md` verdict before publishing.
 
-```bash
-skillspector scan ./skill-name --format markdown --output skillspector-report.md
-```
+For installation and the commands to run an evaluation, see the [SkillEvaluator documentation](https://docs.nvidia.com/skills/skillevaluator).
 
 ## Skill Card
 
@@ -55,7 +55,7 @@ The release packet should include:
 
 - Skill source or release artifact
 - Skill card (`skill-card.md`)
-- SkillSpector report or CI link
+- SkillEvaluator report or CI link (includes the Tier 1 SkillSpector scan)
 - Tier-3 evaluation dataset — accepted at `evals/evals.json`, `evals/*.json`, `eval/*.json`, or `benchmark/evals.json`
 - `BENCHMARK.md` capturing the benchmark report from the evaluation run
 - Detached OMS signature (`skill.oms.sig`)

--- a/docs/scanning-agent-skills.mdx
+++ b/docs/scanning-agent-skills.mdx
@@ -5,11 +5,13 @@ description: "Use SkillSpector to detect vulnerabilities, malicious patterns, an
 
 Agent skills can look harmless while still containing risky instructions, hidden metadata, overbroad permissions, or executable code that does more than the description says. SkillSpector is a security scanner for AI agent skills that helps answer: should this skill be installed?
 
+SkillSpector is also the security tier inside SkillEvaluator. If you are preparing a skill for publication, running SkillEvaluator runs these checks as Tier 1 — see [Evaluate Agent Skills Before Publication](/skills/evaluating-agent-skills). This page covers running the scanner directly, which is what you want when reviewing a skill before installing it.
+
 SkillSpector accepts Git repositories, URLs, zip files, directories, and single files. It runs fast static checks by default and can add optional LLM semantic analysis for issues that require intent comparison.
 
 ## What SkillSpector Checks
 
-SkillSpector covers 64 vulnerability patterns across 16 categories, including:
+SkillSpector covers 68 vulnerability patterns across 17 categories, including:
 
 - Prompt injection
 - Data exfiltration
@@ -106,7 +108,7 @@ skillspector scan ./my-skill/ --no-llm
 
 ## Triage Policy
 
-Use scan results as a release gate:
+Use scan results as one of the release gates. Scanning determines whether a skill is safe to ship; evaluation determines whether it improves an agent's output. Both apply before publication:
 
 | Finding type | Recommended action |
 |---|---|

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -30,6 +30,9 @@ navigation:
       - page: Scan Agent Skills Before Installation
         path: ../docs/scanning-agent-skills.mdx
         slug: scanning-agent-skills
+      - page: Evaluate Agent Skills Before Publication
+        path: ../docs/evaluating-agent-skills.mdx
+        slug: evaluating-agent-skills
       - page: Verify Signed Agent Skills
         path: ../docs/signing-agent-skills.mdx
         slug: signing-agent-skills
@@ -47,15 +50,3 @@ navigation:
     contents:
       - link: Overview
         href: https://docs.nvidia.com/skills/skillevaluator
-      - link: Quickstart
-        href: https://docs.nvidia.com/skills/skillevaluator/quickstart
-      - link: Installation
-        href: https://docs.nvidia.com/skills/skillevaluator/installation
-      - link: "Tier 1: Validation"
-        href: https://docs.nvidia.com/skills/skillevaluator/tier1-validation
-      - link: "Tier 2: Deduplication"
-        href: https://docs.nvidia.com/skills/skillevaluator/tier2-deduplication
-      - link: "Tier 3: Live Evaluation"
-        href: https://docs.nvidia.com/skills/skillevaluator/tier3-live-evaluation
-      - link: CLI Reference
-        href: https://docs.nvidia.com/skills/skillevaluator/cli-reference


### PR DESCRIPTION
## Why

The docs describe scanning, skill cards and signing as the controls that make a skill trustworthy, but say nothing about whether the skill actually works. They also present SkillSpector as a standalone tool, when it is the security tier inside SkillEvaluator.

## Changes

**`docs/index.mdx`** — adds **Evaluated** as a trust control, so the set reads cataloged, scanned, evaluated, signed, documented.

**`docs/agent-skill-trust-pipeline.mdx`** — rewritten. Each stage now states the question it answers and the evidence it produces, rather than leaving trust as an assertion. Adds the three tiers, and the release gate goes from 6 steps to 8: ship an eval task set, run SkillEvaluator, review the verdict.

**`docs/evaluating-agent-skills.mdx`** — new page, placed after the scanning page. Covers what each tier does, what to ship so Tier 3 can run (`evals/evals.json`, and what happens without it), and how to read a `BENCHMARK.md`.

**`docs/scanning-agent-skills.mdx`** — places SkillSpector as SkillEvaluator Tier 1 while keeping the page useful for its own case: reviewing a skill *before installing it*, as opposed to preparing one for publication. Triage policy reworded now that scanning is one gate of several. Pattern count corrected from 64/16 to 68/17 to match the SkillSpector README.

**`docs/release-checklist.mdx`** — `Scanning` becomes `Scanning and Evaluation`. Runs SkillEvaluator rather than SkillSpector directly, and references the SkillEvaluator docs instead of printing a command that would drift out of date here.

**`fern/docs.yml`** — SkillEvaluator section trimmed to Overview as a reference; new page registered after the scanning page.

## Worth a reviewer's attention

**SkillSpector is now stated to be part of SkillEvaluator**, in three places, because people land on pages directly rather than reading in order. This is the substantive framing change in the PR.


## Validation

- `fern/docs.yml` parses; every `path:` in the nav resolves to a file
- The internal link `/skills/evaluating-agent-skills` resolves to a registered slug
- Rendered preview of all five files reviewed before commit
