### PR TITLE
fix(benchmarks): retire the profile field, accept v3 threshold nulls

### DIFF
--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -28,9 +28,10 @@ from pathlib import Path
 SUMMARY_FIELDS = {
     "skill": [re.compile(r"^- Skill: `?([^`\n]+)`?\s*$")],
     "evaluation_date": [re.compile(r"^- Evaluation date: (.+)$")],
-    # v1/v2 only. v3 dropped this line along with the NVSkills-Eval name; it
-    # stays None there rather than being inferred. See NO_FABRICATION below.
-    "profile": [re.compile(r"^- NVSkills-Eval profile: `?([^`\n]+)`?\s*$")],
+    # RETIRED. v1/v2 emitted "- NVSkills-Eval profile: external". v3 dropped
+    # the line along with the NVSkills-Eval name, which is internal and does
+    # not belong in a published report. The field is retired rather than
+    # carried as a permanently-null column named after an internal tool.
     "environment": [re.compile(r"^- Environment: `?([^`\n]+)`?\s*$")],
     # v3 provenance. Absent from v1/v2, which leave these None.
     "evaluator_version": [re.compile(r"^- Evaluator version: `?([^`\n]+?)`?\s*$")],
@@ -200,7 +201,7 @@ def null_rate_regressions(old: dict, new: dict) -> dict:
 
     This is the generic guard against silent degradation: a regeneration can
     succeed, keep a valid schema, pass --check, and still quietly empty a
-    column when an upstream report format changes. Both the v3 profile /
+    column when an upstream report format changes. Both the v3
     pass_threshold drift and the 2026-08-03 disappearance of
     cuopt-multi-objective-exploration are that shape.
     """

--- a/.github/scripts/marketplace/metadata.json
+++ b/.github/scripts/marketplace/metadata.json
@@ -3327,7 +3327,7 @@
     {
       "path": "skills/tao-run-automl",
       "name": "tao-run-automl",
-      "description": "Run AutoML / hyperparameter optimization (HPO) for NVIDIA TAO networks using AutoMLRunner. Handles algorithm selection (bayesian, hyperband, asha, bohb, llm, hybrid, autoresearch), WandB experiment tracking, job execution on any TAO SDK platform, result interpretation, and per-rec custom evaluation hooks. Use when the user mentions TAO AutoML, hyperparameter optimization, HPO, automl, automl_settings, AutoMLRunner, tao_automl, bayesian search, hyperband, ASHA, LLM-guided search, autoresearch, or wants to tune training hyperparameters for any TAO network. Platform-agnostic — runs on any SDK (Brev, SLURM, Kubernetes, Docker).",
+      "description": "Run container-backed AutoML / hyperparameter optimization (HPO) for NVIDIA TAO networks using AutoMLRunner. Handles algorithm selection (bayesian, hyperband, asha, bohb, llm, hybrid, autoresearch), WandB experiment tracking, job execution on any TAO SDK platform, result interpretation, and per-rec custom evaluation hooks. Use when the user mentions TAO AutoML, hyperparameter optimization, HPO, automl, automl_settings, AutoMLRunner, tao_automl, bayesian search, hyperband, ASHA, LLM-guided search, autoresearch, or wants to tune train/distill/prune/quantize action parameters for any TAO network. Model actions use the model skill's resolved container image by default; venv training requires an explicit user request. Platform-agnostic — runs on any SDK (Brev, SLURM, Kubernetes, Docker).",
       "metadata": {
         "product.primary": "TAO Toolkit",
         "classification.category.primary": "ai_and_machine_learning",

--- a/.github/scripts/tests/test_aggregate_benchmarks.py
+++ b/.github/scripts/tests/test_aggregate_benchmarks.py
@@ -9,9 +9,14 @@ layout in circulation:
   v2 — SkillEvaluator 0.9.x  (skills/cuopt-developer, evaluated 2026-06)
   v3 — SkillEvaluator 1.3.x  (skills/nemotron-speech, evaluated 2026-08)
 
-v3 dropped two fields the parser reads (`NVSkills-Eval profile` and
+v3 dropped two fields the parser read (`NVSkills-Eval profile` and
 `Pass threshold`) and added three it does not (`Evaluator version`,
-`Dataset digest`, `Validation status`). These tests pin both halves of that.
+`Dataset digest`, `Validation status`).
+
+`profile` is now retired: NVSkills-Eval is an internal name and does not
+belong in a published report, so the parser no longer looks for it.
+`pass_threshold_pct` is kept and left None on v3 — it is a real provenance
+value that v3 turned into template prose. These tests pin both decisions.
 """
 
 import sys
@@ -67,9 +72,10 @@ class TestNoFabricatedProvenance(unittest.TestCase):
         entry = agg.parse_benchmark(V3)
         self.assertIsNone(entry["pass_threshold_pct"])
 
-    def test_profile_is_none_for_v3(self):
-        entry = agg.parse_benchmark(V3)
-        self.assertIsNone(entry["profile"])
+    def test_profile_is_not_emitted_at_all(self):
+        """Retired field: absent from every entry, both layouts."""
+        self.assertNotIn("profile", agg.parse_benchmark(V3))
+        self.assertNotIn("profile", agg.parse_benchmark(V2))
 
 
 class TestExistingBehaviourStillWorks(unittest.TestCase):
@@ -77,7 +83,6 @@ class TestExistingBehaviourStillWorks(unittest.TestCase):
 
     def test_v2_still_parses_legacy_fields(self):
         entry = agg.parse_benchmark(V2)
-        self.assertEqual(entry["profile"], "external")
         self.assertEqual(entry["pass_threshold_pct"], 50.0)
 
     def test_v3_shared_fields_parse(self):
@@ -95,35 +100,35 @@ class TestNullRateRegressionGuard(unittest.TestCase):
 
     This is the generic guard for the whole class of silent degradation:
     the regeneration succeeds, the schema stays valid, --check passes, and a
-    column quietly goes null. Both the profile/pass_threshold drift and the
+    column quietly goes null. Both the pass_threshold drift and the
     2026-08-03 disappearance of cuopt-multi-objective-exploration are this
     shape.
     """
 
     def test_flags_a_field_that_lost_values(self):
-        old = {"skills": [{"skill": "a", "profile": "external"},
-                          {"skill": "b", "profile": "external"}]}
-        new = {"skills": [{"skill": "a", "profile": None},
-                          {"skill": "b", "profile": None}]}
+        old = {"skills": [{"skill": "a", "environment": "k8s-sandbox"},
+                          {"skill": "b", "environment": "k8s-sandbox"}]}
+        new = {"skills": [{"skill": "a", "environment": None},
+                          {"skill": "b", "environment": None}]}
         regressions = agg.null_rate_regressions(old, new)
-        self.assertIn("profile", regressions)
-        self.assertEqual(regressions["profile"], (0, 2))
+        self.assertIn("environment", regressions)
+        self.assertEqual(regressions["environment"], (0, 2))
 
     def test_silent_on_unchanged_null_rates(self):
-        old = {"skills": [{"skill": "a", "profile": None}]}
-        new = {"skills": [{"skill": "a", "profile": None}]}
+        old = {"skills": [{"skill": "a", "environment": None}]}
+        new = {"skills": [{"skill": "a", "environment": None}]}
         self.assertEqual(agg.null_rate_regressions(old, new), {})
 
     def test_silent_when_a_field_gains_values(self):
-        old = {"skills": [{"skill": "a", "profile": None}]}
-        new = {"skills": [{"skill": "a", "profile": "external"}]}
+        old = {"skills": [{"skill": "a", "environment": None}]}
+        new = {"skills": [{"skill": "a", "environment": "k8s-sandbox"}]}
         self.assertEqual(agg.null_rate_regressions(old, new), {})
 
     def test_ignores_skills_absent_from_the_old_file(self):
         """A newly added skill with empty fields is not a regression."""
-        old = {"skills": [{"skill": "a", "profile": "external"}]}
-        new = {"skills": [{"skill": "a", "profile": "external"},
-                          {"skill": "b", "profile": None}]}
+        old = {"skills": [{"skill": "a", "environment": "k8s-sandbox"}]}
+        new = {"skills": [{"skill": "a", "environment": "k8s-sandbox"},
+                          {"skill": "b", "environment": None}]}
         self.assertEqual(agg.null_rate_regressions(old, new), {})
 
 

--- a/.github/scripts/tests/test_cli_guard.py
+++ b/.github/scripts/tests/test_cli_guard.py
@@ -27,7 +27,8 @@ REPORT = """# Skill Benchmark: foo
 
 - Skill: `foo`
 - Evaluation date: 2026-06-01
-{profile_line}- Environment: `local`
+- Environment: `local`
+{threshold_line}
 - Tasks: 4 evaluation tasks
 - Attempts per task: 1
 
@@ -38,7 +39,7 @@ REPORT = """# Skill Benchmark: foo
 | Accuracy  | 90% (+10%)  |
 """
 
-PROFILE_LINE = "- NVSkills-Eval profile: `external`\n"
+THRESHOLD_LINE = "- Pass threshold: 50%\n"
 
 
 class TestGuardBlocksRegeneration(unittest.TestCase):
@@ -48,7 +49,7 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
         (self.root / "components.d").mkdir()
         self.report = self.root / "skills" / "foo" / "BENCHMARK.md"
         # Baseline: the field is present, benchmarks.json records it.
-        self.report.write_text(REPORT.format(profile_line=PROFILE_LINE))
+        self.report.write_text(REPORT.format(threshold_line=THRESHOLD_LINE))
         (self.root / "benchmarks.json").write_text(agg.generate(self.root))
         self.addCleanup(shutil.rmtree, self.root)
 
@@ -61,7 +62,7 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
             sys.argv = argv
 
     def _drop_the_field(self):
-        self.report.write_text(REPORT.format(profile_line=""))
+        self.report.write_text(REPORT.format(threshold_line=""))
 
     def test_regeneration_succeeds_when_nothing_empties(self):
         self.assertEqual(self._run(), 0)
@@ -81,7 +82,7 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
         self._drop_the_field()
         self.assertEqual(self._run("--allow-null-regressions"), 0)
         written = json.loads((self.root / "benchmarks.json").read_text())
-        self.assertIsNone(written["skills"][0]["profile"])
+        self.assertIsNone(written["skills"][0]["pass_threshold_pct"])
 
 
 if __name__ == "__main__":

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -28,7 +28,6 @@
     {
       "skill": "accelerated-computing-cudf",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -49,7 +48,6 @@
     {
       "skill": "aiq-deploy",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -70,7 +68,6 @@
     {
       "skill": "aiq-research",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -91,7 +88,6 @@
     {
       "skill": "amc-run-rtsp-calibration",
       "evaluation_date": "2026-07-09",
-      "profile": "internal",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -112,7 +108,6 @@
     {
       "skill": "amc-run-sample-calibration",
       "evaluation_date": "2026-07-09",
-      "profile": "internal",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -133,7 +128,6 @@
     {
       "skill": "amc-run-video-calibration",
       "evaluation_date": "2026-07-09",
-      "profile": "internal",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -154,7 +148,6 @@
     {
       "skill": "amc-setup-calibration-stack",
       "evaluation_date": "2026-07-09",
-      "profile": "internal",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -175,7 +168,6 @@
     {
       "skill": "cudaq-guide",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -196,7 +188,6 @@
     {
       "skill": "cuopt-developer",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -217,7 +208,6 @@
     {
       "skill": "cuopt-install",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -238,7 +228,6 @@
     {
       "skill": "cuopt-multi-objective-exploration",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:45bef5ee60d2a85ef8c4a7175c3d9a15eeac738e7bcf291d44de12ad4a35fff2",
@@ -259,7 +248,6 @@
     {
       "skill": "cuopt-numerical-optimization-api",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:f385c69ce235035e8e5cbfd91a8d3245b75473f0bf0d694451e988e439f6e9e1",
@@ -280,7 +268,6 @@
     {
       "skill": "cuopt-numerical-optimization-formulation",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:7f39d48b2b7e50bd2a24f83c7f6172f1f16b1895a59e237bb4c345cf690cb71e",
@@ -301,7 +288,6 @@
     {
       "skill": "cuopt-routing-api-python",
       "evaluation_date": "2026-08-12",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:e13146ac43d578682f0a3d799837f67335d277ef722feb1d28fc526709b6ba4e",
@@ -322,7 +308,6 @@
     {
       "skill": "cuopt-server-api-python",
       "evaluation_date": "2026-06-29",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -343,7 +328,6 @@
     {
       "skill": "cupynumeric-hdf5",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -364,7 +348,6 @@
     {
       "skill": "cupynumeric-install",
       "evaluation_date": "2026-07-27",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -382,7 +365,6 @@
     {
       "skill": "cupynumeric-migration-readiness",
       "evaluation_date": "2026-07-27",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -400,7 +382,6 @@
     {
       "skill": "cupynumeric-parallel-data-load",
       "evaluation_date": "2026-07-27",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -418,7 +399,6 @@
     {
       "skill": "dali-dynamic-mode",
       "evaluation_date": "2026-08-11",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.0",
       "dataset_digest": "sha256:cd54de141f8255b7043b6f2d8b5a203dad6038b1c20b0e36a549f4fac0721cba",
@@ -439,7 +419,6 @@
     {
       "skill": "data-designer",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -460,7 +439,6 @@
     {
       "skill": "deepstream-dev",
       "evaluation_date": "2026-06-12",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -481,7 +459,6 @@
     {
       "skill": "skill",
       "evaluation_date": "2026-06-15",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -499,7 +476,6 @@
     {
       "skill": "deepstream-import-vision-model",
       "evaluation_date": "2026-06-12",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -520,7 +496,6 @@
     {
       "skill": "deepstream-profile-pipeline",
       "evaluation_date": "2026-06-03",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -541,7 +516,6 @@
     {
       "skill": "deepstream-run-mv3dt",
       "evaluation_date": "2026-07-02",
-      "profile": "internal",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -561,7 +535,6 @@
     {
       "skill": "deepstream-sop",
       "evaluation_date": "2026-06-25",
-      "profile": "internal",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -582,7 +555,6 @@
     {
       "skill": "dicom-metadata-extract",
       "evaluation_date": "2026-05-31",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -603,7 +575,6 @@
     {
       "skill": "dicom-series-preflight",
       "evaluation_date": "2026-05-31",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -624,7 +595,6 @@
     {
       "skill": "dicom-series-to-volume",
       "evaluation_date": "2026-05-31",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -645,7 +615,6 @@
     {
       "skill": "digital-health-clinical-asr-build",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -666,7 +635,6 @@
     {
       "skill": "digital-health-clinical-asr-eval",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -687,7 +655,6 @@
     {
       "skill": "digital-health-clinical-asr-finetune",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -708,7 +675,6 @@
     {
       "skill": "digital-health-clinical-asr-setup",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -726,7 +692,6 @@
     {
       "skill": "doca-aes-gcm",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -744,7 +709,6 @@
     {
       "skill": "doca-argp",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -762,7 +726,6 @@
     {
       "skill": "doca-argus",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -780,7 +743,6 @@
     {
       "skill": "doca-bare-metal-deployment",
       "evaluation_date": "2026-07-25",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -798,7 +760,6 @@
     {
       "skill": "doca-bench",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -816,7 +777,6 @@
     {
       "skill": "doca-bench-extension",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -834,7 +794,6 @@
     {
       "skill": "doca-bf3-deployment",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -852,7 +811,6 @@
     {
       "skill": "doca-bf4-deployment",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -870,7 +828,6 @@
     {
       "skill": "doca-caps",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -891,7 +848,6 @@
     {
       "skill": "doca-collectx-deployment",
       "evaluation_date": "2026-07-25",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -909,7 +865,6 @@
     {
       "skill": "doca-comch",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -927,7 +882,6 @@
     {
       "skill": "doca-comm-channel-admin",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -945,7 +899,6 @@
     {
       "skill": "doca-common",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -963,7 +916,6 @@
     {
       "skill": "doca-compress",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -981,7 +933,6 @@
     {
       "skill": "doca-container-deployment",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -999,7 +950,6 @@
     {
       "skill": "doca-debug",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1017,7 +967,6 @@
     {
       "skill": "doca-devemu",
       "evaluation_date": "2026-07-25",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1035,7 +984,6 @@
     {
       "skill": "doca-dma",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1053,7 +1001,6 @@
     {
       "skill": "doca-dms",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1071,7 +1018,6 @@
     {
       "skill": "doca-dpa",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1092,7 +1038,6 @@
     {
       "skill": "doca-dpa-hl-tracer",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1110,7 +1055,6 @@
     {
       "skill": "doca-dpdk-bridge",
       "evaluation_date": "2026-07-14",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1131,7 +1075,6 @@
     {
       "skill": "doca-erasure-coding",
       "evaluation_date": "2026-07-14",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1152,7 +1095,6 @@
     {
       "skill": "doca-eth",
       "evaluation_date": "2026-07-14",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1173,7 +1115,6 @@
     {
       "skill": "doca-firefly",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1191,7 +1132,6 @@
     {
       "skill": "doca-flow",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1209,7 +1149,6 @@
     {
       "skill": "doca-flow-dpa-perf",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1227,7 +1166,6 @@
     {
       "skill": "doca-flow-dpa-provider",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1248,7 +1186,6 @@
     {
       "skill": "doca-flow-grpc-server",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1266,7 +1203,6 @@
     {
       "skill": "doca-flow-perf",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1284,7 +1220,6 @@
     {
       "skill": "doca-flow-tune",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1302,7 +1237,6 @@
     {
       "skill": "doca-gpi",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1320,7 +1254,6 @@
     {
       "skill": "doca-gpunetio",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1338,7 +1271,6 @@
     {
       "skill": "doca-gpunetio-ib-write-bw",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1356,7 +1288,6 @@
     {
       "skill": "doca-gpunetio-ib-write-lat",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1374,7 +1305,6 @@
     {
       "skill": "doca-hardware-safety",
       "evaluation_date": "2026-07-25",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1392,7 +1322,6 @@
     {
       "skill": "doca-mgmt",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1410,7 +1339,6 @@
     {
       "skill": "doca-pcc",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1428,7 +1356,6 @@
     {
       "skill": "doca-pcc-counters",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1446,7 +1373,6 @@
     {
       "skill": "doca-pcc-ztr-rttcc-algo",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1464,7 +1390,6 @@
     {
       "skill": "doca-programming-guide",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1482,7 +1407,6 @@
     {
       "skill": "doca-public-knowledge-map",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1500,7 +1424,6 @@
     {
       "skill": "doca-rdma",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1518,7 +1441,6 @@
     {
       "skill": "doca-rdmi",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1536,7 +1458,6 @@
     {
       "skill": "doca-rmax",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1554,7 +1475,6 @@
     {
       "skill": "doca-setup",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1572,7 +1492,6 @@
     {
       "skill": "doca-sha",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1590,7 +1509,6 @@
     {
       "skill": "doca-sha-offload-engine",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1608,7 +1526,6 @@
     {
       "skill": "doca-socket-relay",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1626,7 +1543,6 @@
     {
       "skill": "doca-spcx-cc",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1644,7 +1560,6 @@
     {
       "skill": "doca-sta",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1662,7 +1577,6 @@
     {
       "skill": "doca-structured-tools-contract",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1680,7 +1594,6 @@
     {
       "skill": "doca-telemetry",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1698,7 +1611,6 @@
     {
       "skill": "doca-telemetry-exporter",
       "evaluation_date": "2026-07-29",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.0",
       "dataset_digest": "sha256:bdb053d3eebd3787bba933e197d64385efe318e5e5666e43c6300e91e2c8f42e",
@@ -1719,7 +1631,6 @@
     {
       "skill": "doca-telemetry-utils",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1737,7 +1648,6 @@
     {
       "skill": "doca-upgrade",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1755,7 +1665,6 @@
     {
       "skill": "doca-urom",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1773,7 +1682,6 @@
     {
       "skill": "doca-urom-svc",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1791,7 +1699,6 @@
     {
       "skill": "doca-verbs",
       "evaluation_date": "2026-07-26",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1809,7 +1716,6 @@
     {
       "skill": "doca-version",
       "evaluation_date": "2026-07-23",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1827,7 +1733,6 @@
     {
       "skill": "dynamo-interconnect-check",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1845,7 +1750,6 @@
     {
       "skill": "dynamo-recipe-runner",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1863,7 +1767,6 @@
     {
       "skill": "dynamo-router-starter",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1881,7 +1784,6 @@
     {
       "skill": "dynamo-troubleshoot",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1899,7 +1801,6 @@
     {
       "skill": "earth2studio-create-datasource",
       "evaluation_date": "2026-06-01",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1917,7 +1818,6 @@
     {
       "skill": "earth2studio-create-diagnostic",
       "evaluation_date": "2026-06-24",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1938,7 +1838,6 @@
     {
       "skill": "earth2studio-create-prognostic",
       "evaluation_date": "2026-06-03",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1956,7 +1855,6 @@
     {
       "skill": "earth2studio-data-fetch",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1977,7 +1875,6 @@
     {
       "skill": "earth2studio-deterministic-forecast",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -1995,7 +1892,6 @@
     {
       "skill": "earth2studio-discover",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2016,7 +1912,6 @@
     {
       "skill": "earth2studio-install",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2037,7 +1932,6 @@
     {
       "skill": "holohub-app-lifecycle",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:018f6fca61cefe2c611e9a1335321e75a24c166dbe6980ffbacfbc0f9d571733",
@@ -2058,7 +1952,6 @@
     {
       "skill": "holohub-debug-build-run",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:c260676bf566fd39aec781cf254c16365214ab7b05e60c0d7f4ac468b89597dc",
@@ -2079,7 +1972,6 @@
     {
       "skill": "holohub-module-lifecycle",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:cbdb11772e761dfe177d00b040909b44f6199ac0f2c1b37d2545a438328f2c52",
@@ -2100,7 +1992,6 @@
     {
       "skill": "holoscan-install-conda",
       "evaluation_date": "2026-05-31",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2121,7 +2012,6 @@
     {
       "skill": "holoscan-install-container",
       "evaluation_date": "2026-05-31",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2142,7 +2032,6 @@
     {
       "skill": "holoscan-install-debian",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2163,7 +2052,6 @@
     {
       "skill": "holoscan-install-source",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2184,7 +2072,6 @@
     {
       "skill": "holoscan-install-wheel",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2205,7 +2092,6 @@
     {
       "skill": "holoscan-setup",
       "evaluation_date": "2026-06-29",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2226,7 +2112,6 @@
     {
       "skill": "hsb-app",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2247,7 +2132,6 @@
     {
       "skill": "hsb-flash",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2268,7 +2152,6 @@
     {
       "skill": "hsb-ip-create-top",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2289,7 +2172,6 @@
     {
       "skill": "hsb-ip-def",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2310,7 +2192,6 @@
     {
       "skill": "hsb-ip-packetizer",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2331,7 +2212,6 @@
     {
       "skill": "hsb-setup",
       "evaluation_date": "2026-06-30",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2352,7 +2232,6 @@
     {
       "skill": "hsb-test",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2373,7 +2252,6 @@
     {
       "skill": "i4h-catheter-navigation",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2391,7 +2269,6 @@
     {
       "skill": "i4h-catheter-navigation-digital-twin",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2409,7 +2286,6 @@
     {
       "skill": "i4h-catheter-navigation-e2e",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2427,7 +2303,6 @@
     {
       "skill": "i4h-catheter-navigation-render-drr",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2445,7 +2320,6 @@
     {
       "skill": "i4h-catheter-navigation-setup",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2463,7 +2337,6 @@
     {
       "skill": "i4h-catheter-navigation-smoke",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2481,7 +2354,6 @@
     {
       "skill": "i4h-catheter-navigation-viewport",
       "evaluation_date": "2026-07-20",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2499,7 +2371,6 @@
     {
       "skill": "i4h-lerobot-viz",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2520,7 +2391,6 @@
     {
       "skill": "i4h-workflow",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2541,7 +2411,6 @@
     {
       "skill": "i4h-workflow-create",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2562,7 +2431,6 @@
     {
       "skill": "i4h-workflow-dataset-annotate",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2583,7 +2451,6 @@
     {
       "skill": "i4h-workflow-dataset-convert",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2604,7 +2471,6 @@
     {
       "skill": "i4h-workflow-dataset-mimic",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2625,7 +2491,6 @@
     {
       "skill": "i4h-workflow-dataset-replay",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2646,7 +2511,6 @@
     {
       "skill": "i4h-workflow-dataset-teleop",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2667,7 +2531,6 @@
     {
       "skill": "i4h-workflow-e2e",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2688,7 +2551,6 @@
     {
       "skill": "i4h-workflow-finetune",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2709,7 +2571,6 @@
     {
       "skill": "i4h-workflow-scene-edit",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2730,7 +2591,6 @@
     {
       "skill": "i4h-workflow-setup",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2751,7 +2611,6 @@
     {
       "skill": "i4h-workflow-validate",
       "evaluation_date": "2026-07-03",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2772,7 +2631,6 @@
     {
       "skill": "jetson-build-source",
       "evaluation_date": "2026-05-30",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2793,7 +2651,6 @@
     {
       "skill": "jetson-customize-camera",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2814,7 +2671,6 @@
     {
       "skill": "jetson-customize-clocks",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2835,7 +2691,6 @@
     {
       "skill": "jetson-customize-fan",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2856,7 +2711,6 @@
     {
       "skill": "jetson-customize-mgbe",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2877,7 +2731,6 @@
     {
       "skill": "jetson-customize-nvpmodel",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2898,7 +2751,6 @@
     {
       "skill": "jetson-customize-pcie",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2919,7 +2771,6 @@
     {
       "skill": "jetson-customize-pinmux",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2940,7 +2791,6 @@
     {
       "skill": "jetson-customize-uphy",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2961,7 +2811,6 @@
     {
       "skill": "jetson-customize-usb",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -2982,7 +2831,6 @@
     {
       "skill": "jetson-derive-carrier",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3003,7 +2851,6 @@
     {
       "skill": "jetson-diagnostic",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3024,7 +2871,6 @@
     {
       "skill": "jetson-download-bsp",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3045,7 +2891,6 @@
     {
       "skill": "jetson-flash-image",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3066,7 +2911,6 @@
     {
       "skill": "jetson-generate-kb",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3087,7 +2931,6 @@
     {
       "skill": "jetson-headless-mode",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3108,7 +2951,6 @@
     {
       "skill": "jetson-inference-mem-tune",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3129,7 +2971,6 @@
     {
       "skill": "jetson-init-image",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3150,7 +2991,6 @@
     {
       "skill": "jetson-init-source",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3171,7 +3011,6 @@
     {
       "skill": "jetson-init-target",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3192,7 +3031,6 @@
     {
       "skill": "jetson-link-docs",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3213,7 +3051,6 @@
     {
       "skill": "jetson-llm-benchmark",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3234,7 +3071,6 @@
     {
       "skill": "jetson-llm-serve",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3255,7 +3091,6 @@
     {
       "skill": "jetson-memory-audit",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3276,7 +3111,6 @@
     {
       "skill": "jetson-optimize-memory",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3297,7 +3131,6 @@
     {
       "skill": "jetson-package",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3318,7 +3151,6 @@
     {
       "skill": "jetson-print-bsp-info",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3339,7 +3171,6 @@
     {
       "skill": "jetson-print-device-info",
       "evaluation_date": "2026-06-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3360,7 +3191,6 @@
     {
       "skill": "jetson-promote-image",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3381,7 +3211,6 @@
     {
       "skill": "jetson-quick-start",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3402,7 +3231,6 @@
     {
       "skill": "jetson-set-target",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3423,7 +3251,6 @@
     {
       "skill": "jetson-speculative-decoding",
       "evaluation_date": "2026-06-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3444,7 +3271,6 @@
     {
       "skill": "jetson-validate-image",
       "evaluation_date": "2026-06-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3465,7 +3291,6 @@
     {
       "skill": "jetson-video-benchmark",
       "evaluation_date": "2026-08-10",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.1.2",
       "dataset_digest": "sha256:e2d80ff3bff2819a83593a6167c1fd9119caa0d8febe727d4a947e1b84baec88",
@@ -3486,7 +3311,6 @@
     {
       "skill": "jetson-video-capability",
       "evaluation_date": "2026-08-10",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.1.2",
       "dataset_digest": "sha256:b440c2dac3de92def79952306c0425803168bede746d14213e367b04f0655282",
@@ -3507,7 +3331,6 @@
     {
       "skill": "jetson-video-pipeline",
       "evaluation_date": "2026-08-10",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.1.2",
       "dataset_digest": "sha256:2954de192ec504a13b63de5d546a514eafdc11544903c203f84432c93bb7a5be",
@@ -3528,7 +3351,6 @@
     {
       "skill": "jetson-video-recipe",
       "evaluation_date": "2026-08-10",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.1.2",
       "dataset_digest": "sha256:cb2ef860b7b7cf59666c858c733f9b9fab262a8b7c52227977b0d53f6ae69da4",
@@ -3549,7 +3371,6 @@
     {
       "skill": "jetson-video-setup",
       "evaluation_date": "2026-08-10",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.1.2",
       "dataset_digest": "sha256:da01efb8a143276d497b34e33588f31b5cb1d0f128bfa23256ee67a894ccd664",
@@ -3570,7 +3391,6 @@
     {
       "skill": "launch-nemo-rl",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3591,7 +3411,6 @@
     {
       "skill": "mcore-create-issue",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3609,7 +3428,6 @@
     {
       "skill": "mcore-linting-and-formatting",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3627,7 +3445,6 @@
     {
       "skill": "mcore-run-on-slurm",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3645,7 +3462,6 @@
     {
       "skill": "mcore-split-pr",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3663,7 +3479,6 @@
     {
       "skill": "mcore-testing",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3681,7 +3496,6 @@
     {
       "skill": "nemo-automodel-distributed-training",
       "evaluation_date": "2026-07-31",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:5a1d8d0db77adff7b1823958919deaac1b8ca472f0809af87c530be247ff8de0",
@@ -3702,7 +3516,6 @@
     {
       "skill": "nemo-automodel-launcher-config",
       "evaluation_date": "2026-05-28",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3723,7 +3536,6 @@
     {
       "skill": "nemo-automodel-model-onboarding",
       "evaluation_date": "2026-07-31",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:814bfc7c94da8ea6fd1a065d7f3f0c4fcda9ef918f1da7eb46630700f241fc25",
@@ -3744,7 +3556,6 @@
     {
       "skill": "nemo-automodel-recipe-development",
       "evaluation_date": "2026-06-26",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3765,7 +3576,6 @@
     {
       "skill": "nemo-fabric-build-adapter",
       "evaluation_date": "2026-08-19",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:b36cb8cb012011c6dbaaec7b2918d4dc18f18a2117ce8eab572181eeeb245976",
@@ -3786,7 +3596,6 @@
     {
       "skill": "nemo-fabric-integrate",
       "evaluation_date": "2026-08-19",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:460ab15c5720276319ee246cc40eebe66a640b3874108e59b6e7c0e086991ebc",
@@ -3807,7 +3616,6 @@
     {
       "skill": "nemo-mbridge-mlm-bridge-training",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3828,7 +3636,6 @@
     {
       "skill": "nemo-mbridge-multi-node-slurm",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3849,7 +3656,6 @@
     {
       "skill": "nemo-mbridge-perf-activation-recompute",
       "evaluation_date": "2026-08-16",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.2.7",
       "dataset_digest": "sha256:b55bb3c51b83cb2245c0d7a8969bbac7066177e342bd9b9c316ac7cf26212ef6",
@@ -3870,7 +3676,6 @@
     {
       "skill": "nemo-mbridge-perf-cpu-offloading",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3891,7 +3696,6 @@
     {
       "skill": "nemo-mbridge-perf-cuda-graphs",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3912,7 +3716,6 @@
     {
       "skill": "nemo-mbridge-perf-expert-parallel-overlap",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:473eeb29e4297235c32a27b47541793b4f7eddba5f4fc3e053f65a5b344292f1",
@@ -3933,7 +3736,6 @@
     {
       "skill": "nemo-mbridge-perf-hierarchical-context-parallel",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3954,7 +3756,6 @@
     {
       "skill": "nemo-mbridge-perf-megatron-fsdp",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3975,7 +3776,6 @@
     {
       "skill": "nemo-mbridge-perf-memory-tuning",
       "evaluation_date": "2026-06-30",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -3996,7 +3796,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-comm-overlap",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:27e48e74e4c441a61624d9c376db3091241d8249209badb9c045fa6c966d02b8",
@@ -4017,7 +3816,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-dispatcher-selection",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4038,7 +3836,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-hardware-configs",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:bfc3173e4e2204740fad6a3746aa0b031118f0a404945c92ba4138ee08607b57",
@@ -4059,7 +3856,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-long-context",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4080,7 +3876,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-optimization-workflow",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:d195b5b0364709939e2d51e5857908465fae4f4bd91ec22a67656cf1acc798e9",
@@ -4101,7 +3896,6 @@
     {
       "skill": "nemo-mbridge-perf-moe-vlm-training",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4122,7 +3916,6 @@
     {
       "skill": "nemo-mbridge-perf-parallelism-strategies",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4143,7 +3936,6 @@
     {
       "skill": "nemo-mbridge-perf-sequence-packing",
       "evaluation_date": "2026-08-17",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.2.7",
       "dataset_digest": "sha256:57d3c088dee48ee97547a666ee24dcac45c6cd5cbf699640c3c7d41710f629a1",
@@ -4164,7 +3956,6 @@
     {
       "skill": "nemo-mbridge-perf-tp-dp-comm-overlap",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4185,7 +3976,6 @@
     {
       "skill": "nemo-mbridge-recipe-recommender",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:ef1ce0be1100bdb45047e4131f641cc24d4f26a6a08e1a4f84d519d0b6da62a6",
@@ -4206,7 +3996,6 @@
     {
       "skill": "nemo-mbridge-resiliency",
       "evaluation_date": "2026-06-02",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4227,7 +4016,6 @@
     {
       "skill": "nemo-relay-debug-runtime-integration",
       "evaluation_date": "2026-07-30",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:6c296a04671b2c4dbcf71cd6635b53ccd7fdef8405ea55c6ba6de51d66a3f0e2",
@@ -4248,7 +4036,6 @@
     {
       "skill": "nemo-relay-get-started",
       "evaluation_date": "2026-08-21",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:d8b84368c53829b1ab95079b2968f8e667766a8d13577bc10331d59a90e243ae",
@@ -4269,7 +4056,6 @@
     {
       "skill": "nemo-relay-install",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4290,7 +4076,6 @@
     {
       "skill": "nemo-relay-instrument-calls",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4311,7 +4096,6 @@
     {
       "skill": "nemo-relay-instrument-context-isolation",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4332,7 +4116,6 @@
     {
       "skill": "nemo-relay-instrument-typed-wrappers",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4353,7 +4136,6 @@
     {
       "skill": "nemo-relay-migrate-from-flow",
       "evaluation_date": "2026-08-12",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:738c9da141c6937b5a549c6cce2751d6b1786921b3eb39fa345e7e2ac44f8fac",
@@ -4374,7 +4156,6 @@
     {
       "skill": "nemo-relay-plugin-adaptive-tuning",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4395,7 +4176,6 @@
     {
       "skill": "nemo-relay-plugin-build",
       "evaluation_date": "2026-08-12",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:c8403ee1b7460312e49238c2b1fb6278c21b125e44f94b87bbe76ddf1cb710b6",
@@ -4416,7 +4196,6 @@
     {
       "skill": "nemo-relay-plugin-observability",
       "evaluation_date": "2026-07-30",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:f399331a28e80f4e118ccf4bfb6f71b126c0d88cd1103bf84c6126b50eb54d8a",
@@ -4437,7 +4216,6 @@
     {
       "skill": "nemo-retriever",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4458,7 +4236,6 @@
     {
       "skill": "nemo-rl-auto-research",
       "evaluation_date": "2026-06-01",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4479,7 +4256,6 @@
     {
       "skill": "nemo-rl-brev-etiquette",
       "evaluation_date": "2026-06-01",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4500,7 +4276,6 @@
     {
       "skill": "nemo-rl-docs",
       "evaluation_date": "2026-06-01",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4521,7 +4296,6 @@
     {
       "skill": "nemo-rl-session-memory",
       "evaluation_date": "2026-06-01",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4542,7 +4316,6 @@
     {
       "skill": "nemoclaw-user-guide",
       "evaluation_date": "2026-07-17",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4563,7 +4336,6 @@
     {
       "skill": "nemotron-asr-finetune",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4584,7 +4356,6 @@
     {
       "skill": "nemotron-customize",
       "evaluation_date": "2026-06-04",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4605,7 +4376,6 @@
     {
       "skill": "nemotron-policy-generator",
       "evaluation_date": "2026-06-03",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4626,7 +4396,6 @@
     {
       "skill": "nemotron-retrieval-recipes",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4647,7 +4416,6 @@
     {
       "skill": "nemotron-speech",
       "evaluation_date": "2026-08-20",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:7da18a129d0ad5efdc392d764333668f68f9acf996152684bc2464427afdb20f",
@@ -4668,7 +4436,6 @@
     {
       "skill": "nv-generate-ct-rflow",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4689,7 +4456,6 @@
     {
       "skill": "nv-generate-mr",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4710,7 +4476,6 @@
     {
       "skill": "nv-generate-mr-brain",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4731,7 +4496,6 @@
     {
       "skill": "nv-generate-mr-brain-finetune",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4752,7 +4516,6 @@
     {
       "skill": "nv-generate-vae-finetune",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4773,7 +4536,6 @@
     {
       "skill": "nv-reason-cxr",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4794,7 +4556,6 @@
     {
       "skill": "nv-segment-ct",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4815,7 +4576,6 @@
     {
       "skill": "nv-segment-ct-finetune",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4836,7 +4596,6 @@
     {
       "skill": "nv-segment-ctmr",
       "evaluation_date": "2026-07-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4857,7 +4616,6 @@
     {
       "skill": "nvidia-skill-finder",
       "evaluation_date": "2026-07-24",
-      "profile": null,
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4875,7 +4633,6 @@
     {
       "skill": "omniverse-cad-to-simready",
       "evaluation_date": "2026-08-12",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:ce412af18bb5e516371ec07ea8752e4043a1d00edd007b505e30f659b8d92047",
@@ -4896,7 +4653,6 @@
     {
       "skill": "omniverse-realtime-viewer",
       "evaluation_date": "2026-08-20",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:22c636e11cd01854316a62aa9e61948dd62ec9d8efda268d6b78487da6c55e82",
@@ -4917,7 +4673,6 @@
     {
       "skill": "omniverse-usd-performance-tuning",
       "evaluation_date": "2026-08-24",
-      "profile": null,
       "environment": "local",
       "evaluator_version": "1.3.2",
       "dataset_digest": "sha256:e8ce4980d3c355c912e64a23c53712932a49478f0c0839b4d48ca0559aa4083c",
@@ -4938,7 +4693,6 @@
     {
       "skill": "paidf-anomalygen",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4959,7 +4713,6 @@
     {
       "skill": "physical-ai-defect-image-generation",
       "evaluation_date": "2026-06-23",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -4980,7 +4733,6 @@
     {
       "skill": "physical-ai-image-attribute-augmentation",
       "evaluation_date": "2026-08-13",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:08e695fc0c489146e8cb39e6b651ee5592a6da00f5f2ee28611bac05d927f532",
@@ -5001,7 +4753,6 @@
     {
       "skill": "physical-ai-infrastructure-setup-and-resilient-scaling",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5019,7 +4770,6 @@
     {
       "skill": "physical-ai-neural-reconstruction",
       "evaluation_date": "2026-07-16",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5040,7 +4790,6 @@
     {
       "skill": "physical-ai-video-data-augmentation",
       "evaluation_date": "2026-07-01",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5061,7 +4810,6 @@
     {
       "skill": "physicsnemo-discover",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5082,7 +4830,6 @@
     {
       "skill": "physicsnemo-shard-tensor",
       "evaluation_date": "2026-08-05",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.0.0",
       "dataset_digest": "sha256:dd5c60518eac8911bdb11a1e2b2eb755fb9faa4bf701c996e6334702ab7a589c",
@@ -5103,7 +4850,6 @@
     {
       "skill": "portfolio-optimization",
       "evaluation_date": "2026-07-30",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:93d7d58ac9dd6ef70bbdea737d6c97c7ff428b7568edfff7aa9028ec3966bc78",
@@ -5124,7 +4870,6 @@
     {
       "skill": "rag-blueprint",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5142,7 +4887,6 @@
     {
       "skill": "rag-eval",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5160,7 +4904,6 @@
     {
       "skill": "rag-perf",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": null,
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5178,7 +4921,6 @@
     {
       "skill": "rtvi-cv-customize-model",
       "evaluation_date": "2026-07-31",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:7ebbe050322d781bde28f4d07a79f421dbf70294c37c25522c802460d5f12921",
@@ -5199,7 +4941,6 @@
     {
       "skill": "rtvi-cv-scaffold-vss-service",
       "evaluation_date": "2026-07-31",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:401fba496bce5a42048bf6833a613cb923e36ddf8de7626d2efcbbfbe5c0d0fb",
@@ -5220,7 +4961,6 @@
     {
       "skill": "rtvi-vlm-customize-model",
       "evaluation_date": "2026-07-31",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "0.9.2",
       "dataset_digest": "sha256:be4b29c85fb10f95f92e1e1cac28bc91a1a7b65cab18e3223986a0e52a66fb20",
@@ -5241,7 +4981,6 @@
     {
       "skill": "skill-card-generator",
       "evaluation_date": "2026-06-30",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5262,7 +5001,6 @@
     {
       "skill": "tao-analyze-changenet-rca",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5283,7 +5021,6 @@
     {
       "skill": "tao-analyze-gaps-visual-changenet",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5303,15 +5040,14 @@
     },
     {
       "skill": "tao-analyze-gaps-vlm-bcq",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:e140184632b0fe19bd5db4852af88c561135630f4b93228a40a301a1db96580d",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5320,19 +5056,18 @@
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 54.3
+      "average_uplift_pct": 43.8
     },
     {
       "skill": "tao-convert-dataset-format",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:2fbc3074b2bf29c63e5b9adbd1040448530ede1c8e428e64ca96693b0b9236a1",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5341,19 +5076,18 @@
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 38.4
+      "average_uplift_pct": 27.4
     },
     {
       "skill": "tao-finetune-clip",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:0a7b21ad86a50e18923dffbf160fb4dd3cfa26464238a34a4adce47a02e6bc1b",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5362,12 +5096,11 @@
       "catalog_dir": "tao-finetune-clip",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 64.0
+      "average_uplift_pct": 58.9
     },
     {
       "skill": "tao-finetune-cosmos-embed",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5388,7 +5121,6 @@
     {
       "skill": "tao-finetune-cosmos-reason",
       "evaluation_date": "2026-06-29",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5409,7 +5141,6 @@
     {
       "skill": "tao-finetune-huggingface-model",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5429,15 +5160,14 @@
     },
     {
       "skill": "tao-generate-image-grounding",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:6e71bdc7c6749095693b9f75023d66f6cf14ce21a8fcf6026e06418a0f1eb5de",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5446,19 +5176,18 @@
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 63.7
+      "average_uplift_pct": 35.9
     },
     {
       "skill": "tao-generate-referring-expressions",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:5d32143561ff4b116cf31ee3c4b782a64cf164ba5aad47c65d8f71564c34eb09",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5467,19 +5196,18 @@
       "catalog_dir": "tao-generate-referring-expressions",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 61.4
+      "average_uplift_pct": 46.2
     },
     {
       "skill": "tao-generate-video-reasoning-annotations",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:fbdeca998d851aa0aab11c3237f6de998b22a3074efd28f8eaa39e1f4d943fa8",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5488,12 +5216,11 @@
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 64.1
+      "average_uplift_pct": 34.9
     },
     {
       "skill": "tao-launch-workflow",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5513,15 +5240,14 @@
     },
     {
       "skill": "tao-list-capabilities",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:37b53f2b0f6a6937497a17b00feacbe45029e33d7a2b28eb1b3ebfaaa89414ec",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5530,12 +5256,11 @@
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 63.8
+      "average_uplift_pct": 37.5
     },
     {
       "skill": "tao-mine-aoi-images",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5556,7 +5281,6 @@
     {
       "skill": "tao-port-huggingface-model",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5577,7 +5301,6 @@
     {
       "skill": "tao-route-visual-changenet-samples",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5597,15 +5320,14 @@
     },
     {
       "skill": "tao-run-automl",
-      "evaluation_date": "2026-06-20",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
-      "tasks": 1,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:6e6a8b1880c4283f37cfa5a864e7adf4d95f63ad1728111063fdc09ab2ac0604",
+      "validation_status": "passed",
+      "tasks": 2,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5614,19 +5336,18 @@
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 57.4
+      "average_uplift_pct": 27.0
     },
     {
       "skill": "tao-run-automl-deft-pipeline",
-      "evaluation_date": "2026-06-20",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:0f684b060be4bb330d1744e55d0e571afca759726c3ea3305f5aff3d68cd5969",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5635,12 +5356,11 @@
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 54.8
+      "average_uplift_pct": 23.8
     },
     {
       "skill": "tao-run-deft-aoi",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5660,15 +5380,14 @@
     },
     {
       "skill": "tao-run-inference-service",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:5ec4eda594f5d0eeda2f3aa6b5018ac7d52381f11b92a4f38cf64323e27c358e",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5677,19 +5396,18 @@
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 60.2
+      "average_uplift_pct": 35.8
     },
     {
       "skill": "tao-run-on-brev",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:be0c191e8b9ac1f2ed8b4cddd431bb80a0d43dc65aced83361bac1b522fd168f",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5698,12 +5416,11 @@
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 10.4
+      "average_uplift_pct": 21.6
     },
     {
       "skill": "tao-run-on-docker",
       "evaluation_date": "2026-07-21",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5721,7 +5438,6 @@
     {
       "skill": "tao-run-on-kubernetes",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5742,7 +5458,6 @@
     {
       "skill": "tao-run-on-local-docker",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5763,7 +5478,6 @@
     {
       "skill": "tao-run-on-slurm",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5784,7 +5498,6 @@
     {
       "skill": "tao-run-platform",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5805,7 +5518,6 @@
     {
       "skill": "tao-setup-nvidia-gpu-host",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5825,15 +5537,14 @@
     },
     {
       "skill": "tao-train-action-recognition",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:5a28679a2ce1c0f618dcb3a8bd8953e64b96e2eda82d50a65fe4ff5081a17989",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5842,19 +5553,18 @@
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 5.8
+      "average_uplift_pct": 21.1
     },
     {
       "skill": "tao-train-bevfusion",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:6bc3159f9695c8804be60ab19012c770f3925eca5d587c746e79b549704c967f",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5863,19 +5573,18 @@
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 24.4
+      "average_uplift_pct": 44.9
     },
     {
       "skill": "tao-train-centerpose",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:8c9306c1db5f60d09b304b060342bac554886b3493acfb625c7664e8f3bea2fb",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5884,19 +5593,18 @@
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 30.8
+      "average_uplift_pct": 42.9
     },
     {
       "skill": "tao-train-deformable-detr",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:4f8a34c161384c71c13bf95c9766cdeeb78b868fc9e9c8f42dbe2c0081e049a4",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5905,12 +5613,11 @@
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 19.2
+      "average_uplift_pct": 24.5
     },
     {
       "skill": "tao-train-depth-anything-v2",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5930,15 +5637,14 @@
     },
     {
       "skill": "tao-train-dino",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:a0a4e58efb79400761614702ba482a9d245b9f3b5fd462ee547295fa15ec910e",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -5947,12 +5653,11 @@
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 54.3
+      "average_uplift_pct": 45.6
     },
     {
       "skill": "tao-train-fast-foundation-stereo",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5973,7 +5678,6 @@
     {
       "skill": "tao-train-foundation-stereo",
       "evaluation_date": "2026-06-22",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -5993,15 +5697,14 @@
     },
     {
       "skill": "tao-train-grounding-dino",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:d5ad56d004c26f0a41b51287912ae2154603d657fc4c3534a90a345f2161c796",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6010,19 +5713,18 @@
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 38.6
+      "average_uplift_pct": 24.9
     },
     {
       "skill": "tao-train-image-classification",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:206d62dbc15f845e57ca15d252f0c09ea9b4ea530419388f2525b5f7db4a1d0a",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6031,19 +5733,18 @@
       "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 67.6
+      "average_uplift_pct": 10.8
     },
     {
       "skill": "tao-train-mask-auto-encoder",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:ab9ef648310ea9533b75741eafbf74552631433c44a51aaa277d1e5c58239568",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6052,19 +5753,18 @@
       "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 51.3
+      "average_uplift_pct": 38.4
     },
     {
       "skill": "tao-train-mask-auto-label",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:7eacf9398cb6274a04cdbee9950ce4646ee885008b9a42a4066b4fe08e4aeddf",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6073,19 +5773,18 @@
       "catalog_dir": "tao-train-mask-auto-label",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 40.2
+      "average_uplift_pct": 19.7
     },
     {
       "skill": "tao-train-mask-grounding-dino",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:6ede99c47438b61c32d88bbdab9337ea8103308129e5ed5f755eccd17a83949f",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6094,19 +5793,18 @@
       "catalog_dir": "tao-train-mask-grounding-dino",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 19.1
+      "average_uplift_pct": 23.7
     },
     {
       "skill": "tao-train-mask2former",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:52024b5b07978a81d4aabc7184678bc6e720de4e36c431bd53f4d2b666606646",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6115,19 +5813,18 @@
       "catalog_dir": "tao-train-mask2former",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 58.1
+      "average_uplift_pct": 20.3
     },
     {
       "skill": "tao-train-metric-learning-recognition",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:87cb14ca8ab20738d96652b26ff54723f103dd297fa23d1157beba407e5d344e",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6136,19 +5833,18 @@
       "catalog_dir": "tao-train-metric-learning-recognition",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 21.4
+      "average_uplift_pct": 20.2
     },
     {
       "skill": "tao-train-nvdinov2",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:fa3fa74847cd160aa846ebcf8cbca2d579f21549b3a16539f883b54e9296dd11",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6157,19 +5853,18 @@
       "catalog_dir": "tao-train-nvdinov2",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 53.3
+      "average_uplift_pct": 32.1
     },
     {
       "skill": "tao-train-nvpanoptix3d",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:cc0384d330cc8872298b458fa580905a2ff75afbdaaf1cdf0c3eddef27369244",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6178,19 +5873,18 @@
       "catalog_dir": "tao-train-nvpanoptix3d",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 37.6
+      "average_uplift_pct": 22.3
     },
     {
       "skill": "tao-train-ocdnet",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:efa0c4ae0da611bf0297a3690e59845bfb8c639705d8ead0825326c2b3602047",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6199,19 +5893,18 @@
       "catalog_dir": "tao-train-ocdnet",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 49.3
+      "average_uplift_pct": 41.1
     },
     {
       "skill": "tao-train-ocrnet",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:85ba50bd18348c2652bcb215456f1887ac642a3b81701a68ad5c5259bdde3091",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6220,19 +5913,18 @@
       "catalog_dir": "tao-train-ocrnet",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 12.8
+      "average_uplift_pct": 43.7
     },
     {
       "skill": "tao-train-oneformer",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:310962cce2a7dce214ed282e3dde459ece3242954c272b5557e3b2bd3fe04a4a",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6241,19 +5933,18 @@
       "catalog_dir": "tao-train-oneformer",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 64.3
+      "average_uplift_pct": 15.6
     },
     {
       "skill": "tao-train-optical-inspection",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:92300e452114b3453095ca91ce8396d14336ce04619a616cf6393957969fb901",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6262,19 +5953,18 @@
       "catalog_dir": "tao-train-optical-inspection",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 19.6
+      "average_uplift_pct": 39.2
     },
     {
       "skill": "tao-train-pointpillars",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:86fdda83cf047fafe307e854d232a524e239aeaad950b54689e8477f3128e3db",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6283,19 +5973,18 @@
       "catalog_dir": "tao-train-pointpillars",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 0.6
+      "average_uplift_pct": 21.2
     },
     {
       "skill": "tao-train-pose-classification",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:911fdab3189500019ddd510c71614289741cbbf0734c34b2b05952c4027e561a",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6304,19 +5993,18 @@
       "catalog_dir": "tao-train-pose-classification",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 64.6
+      "average_uplift_pct": 22.2
     },
     {
       "skill": "tao-train-reid",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:e56d74577eb2d52bf3c78b82bbbb5d7b72f5c078fe9b1c3bcd794756d8509d8f",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6325,19 +6013,18 @@
       "catalog_dir": "tao-train-reid",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 23.1
+      "average_uplift_pct": 23.6
     },
     {
       "skill": "tao-train-rtdetr",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:f8097d932847587633107ec506f93a5af0100ffc2857d5b55ccf2d0eac54e4ea",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6346,19 +6033,18 @@
       "catalog_dir": "tao-train-rtdetr",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 55.0
+      "average_uplift_pct": 13.5
     },
     {
       "skill": "tao-train-segformer",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:f80b8692186ac58315e7b714cea67f5c78b935b2d93e3982e2bd26b67c895d4d",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6367,19 +6053,18 @@
       "catalog_dir": "tao-train-segformer",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 22.8
+      "average_uplift_pct": 42.1
     },
     {
       "skill": "tao-train-single-step",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:48f484a83577a304c6518b28cbd7630e71af86b9a0f1655d980ea51b650d034d",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6388,19 +6073,18 @@
       "catalog_dir": "tao-train-single-step",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 31.5
+      "average_uplift_pct": 16.6
     },
     {
       "skill": "tao-train-sparse4d",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:a66bccd122a4e284a07ecb17ffac7584cd4d490d6b9955f970cea7c4fd14a55a",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6409,12 +6093,11 @@
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 45.8
+      "average_uplift_pct": 18.8
     },
     {
       "skill": "tao-train-visual-changenet",
       "evaluation_date": "2026-06-20",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6434,15 +6117,14 @@
     },
     {
       "skill": "tao-validate-dataset-format",
-      "evaluation_date": "2026-06-22",
-      "profile": "external",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
+      "evaluation_date": "2026-08-24",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:a10c158d485aae405af8bf9fa4683b3c863dd7573f2c4be03d871bd0797abf39",
+      "validation_status": "passed",
       "tasks": 1,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -6451,12 +6133,11 @@
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "has_results": true,
-      "average_uplift_pct": 46.0
+      "average_uplift_pct": 43.0
     },
     {
       "skill": "tilegym-adding-cutile-kernel",
       "evaluation_date": "2026-05-29",
-      "profile": "external",
       "environment": "local",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6477,7 +6158,6 @@
     {
       "skill": "tilegym-converting-cutile-to-julia",
       "evaluation_date": "2026-06-10",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6498,7 +6178,6 @@
     {
       "skill": "tilegym-converting-cutile-to-triton",
       "evaluation_date": "2026-07-14",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6519,7 +6198,6 @@
     {
       "skill": "tilegym-cutile-autotuning",
       "evaluation_date": "2026-06-10",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6540,7 +6218,6 @@
     {
       "skill": "tilegym-cutile-python",
       "evaluation_date": "2026-06-08",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6561,7 +6238,6 @@
     {
       "skill": "tilegym-improve-cutile-kernel-perf",
       "evaluation_date": "2026-07-27",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6579,7 +6255,6 @@
     {
       "skill": "tilegym-monkey-patch-kernels-to-transformers",
       "evaluation_date": "2026-07-13",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6600,7 +6275,6 @@
     {
       "skill": "vss-ask-video",
       "evaluation_date": "2026-06-09",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6621,7 +6295,6 @@
     {
       "skill": "vss-deploy-dense-captioning",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6642,7 +6315,6 @@
     {
       "skill": "vss-deploy-detection-tracking-2d",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6663,7 +6335,6 @@
     {
       "skill": "vss-deploy-detection-tracking-3d",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6684,7 +6355,6 @@
     {
       "skill": "vss-deploy-profile",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6705,7 +6375,6 @@
     {
       "skill": "vss-deploy-video-embedding",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6726,7 +6395,6 @@
     {
       "skill": "vss-generate-video-calibration",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6747,7 +6415,6 @@
     {
       "skill": "vss-generate-video-report",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6768,7 +6435,6 @@
     {
       "skill": "vss-manage-alerts",
       "evaluation_date": "2026-06-14",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6789,7 +6455,6 @@
     {
       "skill": "vss-manage-video-io-storage",
       "evaluation_date": "2026-06-09",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6810,7 +6475,6 @@
     {
       "skill": "vss-query-analytics",
       "evaluation_date": "2026-06-09",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6831,7 +6495,6 @@
     {
       "skill": "vss-search-archive",
       "evaluation_date": "2026-06-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6852,7 +6515,6 @@
     {
       "skill": "vss-setup-behavior-analytics",
       "evaluation_date": "2026-06-10",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6873,7 +6535,6 @@
     {
       "skill": "vss-setup-video-analytics-api",
       "evaluation_date": "2026-06-09",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6894,7 +6555,6 @@
     {
       "skill": "vss-summarize-video",
       "evaluation_date": "2026-07-15",
-      "profile": "external",
       "environment": "astra-sandbox",
       "evaluator_version": null,
       "dataset_digest": null,
@@ -6915,7 +6575,6 @@
     {
       "skill": "warp-compile-time-optimizer",
       "evaluation_date": "2026-08-13",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:7f1d9e790399798ffbe028ff0ae8cdcf78cc28e4b304a09125ad6da274002c60",
@@ -6936,7 +6595,6 @@
     {
       "skill": "warp-debug-gradients",
       "evaluation_date": "2026-08-12",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.4",
       "dataset_digest": "sha256:000033468255fb96783d760282543223f1de0f819410f680afa302b24fa1d4f1",
@@ -6957,7 +6615,6 @@
     {
       "skill": "warp-eval",
       "evaluation_date": "2026-08-11",
-      "profile": null,
       "environment": "k8s-sandbox",
       "evaluator_version": "1.2.0",
       "dataset_digest": "sha256:3cef7eea3a63f09e3fd21bc5026ce689b012891fadbaed79881c8766b7e5640c",
@@ -28761,7 +28418,7 @@
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -28770,7 +28427,7 @@
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -28779,79 +28436,79 @@
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 84.0,
-      "uplift_pct": 84.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 34.0,
-      "uplift_pct": 34.0
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 90.0
+      "uplift_pct": 63.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
+      "score_pct": 83.0,
+      "uplift_pct": 8.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 24.0,
-      "uplift_pct": -3.0
+      "score_pct": 75.0,
+      "uplift_pct": 43.0
     },
     {
       "catalog_dir": "tao-analyze-gaps-vlm-bcq",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
     },
     {
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -28860,7 +28517,7 @@
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -28869,163 +28526,163 @@
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 10.0,
-      "uplift_pct": 10.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 56.0
+    },
+    {
+      "catalog_dir": "tao-convert-dataset-format",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-convert-dataset-format",
-      "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 42.0,
-      "uplift_pct": 32.0
+      "score_pct": 100.0,
+      "uplift_pct": 68.0
     },
     {
       "catalog_dir": "tao-convert-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
+      "score_pct": 85.0,
+      "uplift_pct": 15.0
+    },
+    {
+      "catalog_dir": "tao-convert-dataset-format",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 55.0
+    },
+    {
+      "catalog_dir": "tao-convert-dataset-format",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
       "uplift_pct": 80.0
     },
     {
-      "catalog_dir": "tao-convert-dataset-format",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-convert-dataset-format",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
       "catalog_dir": "tao-finetune-clip",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 83.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 35.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 67.0
+    },
+    {
+      "catalog_dir": "tao-finetune-clip",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 86.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 66.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 41.0
-    },
-    {
-      "catalog_dir": "tao-finetune-clip",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
     },
     {
       "catalog_dir": "tao-finetune-cosmos-embed",
@@ -29301,7 +28958,7 @@
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29310,7 +28967,7 @@
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29319,169 +28976,169 @@
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 96.0,
-      "uplift_pct": 82.0
+      "score_pct": 83.0,
+      "uplift_pct": 57.0
     },
     {
       "catalog_dir": "tao-generate-image-grounding",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
+      "score_pct": 70.0,
+      "uplift_pct": 37.0
+    },
+    {
+      "catalog_dir": "tao-generate-image-grounding",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 55.0
+    },
+    {
+      "catalog_dir": "tao-generate-image-grounding",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-generate-referring-expressions",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 95.0,
       "uplift_pct": 62.0
     },
     {
-      "catalog_dir": "tao-generate-image-grounding",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 70.0,
-      "uplift_pct": 43.0
-    },
-    {
-      "catalog_dir": "tao-generate-image-grounding",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 82.0,
-      "uplift_pct": 82.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
       "catalog_dir": "tao-generate-referring-expressions",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
-    },
-    {
-      "catalog_dir": "tao-generate-referring-expressions",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 86.0,
-      "uplift_pct": 58.0
+      "score_pct": 100.0,
+      "uplift_pct": 57.0
     },
     {
       "catalog_dir": "tao-generate-referring-expressions",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 63.0,
-      "uplift_pct": 36.0
+      "score_pct": 83.0,
+      "uplift_pct": 83.0
     },
     {
       "catalog_dir": "tao-generate-referring-expressions",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29490,7 +29147,7 @@
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29499,73 +29156,73 @@
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-generate-video-reasoning-annotations",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-generate-video-reasoning-annotations",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 86.0
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-generate-video-reasoning-annotations",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 92.0,
       "uplift_pct": 66.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
       "score_pct": 70.0,
-      "uplift_pct": 42.0
+      "uplift_pct": 27.0
     },
     {
       "catalog_dir": "tao-generate-video-reasoning-annotations",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 46.0
+    },
+    {
+      "catalog_dir": "tao-generate-video-reasoning-annotations",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-launch-workflow",
@@ -29661,7 +29318,7 @@
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29670,7 +29327,7 @@
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -29679,25 +29336,25 @@
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 90.0
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 80.0,
+      "uplift_pct": 20.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 100.0
@@ -29706,46 +29363,46 @@
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 56.0,
-      "uplift_pct": 46.0
+      "score_pct": 83.0,
+      "uplift_pct": 67.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 72.0
+      "score_pct": 53.0,
+      "uplift_pct": 5.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 68.0
+      "score_pct": 83.0,
+      "uplift_pct": 83.0
     },
     {
       "catalog_dir": "tao-list-capabilities",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-mine-aoi-images",
@@ -30021,7 +29678,7 @@
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30030,7 +29687,7 @@
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30039,79 +29696,79 @@
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 90.0
+      "score_pct": 100.0,
+      "uplift_pct": 30.0
     },
     {
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 72.0,
-      "uplift_pct": 72.0
+      "score_pct": 47.0,
+      "uplift_pct": 47.0
     },
     {
       "catalog_dir": "tao-run-automl",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-run-automl",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 92.0,
+      "uplift_pct": 8.0
+    },
+    {
+      "catalog_dir": "tao-run-automl",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 43.0
+    },
+    {
+      "catalog_dir": "tao-run-automl",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
       "score_pct": 50.0,
-      "uplift_pct": 40.0
-    },
-    {
-      "catalog_dir": "tao-run-automl",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
-    },
-    {
-      "catalog_dir": "tao-run-automl",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-run-automl",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 59.0,
-      "uplift_pct": 31.0
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30120,7 +29777,7 @@
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30129,73 +29786,73 @@
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 60.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 59.0,
-      "uplift_pct": 59.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
+      "score_pct": 98.0,
+      "uplift_pct": 81.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 66.0
+      "score_pct": 65.0,
+      "uplift_pct": 17.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 75.0,
-      "uplift_pct": 48.0
+      "score_pct": 83.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-automl-deft-pipeline",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 42.0,
-      "uplift_pct": 14.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-deft-aoi",
@@ -30291,7 +29948,7 @@
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30300,7 +29957,7 @@
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30309,79 +29966,79 @@
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 80.0,
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-run-inference-service",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
       "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-run-inference-service",
-      "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 40.0,
-      "uplift_pct": 30.0
-    },
-    {
-      "catalog_dir": "tao-run-inference-service",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 62.0
-    },
-    {
-      "catalog_dir": "tao-run-inference-service",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 95.0,
-      "uplift_pct": 68.0
+      "uplift_pct": 53.0
+    },
+    {
+      "catalog_dir": "tao-run-inference-service",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 52.0
     },
     {
       "catalog_dir": "tao-run-inference-service",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-run-inference-service",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30390,7 +30047,7 @@
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -30399,34 +30056,34 @@
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
+      "score_pct": 60.0,
+      "uplift_pct": -40.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
@@ -30435,37 +30092,37 @@
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 48.0,
-      "uplift_pct": 38.0
+      "score_pct": 78.0,
+      "uplift_pct": 47.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 26.0
+      "score_pct": 75.0,
+      "uplift_pct": 27.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": -0.0
+      "score_pct": 83.0,
+      "uplift_pct": 52.0
     },
     {
       "catalog_dir": "tao-run-on-brev",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-run-on-docker",
@@ -31011,7 +30668,7 @@
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31020,7 +30677,7 @@
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31029,34 +30686,34 @@
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": 0.0
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
     },
     {
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
-    },
-    {
-      "catalog_dir": "tao-train-action-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
+      "score_pct": 100.0,
       "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-action-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
@@ -31065,43 +30722,43 @@
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 12.0
+      "score_pct": 95.0,
+      "uplift_pct": 63.0
     },
     {
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 26.0
+      "score_pct": 90.0,
+      "uplift_pct": 15.0
     },
     {
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": 0.0
+      "score_pct": 83.0,
+      "uplift_pct": 43.0
     },
     {
       "catalog_dir": "tao-train-action-recognition",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31110,7 +30767,7 @@
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31119,79 +30776,79 @@
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-train-bevfusion",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-bevfusion",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
       "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
+      "score_pct": 81.0,
+      "uplift_pct": 81.0
     },
     {
       "catalog_dir": "tao-train-bevfusion",
       "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
+      "dimension": "Effectiveness",
+      "num": null,
       "agent": "claude-code",
+      "score_pct": 95.0,
+      "uplift_pct": 78.0
+    },
+    {
+      "catalog_dir": "tao-train-bevfusion",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 8.0
+    },
+    {
+      "catalog_dir": "tao-train-bevfusion",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 52.0
+    },
+    {
+      "catalog_dir": "tao-train-bevfusion",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 100.0
     },
     {
-      "catalog_dir": "tao-train-bevfusion",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-bevfusion",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": -10.0
-    },
-    {
-      "catalog_dir": "tao-train-bevfusion",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 48.0,
-      "uplift_pct": 16.0
-    },
-    {
-      "catalog_dir": "tao-train-bevfusion",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-bevfusion",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31200,7 +30857,7 @@
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31209,79 +30866,79 @@
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 50.0
-    },
-    {
-      "catalog_dir": "tao-train-centerpose",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 50.0,
-      "uplift_pct": 50.0
-    },
-    {
-      "catalog_dir": "tao-train-centerpose",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-train-centerpose",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-centerpose",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 22.0
-    },
-    {
-      "catalog_dir": "tao-train-centerpose",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 88.0,
       "uplift_pct": 60.0
     },
     {
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-centerpose",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 41.0
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-centerpose",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-train-centerpose",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 68.0
+    },
+    {
+      "catalog_dir": "tao-train-centerpose",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 13.0
     },
     {
       "catalog_dir": "tao-train-centerpose",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 44.0
+    },
+    {
+      "catalog_dir": "tao-train-centerpose",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
       "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
     },
     {
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31290,7 +30947,7 @@
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31299,7 +30956,25 @@
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-train-deformable-detr",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-deformable-detr",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 50.0
@@ -31307,26 +30982,8 @@
     {
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-deformable-detr",
-      "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-train-deformable-detr",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
@@ -31335,37 +30992,37 @@
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 12.0
+      "score_pct": 95.0,
+      "uplift_pct": 78.0
     },
     {
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 48.0,
-      "uplift_pct": 4.0
+      "score_pct": 58.0,
+      "uplift_pct": -17.0
     },
     {
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 41.0
+      "score_pct": 83.0,
+      "uplift_pct": 54.0
     },
     {
       "catalog_dir": "tao-train-deformable-detr",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-depth-anything-v2",
@@ -31461,7 +31118,7 @@
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31470,7 +31127,7 @@
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31479,73 +31136,73 @@
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 60.0
+      "uplift_pct": 80.0
     },
     {
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 30.0
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
     },
     {
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 58.0
-    },
-    {
-      "catalog_dir": "tao-train-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 72.0,
-      "uplift_pct": 45.0
+      "score_pct": 95.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-train-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 25.0
     },
     {
       "catalog_dir": "tao-train-dino",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 44.0
+    },
+    {
+      "catalog_dir": "tao-train-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
     },
     {
       "catalog_dir": "tao-train-fast-foundation-stereo",
@@ -31731,7 +31388,7 @@
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31740,7 +31397,7 @@
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -31749,1744 +31406,1744 @@
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 60.0
     },
     {
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 50.0,
-      "uplift_pct": 30.0
-    },
-    {
-      "catalog_dir": "tao-train-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 80.0
-    },
-    {
-      "catalog_dir": "tao-train-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 76.0,
-      "uplift_pct": 44.0
-    },
-    {
-      "catalog_dir": "tao-train-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 71.0,
-      "uplift_pct": 44.0
-    },
-    {
-      "catalog_dir": "tao-train-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 92.0,
-      "uplift_pct": 92.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 90.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 80.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 79.0,
-      "uplift_pct": 52.0
-    },
-    {
-      "catalog_dir": "tao-train-image-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 80.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 62.0,
-      "uplift_pct": 62.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 14.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-encoder",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 61.0,
-      "uplift_pct": 33.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": 40.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 66.0,
-      "uplift_pct": 28.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 72.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-auto-label",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 50.0
     },
     {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
+      "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-mask-grounding-dino",
+      "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 12.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": -4.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 71.0,
-      "uplift_pct": 45.0
-    },
-    {
-      "catalog_dir": "tao-train-mask-grounding-dino",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 90.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 77.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 72.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 46.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 70.0,
-      "uplift_pct": 43.0
-    },
-    {
-      "catalog_dir": "tao-train-mask2former",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 50.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 34.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 4.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 41.0
-    },
-    {
-      "catalog_dir": "tao-train-metric-learning-recognition",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 90.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 85.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 62.0,
-      "uplift_pct": 62.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 58.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 41.0
-    },
-    {
-      "catalog_dir": "tao-train-nvdinov2",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 61.0,
-      "uplift_pct": 33.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 10.0,
-      "uplift_pct": 10.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 42.0,
-      "uplift_pct": 28.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 76.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-nvpanoptix3d",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 84.0,
-      "uplift_pct": 84.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 77.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 34.0,
-      "uplift_pct": 34.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 90.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 46.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 24.0,
-      "uplift_pct": -3.0
-    },
-    {
-      "catalog_dir": "tao-train-ocdnet",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": 50.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 78.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-ocrnet",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 83.0,
       "uplift_pct": 83.0
     },
     {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
+      "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 86.0
-    },
-    {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 72.0
+      "score_pct": 92.0,
+      "uplift_pct": 18.0
     },
     {
-      "catalog_dir": "tao-train-oneformer",
+      "catalog_dir": "tao-train-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 67.0,
+      "score_pct": 75.0,
+      "uplift_pct": 38.0
+    },
+    {
+      "catalog_dir": "tao-train-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-image-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-image-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-image-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
       "uplift_pct": 40.0
     },
     {
-      "catalog_dir": "tao-train-oneformer",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-optical-inspection",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-optical-inspection",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 80.0,
-      "uplift_pct": 30.0
-    },
-    {
-      "catalog_dir": "tao-train-optical-inspection",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
+      "score_pct": 40.0,
+      "uplift_pct": -60.0
     },
     {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 100.0
+      "uplift_pct": 50.0
     },
     {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 44.0,
-      "uplift_pct": -34.0
+      "score_pct": 78.0,
+      "uplift_pct": 47.0
     },
     {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 12.0
+      "score_pct": 53.0,
+      "uplift_pct": -17.0
     },
     {
-      "catalog_dir": "tao-train-optical-inspection",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-optical-inspection",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 6.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pointpillars",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 88.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 80.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-pose-classification",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 75.0,
+      "score_pct": 83.0,
       "uplift_pct": 48.0
     },
     {
-      "catalog_dir": "tao-train-pose-classification",
+      "catalog_dir": "tao-train-image-classification",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 84.0,
-      "uplift_pct": 84.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 34.0,
-      "uplift_pct": 34.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 90.0,
-      "uplift_pct": 80.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 44.0,
-      "uplift_pct": 16.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 24.0,
-      "uplift_pct": -3.0
-    },
-    {
-      "catalog_dir": "tao-train-reid",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-rtdetr",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-rtdetr",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 52.0
+      "uplift_pct": 60.0
     },
     {
-      "catalog_dir": "tao-train-rtdetr",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-rtdetr",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 40.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 82.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 72.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 71.0,
-      "uplift_pct": 42.0
-    },
-    {
-      "catalog_dir": "tao-train-rtdetr",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 52.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 20.0,
-      "uplift_pct": 20.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 35.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 0.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 82.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 32.0,
-      "uplift_pct": 4.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 68.0,
-      "uplift_pct": 35.0
-    },
-    {
-      "catalog_dir": "tao-train-segformer",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 84.0,
-      "uplift_pct": 84.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Correctness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 50.0,
       "uplift_pct": 50.0
     },
     {
-      "catalog_dir": "tao-train-single-step",
+      "catalog_dir": "tao-train-mask-auto-encoder",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 34.0,
-      "uplift_pct": 34.0
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
     },
     {
-      "catalog_dir": "tao-train-single-step",
+      "catalog_dir": "tao-train-mask-auto-encoder",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 78.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-encoder",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 78.0,
+      "uplift_pct": -12.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-encoder",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-encoder",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
     },
     {
-      "catalog_dir": "tao-train-single-step",
+      "catalog_dir": "tao-train-mask-auto-label",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 90.0,
+      "score_pct": 100.0,
+      "uplift_pct": 47.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 92.0,
+      "uplift_pct": 5.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 55.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-auto-label",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
       "uplift_pct": 80.0
     },
     {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 84.0,
-      "uplift_pct": 70.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 24.0,
-      "uplift_pct": -3.0
-    },
-    {
-      "catalog_dir": "tao-train-single-step",
-      "component": "TAO Toolkit",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
-    },
-    {
-      "catalog_dir": "tao-train-sparse4d",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-sparse4d",
-      "component": "TAO Toolkit",
-      "dimension": "Security",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "tao-train-sparse4d",
+      "catalog_dir": "tao-train-mask-grounding-dino",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 92.0,
+      "uplift_pct": 23.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 75.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-mask-grounding-dino",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 68.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 58.0,
+      "uplift_pct": -17.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 75.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-mask2former",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 92.0,
+      "uplift_pct": 61.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 90.0,
+      "uplift_pct": 5.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 46.0
+    },
+    {
+      "catalog_dir": "tao-train-metric-learning-recognition",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 100.0
     },
     {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 78.0,
+      "uplift_pct": 62.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 95.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 67.0
+    },
+    {
+      "catalog_dir": "tao-train-nvdinov2",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 95.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 75.0,
+      "uplift_pct": 22.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 48.0
+    },
+    {
+      "catalog_dir": "tao-train-nvpanoptix3d",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 98.0,
+      "uplift_pct": 66.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": -17.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 58.0
+    },
+    {
+      "catalog_dir": "tao-train-ocdnet",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 67.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 8.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 38.0
+    },
+    {
+      "catalog_dir": "tao-train-ocrnet",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 78.0,
+      "uplift_pct": 37.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 58.0,
+      "uplift_pct": -17.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 46.0
+    },
+    {
+      "catalog_dir": "tao-train-oneformer",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": 3.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 75.0,
+      "uplift_pct": 42.0
+    },
+    {
+      "catalog_dir": "tao-train-optical-inspection",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 52.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 75.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-pointpillars",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 95.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 92.0,
+      "uplift_pct": 3.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 46.0
+    },
+    {
+      "catalog_dir": "tao-train-pose-classification",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 95.0,
+      "uplift_pct": 58.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 90.0,
+      "uplift_pct": 15.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 53.0
+    },
+    {
+      "catalog_dir": "tao-train-reid",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 40.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 60.0,
+      "uplift_pct": -40.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 95.0,
+      "uplift_pct": 63.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 53.0,
+      "uplift_pct": -22.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 44.0
+    },
+    {
+      "catalog_dir": "tao-train-rtdetr",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 78.0,
+      "uplift_pct": 47.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 83.0,
+      "uplift_pct": -2.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 52.0
+    },
+    {
+      "catalog_dir": "tao-train-segformer",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 45.0,
+      "uplift_pct": 13.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 85.0,
+      "uplift_pct": -5.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 83.0,
+      "uplift_pct": 48.0
+    },
+    {
+      "catalog_dir": "tao-train-single-step",
+      "component": "TAO Toolkit",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-sparse4d",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
+      "catalog_dir": "tao-train-sparse4d",
+      "component": "TAO Toolkit",
+      "dimension": "Security",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 100.0,
+      "uplift_pct": 0.0
+    },
+    {
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 80.0
+    },
+    {
+      "catalog_dir": "tao-train-sparse4d",
+      "component": "TAO Toolkit",
+      "dimension": "Correctness",
+      "num": null,
       "agent": "codex",
-      "score_pct": 50.0,
+      "score_pct": 80.0,
+      "uplift_pct": -20.0
+    },
+    {
+      "catalog_dir": "tao-train-sparse4d",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
       "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 92.0,
-      "uplift_pct": 92.0
-    },
-    {
-      "catalog_dir": "tao-train-sparse4d",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 0.0,
       "uplift_pct": 0.0
@@ -33495,37 +33152,37 @@
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 90.0
+      "score_pct": 78.0,
+      "uplift_pct": 62.0
     },
     {
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 88.0,
-      "uplift_pct": 74.0
+      "score_pct": 58.0,
+      "uplift_pct": -32.0
     },
     {
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 79.0,
-      "uplift_pct": 52.0
+      "score_pct": 83.0,
+      "uplift_pct": 48.0
     },
     {
       "catalog_dir": "tao-train-sparse4d",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 28.0,
-      "uplift_pct": -0.0
+      "score_pct": 0.0,
+      "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-train-visual-changenet",
@@ -33621,7 +33278,7 @@
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -33630,7 +33287,7 @@
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -33639,73 +33296,73 @@
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 50.0,
-      "uplift_pct": 50.0
+      "score_pct": 100.0,
+      "uplift_pct": 60.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
-    },
-    {
-      "catalog_dir": "tao-validate-dataset-format",
-      "component": "TAO Toolkit",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 0.0,
+      "score_pct": 100.0,
       "uplift_pct": 0.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 100.0,
+      "uplift_pct": 50.0
+    },
+    {
+      "catalog_dir": "tao-validate-dataset-format",
+      "component": "TAO Toolkit",
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 97.0
+      "score_pct": 94.0,
+      "uplift_pct": 94.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 78.0,
-      "uplift_pct": 68.0
+      "score_pct": 100.0,
+      "uplift_pct": 63.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 90.0,
-      "uplift_pct": 80.0
+      "score_pct": 83.0,
+      "uplift_pct": 13.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 27.0,
-      "uplift_pct": -0.0
+      "score_pct": 75.0,
+      "uplift_pct": 50.0
     },
     {
       "catalog_dir": "tao-validate-dataset-format",
       "component": "TAO Toolkit",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 96.0,
-      "uplift_pct": 68.0
+      "score_pct": 100.0,
+      "uplift_pct": 100.0
     },
     {
       "catalog_dir": "tilegym-adding-cutile-kernel",

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -207,14 +207,14 @@
     },
     {
       "skill": "cuopt-install",
-      "evaluation_date": "2026-06-26",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
+      "evaluation_date": "2026-08-12",
+      "environment": "k8s-sandbox",
+      "evaluator_version": "1.2.4",
+      "dataset_digest": "sha256:69515ef8677f7773d6ae7ac097b3a02767971b308d79ba74759f647dd33794c5",
       "validation_status": null,
-      "tasks": 1,
+      "tasks": 7,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -223,7 +223,7 @@
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "has_results": true,
-      "average_uplift_pct": 48.0
+      "average_uplift_pct": 30.7
     },
     {
       "skill": "cuopt-multi-objective-exploration",
@@ -7448,16 +7448,16 @@
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 0.0
+      "score_pct": 86.0,
+      "uplift_pct": -7.0
     },
     {
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -7466,73 +7466,73 @@
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 70.0
+      "score_pct": 94.0,
+      "uplift_pct": 9.0
     },
     {
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 22.0
+      "score_pct": 100.0,
+      "uplift_pct": 11.0
     },
     {
       "catalog_dir": "cuopt-install",
       "component": "cuOpt",
       "dimension": "Discoverability",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "cuopt-install",
-      "component": "cuOpt",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 72.0
-    },
-    {
-      "catalog_dir": "cuopt-install",
-      "component": "cuOpt",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 74.0
-    },
-    {
-      "catalog_dir": "cuopt-install",
-      "component": "cuOpt",
-      "dimension": "Effectiveness",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 6.0
-    },
-    {
-      "catalog_dir": "cuopt-install",
-      "component": "cuOpt",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 95.0,
-      "uplift_pct": 67.0
-    },
-    {
-      "catalog_dir": "cuopt-install",
-      "component": "cuOpt",
-      "dimension": "Efficiency",
-      "num": 1,
-      "agent": "codex",
       "score_pct": 96.0,
       "uplift_pct": 69.0
+    },
+    {
+      "catalog_dir": "cuopt-install",
+      "component": "cuOpt",
+      "dimension": "Discoverability",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 46.0
+    },
+    {
+      "catalog_dir": "cuopt-install",
+      "component": "cuOpt",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 81.0,
+      "uplift_pct": 18.0
+    },
+    {
+      "catalog_dir": "cuopt-install",
+      "component": "cuOpt",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 93.0,
+      "uplift_pct": 17.0
+    },
+    {
+      "catalog_dir": "cuopt-install",
+      "component": "cuOpt",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 93.0,
+      "uplift_pct": 81.0
+    },
+    {
+      "catalog_dir": "cuopt-install",
+      "component": "cuOpt",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 67.0,
+      "uplift_pct": 63.0
     },
     {
       "catalog_dir": "cuopt-multi-objective-exploration",


### PR DESCRIPTION
## Why

The `Generate Skill Metadata` job has failed on every sync since #482 landed TAO's 37 re-signed skills, opening issue #483 and emailing on each run:

```
Refusing to write benchmarks.json: fields lost values.
  pass_threshold_pct:  62 -> 99 nulls
  profile:            109 -> 146 nulls
```

Both counts rose by exactly 37 — the TAO skills. This is the null-loss guard from #468 working correctly, not a break.

**Root cause, checked against the evaluator source rather than inferred.** SkillEvaluator 0.2.1 (released 2026-08-24, the same day TAO re-signed) "redesigned `BENCHMARK.md` as a decision-first publication card." `src/skillevaluator/reporting/benchmark.py` now emits only: Skill, Evaluation date, Evaluator version, Agents, Tasks, Dataset digest, Attempts per task, Environment, Tier 3 evidence, Tier 3 live evaluation, Overall verdict, Overall Tier 3 lift, Dimension bands. Neither dropped field has an emission path.

## What this changes

The two fields need different answers.

**`profile` — retired.** v1/v2 emitted `- NVSkills-Eval profile: external`. NVSkills-Eval is an internal name and does not belong in a published report, so v3 dropping it was correct. Keeping a permanently-null column named after an internal tool is worse than removing it.

**`pass_threshold_pct` — kept, null on v3.** It is a genuine provenance value that v3 turned into template prose. The same `50%` sentence appears verbatim on skills with 4, 5 and 18 tasks, so scraping it would stamp one number on every skill regardless of what it was actually evaluated against. The `NO_FABRICATION` note in the parser already made this call; this PR leaves it standing. Asking SkillEvaluator to emit it as a real field again is a separate conversation, not blocked by this.

## What's in the diff

- `aggregate_benchmarks.py` — remove the `profile` pattern, with a comment recording why it is retired rather than merely absent
- `test_aggregate_benchmarks.py` / `test_cli_guard.py` — both used `profile` as their sample droppable field; switched to live fields so the guard tests still exercise a real regression
- `benchmarks.json` — regenerated once with `--allow-null-regressions` to land both changes

## Verification

- 16/16 tests pass
- A strict `--check` passes against the regenerated file, so **the guard stays armed** for the next format change
- 343 skills, 0 carrying a `profile` key, 99 with a null `pass_threshold_pct` (the v3 cohort)
