### PR TITLE
feat: register NeMo Fabric skills

### DIFF
--- a/components.d/nemo-fabric.yml
+++ b/components.d/nemo-fabric.yml
@@ -1,0 +1,10 @@
+name: NeMo Fabric
+repo: NVIDIA/NeMo-Fabric
+description: Portable skills for integrating applications with NeMo Fabric through its public SDK and building compatible third-party adapters.
+links:
+  discussions: false
+skills:
+  - path: skills/nemo-fabric-integrate/
+    catalog_dir: nemo-fabric-integrate
+  - path: skills/nemo-fabric-build-adapter/
+    catalog_dir: nemo-fabric-build-adapter


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative) — pending product-team confirmation
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

## Summary

Registers the two portable, public NeMo Fabric integration skills:

- `nemo-fabric-integrate` for consumer applications using the typed Python SDK
- `nemo-fabric-build-adapter` for third-party adapter authors using the public adapter contract

The source bundles are in `NVIDIA/NeMo-Fabric` at `skills/`, include their signature, skill card, and evaluation assets, and are intentionally distinct from its repository-internal maintainer skill set.

## Validation

- Parsed the component manifest and verified its exact two source-to-catalog mappings.
- Verified both source paths and required catalog artifacts at NeMo Fabric `main` commit `b73bbb1a4dd1a31214723ce339dc167f3b7e4b31`.
- Confirmed catalog-directory names are unique and ran `git diff --check`.

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency requiring OSRB filing

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
