### PR TITLE
Add Jetson video SDK skills to catalog

### DIFF
--- a/components.d/jetson-device.yml
+++ b/components.d/jetson-device.yml
@@ -22,6 +22,16 @@ skills:
     catalog_dir: jetson-print-device-info
   - path: skills/jetson-speculative-decoding/
     catalog_dir: jetson-speculative-decoding
+  - path: skills/jetson-video-benchmark/
+    catalog_dir: jetson-video-benchmark
+  - path: skills/jetson-video-capability/
+    catalog_dir: jetson-video-capability
+  - path: skills/jetson-video-pipeline/
+    catalog_dir: jetson-video-pipeline
+  - path: skills/jetson-video-recipe/
+    catalog_dir: jetson-video-recipe
+  - path: skills/jetson-video-setup/
+    catalog_dir: jetson-video-setup
 links:
   contributing: false
   discussions: false


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

Not applicable. Jetson Device is already registered in the catalog; this PR adds new skill paths to the existing component.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid
- [ ] `SKILL.md` frontmatter spec-compliant
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context

Registers the following Jetson Video SDK skills from `NVIDIA-AI-IOT/jetson-device-skills`:

- `jetson-video-benchmark`
- `jetson-video-capability`
- `jetson-video-pipeline`
- `jetson-video-recipe`
- `jetson-video-setup`

Each entry maps its source directory to a corresponding top-level catalog directory. The existing automated sync workflow will mirror the skills after this registry change is merged.
