### PR TITLE
fix(physical-ai): point at the renamed image-attribute-augmentation skill

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -4281,7 +4281,7 @@
         "codex"
       ],
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "has_results": true,
       "average_uplift_pct": 1.2
     },
@@ -26648,7 +26648,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Security",
       "num": 8,
       "agent": "claude-code",
@@ -26657,7 +26657,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Security",
       "num": 8,
       "agent": "codex",
@@ -26666,7 +26666,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Correctness",
       "num": 8,
       "agent": "claude-code",
@@ -26675,7 +26675,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Correctness",
       "num": 8,
       "agent": "codex",
@@ -26684,7 +26684,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Discoverability",
       "num": 8,
       "agent": "claude-code",
@@ -26693,7 +26693,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Discoverability",
       "num": 8,
       "agent": "codex",
@@ -26702,7 +26702,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Effectiveness",
       "num": 8,
       "agent": "claude-code",
@@ -26711,7 +26711,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Effectiveness",
       "num": 8,
       "agent": "codex",
@@ -26720,7 +26720,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Efficiency",
       "num": 8,
       "agent": "claude-code",
@@ -26729,7 +26729,7 @@
     },
     {
       "catalog_dir": "physical-ai-people-attribute-search",
-      "component": "Physical AI",
+      "component": null,
       "dimension": "Efficiency",
       "num": 8,
       "agent": "codex",

--- a/components.d/physical-ai-data-factory.yml
+++ b/components.d/physical-ai-data-factory.yml
@@ -6,7 +6,7 @@ skills:
     catalog_dir: physical-ai-defect-image-generation
   - path: skills/physical-ai-video-data-augmentation/
     catalog_dir: physical-ai-video-data-augmentation
-  - path: skills/physical-ai-people-attribute-search/
-    catalog_dir: physical-ai-people-attribute-search
+  - path: skills/physical-ai-image-attribute-augmentation/
+    catalog_dir: physical-ai-image-attribute-augmentation
 links:
   discussions: false


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Summary

`physical-ai-people-attribute-search` was renamed to `physical-ai-image-attribute-augmentation` at source (#410), but `components.d/physical-ai-data-factory.yml` was never updated. The sync has been looking for a directory that no longer exists and reporting it as a failed component on every run since.

```
- **Physical AI** (NVIDIA/physical-ai-data-factory):
  `skills/physical-ai-people-attribute-search/` empty or missing
```

## The part the failing line hid

The catalog **still publishes** `skills/physical-ai-people-attribute-search/` — 8 files, live on `main` — under a name the owning team retired, frozen at its pre-rename content, with no path for updates to reach it. Meanwhile the current skill has never synced at all.

So this is not just a noisy sync log; the public catalog is serving a stale skill under a dead name.

## Verified before pointing at it

`skills/physical-ai-image-attribute-augmentation/` at source `main`:

| Artifact | |
|---|---|
| `SKILL.md` | present, frontmatter `name` matches the directory |
| `skill.oms.sig` | present |
| `skill-card.md` | present |
| `evals/evals.json` | present |
| `BENCHMARK.md` | **Overall verdict: PASS**, Tier 3 PASS — 2 agents, 10 tasks, evaluated 2026-08-13 |

The retired name is kept as a trigger keyword in the skill's description, so discoverability survives the rename.

## No separate cleanup needed

The old `catalog_dir` appears in neither `catalog-exceptions.yml` nor `.github/scripts/manual-components.yml`, so `prune-orphans.sh` removes the stale directory on the next sync.

## Not related to the private-repo Physical AI skills

The five hand-staged skills in `manual-components.yml` (the `omniverse-*` set plus `physical-ai-infrastructure-setup-and-resilient-scaling` and `physical-ai-neural-reconstruction`) come from the team's private repo via direct PRs and are unaffected by this change.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).