### PR TITLE
chore: stop watching plugins/ and rules/team-rules/ for NVSkills CI

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -113,8 +113,7 @@ jobs:
                 (. // "") |
                 startswith("skills/") or
                 startswith("team-skills/") or
-                startswith("rules/team-rules/") or
-                startswith("plugins/");
+                startswith("rules/team-rules/");
               [
                 .files[]? |
                 select((.filename | watched) or (.previous_filename? | watched)) |
@@ -197,8 +196,7 @@ jobs:
                 (. // "") |
                 startswith("skills/") or
                 startswith("team-skills/") or
-                startswith("rules/team-rules/") or
-                startswith("plugins/");
+                startswith("rules/team-rules/");
               any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
@@ -363,7 +361,7 @@ jobs:
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
-            "\`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+            "\`skills/\`, \`team-skills/\`, or \`rules/team-rules/\`."
           if [ "${is_fork_pull_request}" = "true" ]; then
             append_summary \
               "" \

--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -112,8 +112,7 @@ jobs:
               def watched:
                 (. // "") |
                 startswith("skills/") or
-                startswith("team-skills/") or
-                startswith("rules/team-rules/");
+                startswith("team-skills/");
               [
                 .files[]? |
                 select((.filename | watched) or (.previous_filename? | watched)) |
@@ -195,8 +194,7 @@ jobs:
               def watched:
                 (. // "") |
                 startswith("skills/") or
-                startswith("team-skills/") or
-                startswith("rules/team-rules/");
+                startswith("team-skills/");
               any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
@@ -361,7 +359,7 @@ jobs:
             "Latest watched-path change: \`${latest_watched_path}\`." \
             "" \
             "Comment \`/nvskills-ci\` on this PR after every commit that changes" \
-            "\`skills/\`, \`team-skills/\`, or \`rules/team-rules/\`."
+            "\`skills/\` or \`team-skills/\`."
           if [ "${is_fork_pull_request}" = "true" ]; then
             append_summary \
               "" \

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -118,8 +118,7 @@ jobs:
               def watched:
                 (. // "") |
                 startswith("skills/") or
-                startswith("team-skills/") or
-                startswith("rules/team-rules/");
+                startswith("team-skills/");
               any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
@@ -135,7 +134,7 @@ jobs:
             {
               echo "## NVSkills CI request"
               echo
-              echo "Skipped: no changes under \`skills/\`, \`team-skills/\`, or \`rules/team-rules/\`."
+              echo "Skipped: no changes under \`skills/\` or \`team-skills/\`."
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi

--- a/.github/workflows/team-request.yml
+++ b/.github/workflows/team-request.yml
@@ -119,8 +119,7 @@ jobs:
                 (. // "") |
                 startswith("skills/") or
                 startswith("team-skills/") or
-                startswith("rules/team-rules/") or
-                startswith("plugins/");
+                startswith("rules/team-rules/");
               any(.[]; (.filename | watched) or (.previous_filename? | watched))
             ' >/dev/null; then
               has_watched_change=true
@@ -136,7 +135,7 @@ jobs:
             {
               echo "## NVSkills CI request"
               echo
-              echo "Skipped: no changes under \`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+              echo "Skipped: no changes under \`skills/\`, \`team-skills/\`, or \`rules/team-rules/\`."
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi


### PR DESCRIPTION
Removes `plugins/` and `rules/team-rules/` from the NVSkills CI watched-path classification, per policy decision. The watched set becomes `skills/` and `team-skills/`.

- `team-request.yml`: dispatch filter no longer matches either prefix (via `filename` or `previous_filename`); skip message updated.
- `require-nvskills-status.yml`: both the per-commit (`first_watched_path`) and PR-level watched filters updated; failure message updated.

Rationale: `plugins/` in this repo is a **generated tree** built from `skills/` + `plugins.d/` — gating it double-validates content already validated at its source (`validate-plugins.yml` still checks the generated tree for drift). `rules/team-rules/` is removed from gating by the same policy decision.

**Deliberately kept:** the generated-artifact regex for trusted signature commits still accepts `plugins/**` signature files, so signature commits touching plugin artifacts keep classifying as trusted.

Both watched filters remain byte-identical between the dispatch and gate sides, preserving the gate-demands ⇒ dispatch-fires invariant from #429.

Sibling change: NVIDIA/nvskills-ci#63. **Merge order matters: this PR must merge before NVIDIA/nvskills-ci#63** — team repos take their gate from this repo's `@main` but dispatch to nvskills-ci`@main`, whose validator will skip unwatched-only PRs without posting a status. Gates must stop demanding before the center stops supplying.

E2E validation (plugins case): NVIDIA/nvskills-ci-test#23 — no gate run on PR open, `/nvskills-ci` skips without dispatch, merge state CLEAN.