### PR TITLE
feat(ci): restore fork pull request support

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -28,9 +28,12 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
+          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
+          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
+          SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
-          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
+          MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3300' }}
         run: |
           set -euo pipefail
 
@@ -48,6 +51,25 @@ jobs:
               ''|*[!0-9]*|0) printf '%s' "$2" ;;
               *) printf '%s' "$1" ;;
             esac
+          }
+
+          bounded_positive_integer() {
+            local value
+            local maximum="$3"
+
+            value="$(positive_integer "$1" "$2")"
+            while [ "${value#0}" != "${value}" ]; do
+              value="${value#0}"
+            done
+            if [ -z "${value}" ] || [ "${value}" = "0" ]; then
+              value="$2"
+            fi
+            if [ "${#value}" -gt "${#maximum}" ] ||
+              { [ "${#value}" -eq "${#maximum}" ] && [[ "${value}" > "${maximum}" ]]; }; then
+              echo "::warning::Configured wait value ${value}s exceeds the safe maximum ${maximum}s; clamping it." >&2
+              value="${maximum}"
+            fi
+            printf '%s' "${value}"
           }
 
           case "${HEAD_REF}" in
@@ -120,6 +142,47 @@ jobs:
             '
           }
 
+          is_generated_signature_artifact_commit() {
+            local commit_json="$1"
+            local commit_title
+
+            commit_title="$(printf '%s' "${commit_json}" | jq -r '.commit.message | split("\n")[0]')"
+            [ "${commit_title}" = "${SIGNATURE_COMMIT_TITLE}" ] || return 1
+
+            printf '%s' "${commit_json}" | jq -e '
+              def generated_artifact:
+                test(
+                  "^(skills/[^/]+|team-skills/[^/]+/[^/]+|" +
+                  "plugins/[^/]+|plugins/[^/]+/skills/[^/]+)/" +
+                  "(BENCHMARK\\.md|skill-card\\.md|skill\\.oms\\.sig|" +
+                  "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
+                );
+              any(.files[]?; .filename | endswith("/skill.oms.sig")) and
+              all(.files[]?;
+                ((.previous_filename? // "") | length) == 0 and
+                (.filename | generated_artifact)
+              )
+            ' >/dev/null
+          }
+
+          is_service_generated_signature_commit() {
+            local commit_json="$1"
+
+            is_generated_signature_artifact_commit "${commit_json}" || return 1
+            printf '%s' "${commit_json}" | jq -e \
+              --arg actor "${SIGNATURE_PUSH_ACTOR}" \
+              --arg service_login "${SIGNATURE_SERVICE_ACCOUNT_LOGIN}" '
+                ((.author.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                ((.committer.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                (
+                  ($service_login | length) > 0 and
+                  (
+                    ((.author.login? // "") | ascii_downcase) == ($service_login | ascii_downcase) or
+                    ((.committer.login? // "") | ascii_downcase) == ($service_login | ascii_downcase)
+                  )
+                )
+              ' >/dev/null
+          }
           if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
             echo "Pull request metadata is incomplete."
             exit 1
@@ -188,12 +251,19 @@ jobs:
 
           latest_watched_sha=""
           latest_watched_path=""
+          latest_generated_signature_sha=""
           for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
             commit_sha="${commit_shas[idx]}"
             if [ "${commit_sha}" = "${head_sha}" ]; then
               commit_json="${head_commit_json}"
             else
               commit_json="$(get_commit_json "${commit_sha}")"
+            fi
+            if is_service_generated_signature_commit "${commit_json}"; then
+              if [ -z "${latest_generated_signature_sha}" ]; then
+                latest_generated_signature_sha="${commit_sha}"
+              fi
+              continue
             fi
             watched_path="$(first_watched_path "${commit_json}")"
             if [ -n "${watched_path}" ]; then
@@ -204,6 +274,13 @@ jobs:
           done
 
           if [ -z "${latest_watched_sha}" ]; then
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Failed: generated signature commit \`${latest_generated_signature_sha}\` has no preceding watched-path content commit to validate."
+              exit 1
+            fi
             append_summary \
               "## NVSkills CI required status" \
               "" \
@@ -211,9 +288,14 @@ jobs:
             exit 0
           fi
 
-          poll_seconds="$(positive_integer "${STATUS_POLL_SECONDS}" 30)"
-          missing_grace_seconds="$(positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120)"
-          max_wait_seconds="$(positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3600)"
+          status_floor_sha="${latest_watched_sha}"
+          if [ -n "${latest_generated_signature_sha}" ]; then
+            status_floor_sha="${latest_generated_signature_sha}"
+          fi
+
+          poll_seconds="$(bounded_positive_integer "${STATUS_POLL_SECONDS}" 30 300)"
+          missing_grace_seconds="$(bounded_positive_integer "${MISSING_STATUS_GRACE_SECONDS}" 120 600)"
+          max_wait_seconds="$(bounded_positive_integer "${MAX_STATUS_WAIT_SECONDS}" 3300 3300)"
           elapsed_seconds=0
           status_sha=""
           status_state="missing"
@@ -237,7 +319,7 @@ jobs:
                   '[.[] | select(.context == $context)][0].target_url // ""')"
                 break
               fi
-              if [ "${commit_sha}" = "${latest_watched_sha}" ]; then
+              if [ "${commit_sha}" = "${status_floor_sha}" ]; then
                 break
               fi
             done
@@ -263,7 +345,7 @@ jobs:
                 ;;
             esac
 
-            echo "Waiting for ${STATUS_CONTEXT} at or after ${latest_watched_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
+            echo "Waiting for ${STATUS_CONTEXT} at or after ${status_floor_sha} (state: ${status_state}, elapsed: ${elapsed_seconds}s)."
             sleep "${poll_seconds}"
             elapsed_seconds=$((elapsed_seconds + poll_seconds))
           done
@@ -275,6 +357,11 @@ jobs:
               "Passed: \`${STATUS_CONTEXT}\` succeeded for validation evidence commit \`${status_sha}\`." \
               "" \
               "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "" \
+                "Latest generated signature commit: \`${latest_generated_signature_sha}\`."
+            fi
             if [ "${status_sha}" != "${head_sha}" ]; then
               append_summary \
                 "" \
@@ -286,15 +373,14 @@ jobs:
           append_summary \
             "## NVSkills CI required status" \
             "" \
-            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after latest watched commit \`${latest_watched_sha}\` (state: \`${status_state}\`)." \
+            "Failed: no successful \`${STATUS_CONTEXT}\` status was found at or after required evidence commit \`${status_floor_sha}\` (state: \`${status_state}\`)." \
             "" \
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
             "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
             "" \
-            "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
-            "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
+            "For a fork pull request, add \`${SIGNATURE_SERVICE_ACCOUNT_LOGIN}\`, the configured NVSkills signing service account, as a collaborator with write access to the fork repository, then ask a maintainer of the base repository to comment \`/nvskills-ci\`."
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -33,8 +33,31 @@ jobs:
       group: nvskills-ci-request-${{ github.repository }}-${{ github.event.issue.number || github.sha }}
       cancel-in-progress: true
     steps:
+      - name: Check dispatch availability
+        id: dispatch
+        env:
+          DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_TOKEN}" ]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [ "${EVENT_NAME}" = "push" ]; then
+            {
+              echo "## NVSkills CI request"
+              echo
+              echo "Skipped: this trusted signature push has no dispatch secret. The originating central run verifies the generated signature commit."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "Missing NVSKILLS_CI_DISPATCH_TOKEN secret."
+          exit 1
+
       - name: Validate requester permission
-        if: ${{ github.event_name == 'issue_comment' }}
+        if: ${{ steps.dispatch.outputs.enabled == 'true' && github.event_name == 'issue_comment' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -53,6 +76,7 @@ jobs:
 
       - name: Resolve request context
         id: context
+        if: ${{ steps.dispatch.outputs.enabled == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -153,7 +177,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Dispatch NVSkills CI
-        if: steps.context.outputs.should_dispatch == 'true'
+        if: steps.dispatch.outputs.enabled == 'true' && steps.context.outputs.should_dispatch == 'true'
         env:
           DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Restores fork pull request support from #416 after revert #422, and incorporates current main workflow fixes.

- Recognize generated commits only when paths, title, and verified GitHub identity match policy.
- Require successful validation evidence at or after a generated signature commit; never turn green solely because the signer pushed.
- Bound required-status polling and retain the quick exit for PRs without watched changes.
- Keep upstream bot-branch exemptions restricted to the upstream repository, so fork branch names cannot bypass validation.
- Preserve current requester authorization, paginated commit-file handling, and watched paths (skills/ and team-skills/).
- Explain service-account collaborator onboarding for fork write-back.

## Dependencies and merge order

1. NVCARPS-CI !201 (fork signer and credential isolation).
2. NVIDIA/nvskills-ci#60 (fork policy, exact head/base routing and status propagation).
3. This PR.

End-to-end functional testing completed successfully. Keep draft pending security approval. #427 is an older smoke-test PR, not an implementation dependency.

## Verification (16 September)

- Conflicts with current main resolved; signed-off commits and repository checks pass.
- Required workflow matches the nvskills-ci copy exercised by the 48-test backend suite.
- Actual Bash regression tests cover missing/failed validation, verified versus spoofed signatures, renamed skill paths, new content after signing, unrelated commits, bounded waits and the no-skill fast exit.
- Live happy path passed in [nvskills-ci-test#28](https://github.com/NVIDIA/nvskills-ci-test/pull/28): all three tiers, SkillCritic, canonical report, gate, 3S signing/verification and service-account write-back. [GitHub coordinator](https://github.com/NVIDIA/nvskills-ci/actions/runs/35056468459) and [GitLab pipeline 68107344](https://gitlab-master.nvidia.com/nvcarps/ci-group/nvcarps-ci/-/pipelines/68107344) are successful.
- Docs changes during validation were preserved; another docs-only commit after signing kept the [required check green](https://github.com/NVIDIA/nvskills-ci-test/actions/runs/35058083078) without rerunning evaluation.
- Live stale-content test passed in [nvskills-ci-test#26](https://github.com/NVIDIA/nvskills-ci-test/pull/26): a SKILL.md commit during validation correctly failed the [signer](https://gitlab-master.nvidia.com/nvcarps/ci-group/nvcarps-ci/-/jobs/441805964), published no artifacts and left the coordinator/new-content required check failed.
- Live reserved-name test passed in [nvskills-ci-test#27](https://github.com/NVIDIA/nvskills-ci-test/pull/27): a fork named automated/sync-skills could not bypass missing validation.
- Test PRs were closed without merging the sample skill; branches and run evidence remain available. The private test repository caller was restored after testing.
- The live tests cover branch movement before signing and unrelated movement after signing. The narrower rebase-during-push race is covered by the local shell suite, not claimed as a live test.
- Initial E2E run was canceled because generic runner preflight used an unreachable fallback sandbox kubeconfig. Test-only routing now clears that fallback; live Tier 3 still uses the current runner-mounted kubeconfig. No production validation checks or gates were disabled.

Temporary routing remains only on retained test branches; the nvskills-ci-test main caller is restored. It is not part of this PR. The separate runner preflight fix is tracked in NVCARPS-CI !272.