### PR TITLE
docs: simplify approval and license wording in contributor docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,20 +10,18 @@
 
 By submitting this PR, I confirm on behalf of my team:
 
-- [ ] **Skills cleared for open source release** per NVIDIA's internal IP review process (six-question check, all answers affirmative)
+- [ ] **Skills cleared for open source release** by the owning team, with all required approvals in place
 - [ ] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
 - [ ] **No new license or new third-party component** introduced beyond what the source repo already carries
 - [ ] **Source repo is public and under an NVIDIA-owned GitHub org**
 - [ ] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)
-
-> NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection.
 
 ## Reviewer checklist (OSS Skills PIC)
 
 - [ ] Author confirmations above are checked
 - [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
 - [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
-- [ ] No new license or third-party dependency requiring OSRB filing
+- [ ] No new license or third-party dependency introduced
 
 ## All PRs
 

--- a/.github/external-contributors.yml
+++ b/.github/external-contributors.yml
@@ -5,7 +5,7 @@
 #
 # The verify-authors check requires an @nvidia.com or github-noreply
 # email on every commit. External (non-NVIDIA) contributions are
-# accepted only after a maintainer-run IP review of the contribution.
+# accepted only after a maintainer-run review of the contribution.
 # Once a contribution passes review, a maintainer records the
 # contributor here, and the authors check accepts their email for the
 # listed pull requests only.

--- a/.github/scripts/marketplace/metadata-exclusions.yaml
+++ b/.github/scripts/marketplace/metadata-exclusions.yaml
@@ -12,7 +12,7 @@
 # Example:
 #   exclusions:
 #     - name: experimental-skill-foo
-#       reason: Awaiting OSRB review.
+#       reason: Awaiting owner confirmation.
 #       owner: "@example-team"
 #     - name: in-flight-rename
 #       reason: Skill rename in flight; re-include after content stabilizes.

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -330,7 +330,7 @@ jobs:
           # Every catalog skill (defined by SKILL.md) must ship with:
           #   - skill.oms.sig  (detached NVIDIA signature)
           #   - skill-card.md  (skill metadata card)
-          #   - eval data      (Tier-3 NV-ACES dataset). Accepted in any
+          #   - eval data      (Tier-3 evaluation dataset). Accepted in any
           #                     of these forms — semantic equivalence,
           #                     not literal-filename:
           #                       * evals.json anywhere in the skill dir

--- a/.github/workflows/verify-content-integrity.yml
+++ b/.github/workflows/verify-content-integrity.yml
@@ -110,7 +110,7 @@ jobs:
             fi
             echo '```'
             echo ""
-            echo "**Recovery (skill owners):** the mismatch exists at your source repo — content was modified after the signing run. Open a PR that touches the skill directory (a trivial SKILL.md version bump works if your changes are already merged), comment \`/nvskills-ci\`, and merge with the generated signature commit. Do not modify skill files afterward. Steps: https://nvidia.atlassian.net/wiki/spaces/GAIT/pages/3483240468"
+            echo "**Recovery (skill owners):** the mismatch exists at your source repo — content was modified after the signing run. Open a PR that touches the skill directory (a trivial SKILL.md version bump works if your changes are already merged), comment \`/nvskills-ci\`, and merge with the generated signature commit. Do not modify skill files afterward. If you need help, contact a CODEOWNER."
             echo ""
             echo "This issue auto-updates on every failing sweep and closes automatically when a sweep passes."
           } > "$body"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,21 @@ GitHub search ranks repositories on metadata and engagement, not just content. B
 
 These apply to the *source* repo; the catalog repo's own metadata is maintained by the catalog team.
 
-## IP Review and License (External Skills)
+## License
 
-For skills published to `github.com/nvidia/skills`, NVIDIA contributors confirm three things per onboarding PR:
+Skills published to `github.com/nvidia/skills` are licensed under one of:
 
-1. The skills have been cleared for open source release per NVIDIA's internal IP review process (six-question check).
+- Apache 2.0
+- CC-BY 4.0
+- Dual (Apache 2.0 + CC-BY 4.0)
+
+Contributors confirm three things per onboarding PR:
+
+1. The skills have been cleared for open source release by the owning team.
 2. The skill is licensed under Apache 2.0, CC-BY 4.0, or dual-license (Apache 2.0 + CC-BY 4.0).
 3. No new license or new third-party component has been introduced beyond what the source repo already carries.
 
-NVIDIA contributors: see the internal onboarding guide for the IP review process details and license selection. The [pull request template](.github/PULL_REQUEST_TEMPLATE.md) prompts for these affirmations on every onboarding PR.
+The [pull request template](.github/PULL_REQUEST_TEMPLATE.md) prompts for these affirmations on every onboarding PR.
 
 ## Signing Your Work
 


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Summary

Verbiage-only cleanup across six files. The contributor-facing docs described *how* teams reach an approval decision; this rewords them to state *what* contributors must confirm, and leaves the mechanics to each team's own process.

| File | Change |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | Reworded the clearance affirmation; dropped a note pointing at team-internal material; reworded a reviewer checklist item |
| `CONTRIBUTING.md` | Section retitled to **License**, with the accepted licenses promoted to an explicit list; reworded the clearance line |
| `.github/workflows/verify-content-integrity.yml` | Replaced an internal link in the public failure message with a pointer to CODEOWNERS |
| `.github/external-contributors.yml` | Comment reworded to match the neutral phrasing `verify-authors.yml` already uses |
| `.github/workflows/sync-skills.yml` | Comment: stale tool name → "Tier-3 evaluation dataset" |
| `.github/scripts/marketplace/metadata-exclusions.yaml` | Example comment reworded |

The affirmation checkbox is **reworded, not removed** — it stays the record that clearance happened.

## Validation

- The PR template is not machine-read: grepped all of `.github/`; the only references are the file to itself. No workflow parses the affirmations.
- No markdown/YAML linters run in CI.
- All four touched YAML files parse clean under `yaml.safe_load`.
- All 17 `run:` blocks across both touched workflows pass `bash -n`. The content-integrity string keeps its escaped backticks; only the trailing clause changed.
- Three of the six changes are comments only — no executable surface.
- The DCO v1.1 (a)–(d) text in `CONTRIBUTING.md` is untouched (verified all four clauses still present).
- No internal links remain in any catalog-owned file.

Note: the `CONTRIBUTING.md` heading changes, so the old `#ip-review-and-license-external-skills` anchor no longer resolves. Nothing in the repo linked it.

## Reviewer checklist (OSS Skills PIC)

- [x] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid — n/a, no component change
- [ ] `SKILL.md` frontmatter spec-compliant — n/a, no skill content touched
- [x] No new license or third-party dependency introduced

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)