### PR TITLE
fix(ci): stop require-nvskills-ci crashing on large commits

### DIFF
--- a/.github/workflows/require-nvskills-status.yml
+++ b/.github/workflows/require-nvskills-status.yml
@@ -78,33 +78,55 @@ jobs:
             local page=1
             local response
             local first_response=""
-            local page_files
-            local all_files='[]'
             local page_count
+            # Accumulate through files, never shell variables passed as argv.
+            # Linux caps a single argument at 128 KiB (MAX_ARG_STRLEN); the
+            # commit payload exceeds that long before the page-30 guard below
+            # can fire, so --argjson died with "Argument list too long" instead
+            # of returning a verdict. See PR #471 (96 files, 865 KiB).
+            local scratch_dir all_files_file page_files_file
+            if ! scratch_dir="$(mktemp -d)" || [ -z "${scratch_dir}" ]; then
+              echo "Unable to create a scratch directory for commit ${commit_sha}." >&2
+              return 1
+            fi
+            all_files_file="${scratch_dir}/all.json"
+            page_files_file="${scratch_dir}/page.json"
+            printf '[]' > "${all_files_file}"
 
             while true; do
               response="$(github_get "https://api.github.com/repos/${owner}/${repo}/commits/${commit_sha}?per_page=100&page=${page}")"
               if [ "${page}" -eq 1 ]; then
                 first_response="${response}"
               fi
-              page_files="$(printf '%s' "${response}" | jq -c '.files // []')"
-              page_count="$(printf '%s' "${page_files}" | jq 'length')"
-              all_files="$(jq -cn \
-                --argjson existing "${all_files}" \
-                --argjson current "${page_files}" \
-                '$existing + $current')"
+              # Keep only what the classifiers below read: .filename and
+              # .previous_filename. The API returns each file's full patch,
+              # which is ~98% of the payload and never inspected. Dropping
+              # .previous_filename here would let a rename INTO a signature
+              # artifact name pass is_generated_signature_artifact_commit,
+              # so both fields are required.
+              printf '%s' "${response}" \
+                | jq -c '[.files[]? | {filename, previous_filename}]' > "${page_files_file}"
+              page_count="$(jq 'length' < "${page_files_file}")"
+              jq -cn \
+                --slurpfile existing "${all_files_file}" \
+                --slurpfile current "${page_files_file}" \
+                '$existing[0] + $current[0]' > "${all_files_file}.new"
+              mv "${all_files_file}.new" "${all_files_file}"
 
               if [ "${page_count}" -lt 100 ]; then
                 break
               fi
               if [ "${page}" -ge 30 ]; then
                 echo "Commit ${commit_sha} has too many files to classify safely." >&2
+                rm -rf "${scratch_dir}"
                 return 1
               fi
               page=$((page + 1))
             done
 
-            printf '%s' "${first_response}" | jq -c --argjson files "${all_files}" '.files = $files'
+            printf '%s' "${first_response}" \
+              | jq -c --slurpfile files "${all_files_file}" '.files = $files[0]'
+            rm -rf "${scratch_dir}"
           }
 
           first_watched_path() {


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## Summary

`require-nvskills-ci` is a **required** status check, and it currently crashes rather than returning a verdict whenever a commit's file payload exceeds roughly 128 KiB.

`get_commit_json` passed the accumulated file list to `jq` with `--argjson`. Linux caps a *single argument* at 128 KiB (`MAX_ARG_STRLEN`) independently of total `ARG_MAX`, and the commits API returns every file's full `patch` — **865 KiB** for a 96-file commit:

```
/usr/bin/jq: Argument list too long
jq: invalid JSON text passed to --argjson
Process completed with exit code 2
```

The `page >= 30` guard never fires, because the crash happens first. #471 is the first PR large enough to hit this; it will recur on any sizeable PR.

## The fix

**Keep only the fields the classifiers read.** They inspect `.filename` and `.previous_filename` and nothing else, so the patch bodies — ~98% of the payload — are dropped at ingest. **865 KiB → 11 KiB.**

**`.previous_filename` must be kept.** Reducing to `{filename}` alone makes `is_generated_signature_artifact_commit` **ALLOW** a commit that renames a file *into* a signature-artifact name, which it rejects today. That is the one change here that could have silently weakened the gate, and it is why the strip is `{filename, previous_filename}`.

**Accumulate via `--slurpfile`, not argv.** Stripping fixes today's failure; this makes the failure mode structurally unreachable.

**Guard `mktemp -d`.** On failure the paths resolved empty, the loop burned 30 API calls against a broken state, and it reported "too many files to classify safely" — a misleading message for an unrelated fault.

## Verification

`get_commit_json` and the classifiers were extracted from this file and driven with fixtures. **Verdicts are identical before and after:**

| Fixture | Before | After |
|---|---|---|
| sig + benchmark, correct title | ALLOW | ALLOW |
| sig present, **wrong** commit title | reject | reject |
| skill content, **no** sig | reject | reject |
| plain rename | reject | reject |
| **rename → artifact name** | reject | reject |
| unrelated file alongside sig | reject | reject |

Real #471 payload: **865,315 → 11,221 bytes**, all 96 files preserved, largest single argument now well under the 131,072-byte limit.

**Caveat:** the crash cannot be reproduced on macOS, which has no per-argument limit. What is verified here is that verdicts are unchanged and the payload drops below the Linux limit. CI passing on #471 is the confirming evidence.

## Not fixed here

The loop paginates `/commits/{sha}` with `per_page`/`page`, which that endpoint ignores. Commits over 100 files re-fetch the same set and append it to themselves until the page-30 guard trips with a misleading size error. Separate bug, same function — worth its own change.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).