### PR TITLE
chore: add @siqinvidia as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
 
 # Default owners for all files in the repo
-* @mosheabr @sayalinvidia @jasonnvidia
+* @mosheabr @sayalinvidia @jasonnvidia @siqinvidia


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## All PRs

- [x] All commits signed off with DCO.

## Other context

Adds `@siqinvidia` to the default owners rule in `.github/CODEOWNERS`, alongside `@mosheabr`, `@sayalinvidia`, and `@jasonnvidia`. No other files change.

**Follow-up required before this takes effect:** `siqinvidia` currently has `read` permission on this repository. GitHub ignores CODEOWNERS entries for users without write access, so this entry will parse cleanly but Siqi's reviews will not satisfy the code-owner requirement until repo permission is raised to write. That access grant is a separate repo-admin action.