### PR TITLE
fix(ci): ignore trusted signature artifact commits

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -28,6 +28,9 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.sha || github.sha }}
           STATUS_CONTEXT: ${{ vars.NVSKILLS_STATUS_CONTEXT || 'NVSkills CI' }}
+          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
+          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]' }}
+          SIGNATURE_SERVICE_ACCOUNT_LOGIN: ${{ vars.NVSKILLS_FORK_SERVICE_ACCOUNT_LOGIN || vars.NVSKILLS_SIGNATURE_COMMIT_LOGIN || 'svc-nvskills-signing' }}
           STATUS_POLL_SECONDS: ${{ vars.NVSKILLS_STATUS_POLL_SECONDS || '30' }}
           MISSING_STATUS_GRACE_SECONDS: ${{ vars.NVSKILLS_MISSING_STATUS_GRACE_SECONDS || '120' }}
           MAX_STATUS_WAIT_SECONDS: ${{ vars.NVSKILLS_MAX_STATUS_WAIT_SECONDS || '3600' }}
@@ -120,6 +123,48 @@ jobs:
             '
           }
 
+          is_generated_signature_artifact_commit() {
+            local commit_json="$1"
+            local commit_title
+
+            commit_title="$(printf '%s' "${commit_json}" | jq -r '(.commit.message // "") | split("\n")[0]')"
+            [ "${commit_title}" = "${SIGNATURE_COMMIT_TITLE}" ] || return 1
+
+            printf '%s' "${commit_json}" | jq -e '
+              def generated_artifact:
+                test(
+                  "^(skills/[^/]+|team-skills/[^/]+/[^/]+|" +
+                  "plugins/[^/]+|plugins/[^/]+/skills/[^/]+)/" +
+                  "(BENCHMARK\\.md|skill-card\\.md|skill\\.oms\\.sig|" +
+                  "skill-card-review-needed\\.md|[^/]+-review-needed\\.md)$"
+                );
+              any(.files[]?; .filename | endswith("/skill.oms.sig")) and
+              all(.files[]?;
+                ((.previous_filename? // "") | length) == 0 and
+                (.filename | generated_artifact)
+              )
+            ' >/dev/null
+          }
+
+          is_service_generated_signature_commit() {
+            local commit_json="$1"
+
+            is_generated_signature_artifact_commit "${commit_json}" || return 1
+            printf '%s' "${commit_json}" | jq -e \
+              --arg actor "${SIGNATURE_PUSH_ACTOR}" \
+              --arg service_login "${SIGNATURE_SERVICE_ACCOUNT_LOGIN}" '
+                ((.author.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                ((.committer.login? // "") | ascii_downcase) == ($actor | ascii_downcase) or
+                (
+                  ($service_login | length) > 0 and
+                  (
+                    ((.author.login? // "") | ascii_downcase) == ($service_login | ascii_downcase) or
+                    ((.committer.login? // "") | ascii_downcase) == ($service_login | ascii_downcase)
+                  )
+                )
+              ' >/dev/null
+          }
+
           if [ -z "${pr_number}" ] || [ -z "${head_sha}" ]; then
             echo "Pull request metadata is incomplete."
             exit 1
@@ -127,6 +172,14 @@ jobs:
 
           pr_json="$(github_get "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}")"
           current_head_sha="$(printf '%s' "${pr_json}" | jq -r '.head.sha | ascii_downcase')"
+          head_repo_full_name="$(printf '%s' "${pr_json}" | jq -r '(.head.repo.full_name // "") | ascii_downcase')"
+          base_repo_full_name="$(printf '%s' "${pr_json}" | jq -r '(.base.repo.full_name // "") | ascii_downcase')"
+          is_fork_pull_request=false
+          if [ -n "${head_repo_full_name}" ] &&
+            [ -n "${base_repo_full_name}" ] &&
+            [ "${head_repo_full_name}" != "${base_repo_full_name}" ]; then
+            is_fork_pull_request=true
+          fi
           if [ "${current_head_sha}" != "${head_sha}" ]; then
             append_summary \
               "## NVSkills CI required status" \
@@ -188,12 +241,19 @@ jobs:
 
           latest_watched_sha=""
           latest_watched_path=""
+          latest_generated_signature_sha=""
           for ((idx=${#commit_shas[@]} - 1; idx >= 0; idx--)); do
             commit_sha="${commit_shas[idx]}"
             if [ "${commit_sha}" = "${head_sha}" ]; then
               commit_json="${head_commit_json}"
             else
               commit_json="$(get_commit_json "${commit_sha}")"
+            fi
+            if is_service_generated_signature_commit "${commit_json}"; then
+              if [ -z "${latest_generated_signature_sha}" ]; then
+                latest_generated_signature_sha="${commit_sha}"
+              fi
+              continue
             fi
             watched_path="$(first_watched_path "${commit_json}")"
             if [ -n "${watched_path}" ]; then
@@ -204,6 +264,13 @@ jobs:
           done
 
           if [ -z "${latest_watched_sha}" ]; then
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "## NVSkills CI required status" \
+                "" \
+                "Failed: generated signature commit \`${latest_generated_signature_sha}\` has no preceding watched-path content commit to validate."
+              exit 1
+            fi
             append_summary \
               "## NVSkills CI required status" \
               "" \
@@ -275,10 +342,15 @@ jobs:
               "Passed: \`${STATUS_CONTEXT}\` succeeded for validation evidence commit \`${status_sha}\`." \
               "" \
               "Latest watched-path change: \`${latest_watched_path}\` at \`${latest_watched_sha}\`."
+            if [ -n "${latest_generated_signature_sha}" ]; then
+              append_summary \
+                "" \
+                "Trusted generated signature commit \`${latest_generated_signature_sha}\` was excluded from content status requirements."
+            fi
             if [ "${status_sha}" != "${head_sha}" ]; then
               append_summary \
                 "" \
-                "PR head \`${head_sha}\` contains only trailing changes outside watched NVSkills paths after the validated tree."
+                "PR head \`${head_sha}\` contains no unvalidated watched-path content after the validation evidence commit."
             fi
             exit 0
           fi
@@ -291,10 +363,12 @@ jobs:
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
-            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`." \
-            "" \
-            "\`/nvskills-ci\` only works on branches in \`NVIDIA/skills\`, not forks." \
-            "If this PR is from a fork, move the changes to a branch in \`NVIDIA/skills\` first."
+            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+          if [ "${is_fork_pull_request}" = "true" ]; then
+            append_summary \
+              "" \
+              "\`/nvskills-ci\` only works on branches in the parent repo, not forks."
+          fi
           if [ -n "${status_sha}" ]; then
             append_summary "" "Latest NVSkills CI status checked: \`${status_state}\` on \`${status_sha}\`."
           fi


### PR DESCRIPTION
## Summary

- Treat tightly constrained NVSkills signing commits as generated artifacts when locating the latest content commit that requires validation.
- Continue requiring a real successful `NVSkills CI` status on or after that content commit; generated commits do not create a green result by themselves.
- Show repository-neutral fork guidance only for actual fork pull requests.

## Root cause

The required-status workflow treated the service account's generated `BENCHMARK.md`, `skill-card.md`, and `skill.oms.sig` commit as a new watched-path content change. Since that generated commit did not have its own `NVSkills CI` status, an already validated PR was blocked as `missing`. The failure text also hardcoded `NVIDIA/skills` and appeared on same-repository PRs.

This was reproduced on [physical-ai-skill-hub-dev PR #272](https://github.com/NVIDIA-dev/physical-ai-skill-hub-dev/pull/272) and [its failing workflow run](https://github.com/NVIDIA-dev/physical-ai-skill-hub-dev/actions/runs/31602421696/job/94173545357).

## Safety

A commit is skipped only when all of these hold:

- exact configured signature commit title
- GitHub author or committer matches the configured bot/service account
- every changed path is an allowed generated artifact path
- at least one `skill.oms.sig` is present
- no renamed files are present

A later human commit touching a watched path still becomes the validation floor and must have a successful status.

## Validation

- Parsed the workflow YAML and embedded Bash successfully.
- Replayed PR #272 against the live GitHub API: the gate passed using validated content commit `19c60a0876ab7d4e8ecd1579cfa20280ea5a580d` beneath signing commit `48004197bdd8c9c721c814024903ec8fa40c7c96`.
- Replayed the same PR with a missing status: the gate failed and did not show fork guidance.
- Replayed fork PR `NVIDIA/nvskills-ci-test#17`: generated signing commits were skipped correctly, and a missing-status run showed the generic parent-repository guidance.
- Confirmed human-authored lookalikes, extra content files, missing signatures, renamed files, and non-exact titles are not exempt.
