### PR TITLE
DeepStream 9.1.0 Skills Update

### DIFF
--- a/components.d/deepstream.yml
+++ b/components.d/deepstream.yml
@@ -4,6 +4,8 @@ name: DeepStream
 repo: NVIDIA/DeepStream
 description: Agentic skills for guided DeepStream development.
 skills:
+  - path: skills/amc-run-rtsp-calibration/
+    catalog_dir: amc-run-rtsp-calibration
   - path: skills/amc-run-sample-calibration/
     catalog_dir: amc-run-sample-calibration
   - path: skills/amc-run-video-calibration/
@@ -18,7 +20,15 @@ skills:
     catalog_dir: deepstream-import-vision-model
   - path: skills/deepstream-profile-pipeline/
     catalog_dir: deepstream-profile-pipeline
+  - path: skills/deepstream-run-mv3dt/
+    catalog_dir: deepstream-run-mv3dt
   - path: skills/deepstream-sop/
     catalog_dir: deepstream-sop
+  - path: skills/rtvi-cv-customize-model/
+    catalog_dir: rtvi-cv-customize-model
+  - path: skills/rtvi-cv-scaffold-vss-service/
+    catalog_dir: rtvi-cv-scaffold-vss-service
+  - path: skills/rtvi-vlm-customize-model/
+    catalog_dir: rtvi-vlm-customize-model
 links:
   discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
- [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [x] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [x] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [ ] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

<!-- Brief description of the change -->
