### PR TITLE
fix: dispatch NVSkills CI for renames out of watched paths

### DIFF
--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -41,11 +41,7 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          role_name="$(curl -fsSL \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/collaborators/${ACTOR}/permission" \
-            | jq -r '.role_name // ""')"
+          role_name="$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name // ""')"
           case "${role_name}" in
             admin|maintain) ;;
             *) echo "Requester must have maintain or admin permission"; exit 1 ;;
@@ -156,7 +152,7 @@ jobs:
       - name: Dispatch NVSkills CI
         if: steps.context.outputs.should_dispatch == 'true'
         env:
-          DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.context.outputs.pr_number }}
           REQUEST_HEAD_SHA: ${{ steps.context.outputs.head_sha }}
@@ -167,7 +163,7 @@ jobs:
           REQUESTED_BY: ${{ github.actor }}
         run: |
           set -euo pipefail
-          if [ -z "${DISPATCH_TOKEN}" ]; then
+          if [ -z "${GH_TOKEN}" ]; then
             echo "Missing NVSKILLS_CI_DISPATCH_TOKEN secret."
             exit 1
           fi
@@ -175,29 +171,15 @@ jobs:
           owner="${REPO%%/*}"
           repo="${REPO#*/}"
 
-          curl -fsSL -X POST \
-            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/NVIDIA/nvskills-ci/actions/workflows/nvskills-ci.yml/dispatches" \
-            -d "$(jq -n \
-              --arg ref "main" \
-              --arg source_owner "${owner}" \
-              --arg source_repo "${repo}" \
-              --arg pr_number "${PR_NUMBER}" \
-              --arg request_run_id "${REQUEST_RUN_ID}" \
-              --arg request_head_sha "${REQUEST_HEAD_SHA}" \
-              --arg request_base_ref "${REQUEST_BASE_REF}" \
-              --arg request_commit_title "${REQUEST_COMMIT_TITLE}" \
-              --arg request_comment_id "${REQUEST_COMMENT_ID}" \
-              --arg requested_by "${REQUESTED_BY}" \
-              '{ref: $ref, inputs: {
-                source_owner: $source_owner,
-                source_repo: $source_repo,
-                pr_number: $pr_number,
-                request_run_id: $request_run_id,
-                request_head_sha: $request_head_sha,
-                request_base_ref: $request_base_ref,
-                request_commit_title: $request_commit_title,
-                request_comment_id: $request_comment_id,
-                requested_by: $requested_by
-              }}')"
+          gh workflow run nvskills-ci.yml \
+            -R NVIDIA/nvskills-ci \
+            --ref main \
+            -f source_owner="${owner}" \
+            -f source_repo="${repo}" \
+            -f pr_number="${PR_NUMBER}" \
+            -f request_run_id="${REQUEST_RUN_ID}" \
+            -f request_head_sha="${REQUEST_HEAD_SHA}" \
+            -f request_base_ref="${REQUEST_BASE_REF}" \
+            -f request_commit_title="${REQUEST_COMMIT_TITLE}" \
+            -f request_comment_id="${REQUEST_COMMENT_ID}" \
+            -f requested_by="${REQUESTED_BY}"

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -119,12 +119,13 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=100&page=${page}")"
             if printf '%s' "${files_json}" | jq -e '
-              any(.[]; .filename |
+              def watched:
+                (. // "") |
                 startswith("skills/") or
                 startswith("team-skills/") or
                 startswith("rules/team-rules/") or
-                startswith("plugins/")
-              )
+                startswith("plugins/");
+              any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
               break


### PR DESCRIPTION
## Problem

`require-nvskills-status.yml` (the required-status gate) classifies a PR as requiring an `NVSkills CI` status when **either** `filename` **or** `previous_filename` of any changed file is under a watched path (`skills/`, `team-skills/`, `rules/team-rules/`, `plugins/`). The dispatch step in `team-request.yml` only checked `filename`.

A PR that renames a file **out** of a watched path (e.g. `skills/foo/SKILL.md` → `docs/foo.md`, i.e. unpublishing a skill) therefore deadlocks:

- the gate demands an `NVSkills CI` status (it matches `previous_filename`) and fails after the missing-status grace period;
- `/nvskills-ci` skips with *"no changes under watched paths"* and never dispatches the pipeline that would produce the status.

The PR is permanently blocked.

## Fix

Align the dispatch step's watched-path filter with the gate's: match `previous_filename` as well (the jq `watched` predicate is copied verbatim from `require-nvskills-status.yml`). The pipeline validates the **resulting worktree**, so a rename that leaves no publishable skill resolves to a successful *not required* status — the same path deletions already take.

| Change | Dispatch | Outcome |
|---|---|---|
| `docs/foo.md` → `skills/foo/SKILL.md` | yes | scan |
| `skills/foo` → `skills/bar` | yes | scan |
| `skills/foo/SKILL.md` → `docs/foo.md` | yes (was: **never**) | not required |
| unrelated rename/modify | no | — |

## Verification

- jq filter exercised against 16+ edge-case payloads (rename out/in/within, deletion, missing/null `previous_filename`, `skillsX/` prefix confusion, unicode paths, empty pages) — all classify per the table above; `jq -e` exit codes drive the intended branches.
- Structural check: the gate demands a status **only if** its PR-level files scan matches, and that scan now uses the identical predicate — gate-demands ⇒ dispatch-fires, so the deadlock class is closed.
- Deadlock reproduced end-to-end and dispatch-after-fix demonstrated with the same one-hunk change on the copy consumed by NVIDIA/nvskills-ci-test: [demo PR #20](https://github.com/NVIDIA/nvskills-ci-test/pull/20) — before: dispatch step skipped + gate failed with `state: missing`; after: `should_dispatch=true` and the dispatch call was issued.
- Downstream: `run_validation_tier.sh` exits 0 (`No content directories changed — skipping`) when the resulting worktree maps to zero skill dirs, so the dispatched run completes successfully.
