### PR TITLE
chore(tao): sync TAO Toolkit catalog from release/latest

### DIFF
--- a/components.d/tao-toolkit.yml
+++ b/components.d/tao-toolkit.yml
@@ -1,5 +1,6 @@
 name: TAO Toolkit
 repo: NVIDIA-TAO/tao-skill-bank
+ref: release/latest
 description: NVIDIA TAO Toolkit - fine-tune and optimize 100+ pretrained vision AI models with your own data using low-code microservices, then export production-ready models for edge or cloud deployment.
 skills:
   # applications


### PR DESCRIPTION
## What
Add `ref: release/latest` to `components.d/tao-toolkit.yml` so the catalog syncs the TAO Toolkit component from the **`release/latest`** branch of `NVIDIA-TAO/tao-skill-bank` instead of the default `main`.

```diff
 repo: NVIDIA-TAO/tao-skill-bank
+ref: release/latest
```

## Why
- `release/latest` is a **stable moving pointer** we re-point at each release cut (currently → release/7.1.0). Onboard it once; no per-release config churn.
- `main` has diverged post GitLab→GitHub migration; the release line is our intended, fully-signed sync source.

## DRAFT — do not merge yet
Holding as **draft** until all skills on `release/latest` are freshly signed (signing PR NVIDIA-TAO/tao-skill-bank#154, pending onboarding change NVIDIA/nvskills-ci#65). Merging before signing completes would sync unsigned content (the sync's sig-drift guard would just hold it anyway).

## Follow-up before un-draft
Reconcile the `skills:` list here against `release/latest`'s actual set (62 skills) — it currently reflects main's registration. I'll update the list in this same PR before marking ready.