### PR TITLE
fix(benchmarks): stop the null guard blocking on a retiring field

### DIFF
--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -82,6 +82,25 @@ FLOAT_FIELDS = {"pass_threshold_pct"}
 # provenance claim in the file whose purpose is recording provenance. Leave
 # pass_threshold_pct None on v3 until SkillEvaluator emits it as a real field.
 
+# Fields mid-retirement: known to be losing values as cards migrate, so a
+# rising null count is the expected transition rather than a parser break.
+#
+# pass_threshold_pct is read from the "- Pass threshold: N%" line that v1/v2
+# cards carry and v3 cards dropped (see NO_FABRICATION above). Every skill that
+# re-runs CI and lands a v3 card therefore adds exactly one null. Without this
+# exemption the guard blocks every sync that migrates any skill — it fired on
+# cuopt-server-api-python on 2026-08-28 and would fire again on each of the
+# ~100 skills still carrying a v1/v2 value.
+#
+# The drift is still reported, just not treated as blocking: the point of the
+# guard is catching a parser that broke without anyone noticing, and this is
+# the opposite — a change we understand and chose. Every other field stays
+# guarded.
+#
+# Remove this once SkillEvaluator emits the threshold as a real per-run field
+# and the parser reads it again.
+MIGRATING_FIELDS = {"pass_threshold_pct"}
+
 
 def parse_uplift(raw):
     """Convert an uplift cell capture to a float, or None when absent.
@@ -360,6 +379,17 @@ def main() -> int:
     if target.exists() and not args.allow_null_regressions:
         previous = json.loads(target.read_text(encoding="utf-8"))
         lost = null_rate_regressions(previous, json.loads(payload))
+
+        # Report every regression; block only on the ones we did not expect.
+        for field, (was, now) in sorted(lost.items()):
+            if field in MIGRATING_FIELDS:
+                print(
+                    f"note: {field} {was} -> {now} nulls — expected while cards "
+                    "migrate; see MIGRATING_FIELDS.",
+                    file=sys.stderr,
+                )
+        lost = {f: v for f, v in lost.items() if f not in MIGRATING_FIELDS}
+
         if lost:
             print(
                 "Refusing to write benchmarks.json: fields lost values.\n"

--- a/.github/scripts/tests/test_cli_guard.py
+++ b/.github/scripts/tests/test_cli_guard.py
@@ -6,6 +6,11 @@
 Builds a throwaway repo with one skill, generates benchmarks.json from it,
 then removes a field from the source report and regenerates. That second run
 is the silent-degradation scenario and must fail loudly.
+
+The probe field is `environment`. It used to be `pass_threshold_pct`, but that
+field is now in MIGRATING_FIELDS — v3 cards stopped emitting it, so it drifts
+to null by design and no longer blocks. Probing with it would have made these
+tests pass for the wrong reason.
 """
 
 import json
@@ -27,9 +32,7 @@ REPORT = """# Skill Benchmark: foo
 
 - Skill: `foo`
 - Evaluation date: 2026-06-01
-- Environment: `local`
-{threshold_line}
-- Tasks: 4 evaluation tasks
+{environment_line}{threshold_line}- Tasks: 4 evaluation tasks
 - Attempts per task: 1
 
 ## Results
@@ -39,6 +42,7 @@ REPORT = """# Skill Benchmark: foo
 | Accuracy  | 90% (+10%)  |
 """
 
+ENVIRONMENT_LINE = "- Environment: `local`\n"
 THRESHOLD_LINE = "- Pass threshold: 50%\n"
 
 
@@ -48,10 +52,18 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
         (self.root / "skills" / "foo").mkdir(parents=True)
         (self.root / "components.d").mkdir()
         self.report = self.root / "skills" / "foo" / "BENCHMARK.md"
-        # Baseline: the field is present, benchmarks.json records it.
-        self.report.write_text(REPORT.format(threshold_line=THRESHOLD_LINE))
+        # Baseline: both fields present, benchmarks.json records them.
+        self._write()
         (self.root / "benchmarks.json").write_text(agg.generate(self.root))
         self.addCleanup(shutil.rmtree, self.root)
+
+    def _write(self, *, environment=True, threshold=True):
+        self.report.write_text(
+            REPORT.format(
+                environment_line=ENVIRONMENT_LINE if environment else "",
+                threshold_line=THRESHOLD_LINE if threshold else "",
+            )
+        )
 
     def _run(self, *extra):
         argv = sys.argv
@@ -61,28 +73,89 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
         finally:
             sys.argv = argv
 
-    def _drop_the_field(self):
-        self.report.write_text(REPORT.format(threshold_line=""))
+    def _written(self):
+        return json.loads((self.root / "benchmarks.json").read_text())["skills"][0]
 
     def test_regeneration_succeeds_when_nothing_empties(self):
         self.assertEqual(self._run(), 0)
 
     def test_regeneration_fails_when_a_field_empties(self):
-        self._drop_the_field()
+        self._write(environment=False)
         self.assertEqual(self._run(), 1)
 
     def test_failed_run_leaves_benchmarks_json_untouched(self):
         before = (self.root / "benchmarks.json").read_text()
-        self._drop_the_field()
+        self._write(environment=False)
         self._run()
         self.assertEqual((self.root / "benchmarks.json").read_text(), before)
 
     def test_escape_hatch_allows_a_deliberate_format_change(self):
         """An upstream format change must be landable without editing code."""
-        self._drop_the_field()
+        self._write(environment=False)
         self.assertEqual(self._run("--allow-null-regressions"), 0)
-        written = json.loads((self.root / "benchmarks.json").read_text())
-        self.assertIsNone(written["skills"][0]["pass_threshold_pct"])
+        self.assertIsNone(self._written()["environment"])
+
+
+class TestMigratingFieldExemption(unittest.TestCase):
+    """A field mid-retirement must not block, and must not hide anything else.
+
+    v3 cards dropped the "- Pass threshold: N%" line, so every skill that
+    re-runs CI adds one null. Without the exemption the guard blocked every
+    sync that migrated any skill — it fired on cuopt-server-api-python on
+    2026-08-28 and stalled metadata regeneration for hours.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        (self.root / "skills" / "foo").mkdir(parents=True)
+        (self.root / "components.d").mkdir()
+        self.report = self.root / "skills" / "foo" / "BENCHMARK.md"
+        self.report.write_text(
+            REPORT.format(environment_line=ENVIRONMENT_LINE, threshold_line=THRESHOLD_LINE)
+        )
+        (self.root / "benchmarks.json").write_text(agg.generate(self.root))
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def _write(self, *, environment=True, threshold=True):
+        self.report.write_text(
+            REPORT.format(
+                environment_line=ENVIRONMENT_LINE if environment else "",
+                threshold_line=THRESHOLD_LINE if threshold else "",
+            )
+        )
+
+    def _run(self, *extra):
+        argv = sys.argv
+        sys.argv = ["aggregate_benchmarks.py", "--repo-root", str(self.root), *extra]
+        try:
+            return agg.main()
+        finally:
+            sys.argv = argv
+
+    def test_pass_threshold_pct_is_exempt(self):
+        self.assertIn("pass_threshold_pct", agg.MIGRATING_FIELDS)
+
+    def test_losing_only_a_migrating_field_does_not_block(self):
+        self._write(threshold=False)
+        self.assertEqual(self._run(), 0)
+        written = json.loads((self.root / "benchmarks.json").read_text())["skills"][0]
+        self.assertIsNone(written["pass_threshold_pct"])
+        # The rest of the row must survive the write.
+        self.assertEqual(written["environment"], "local")
+
+    def test_exemption_does_not_mask_a_real_regression(self):
+        """Both fields empty at once: the non-exempt one must still block."""
+        self._write(environment=False, threshold=False)
+        self.assertEqual(self._run(), 1)
+
+    def test_migrating_drift_is_still_reported(self):
+        """Exempt does not mean silent — the drift must stay visible."""
+        self._write(threshold=False)
+        regressions = agg.null_rate_regressions(
+            json.loads((self.root / "benchmarks.json").read_text()),
+            json.loads(agg.generate(self.root)),
+        )
+        self.assertIn("pass_threshold_pct", regressions)
 
 
 if __name__ == "__main__":

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "source": "skills/*/BENCHMARK.md",
   "skill_count": 343,
-  "result_row_count": 3215,
+  "result_row_count": 3210,
   "skills_without_results": [
     "deepstream-generate-pipeline",
     "digital-health-clinical-asr-setup",
@@ -307,14 +307,14 @@
     },
     {
       "skill": "cuopt-server-api-python",
-      "evaluation_date": "2026-06-29",
-      "environment": "astra-sandbox",
-      "evaluator_version": null,
-      "dataset_digest": null,
-      "validation_status": null,
-      "tasks": 1,
+      "evaluation_date": "2026-08-25",
+      "environment": "local",
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:89ad304517df359a8c33a1f67da3ad9df8aeae5ec234d2adbed1593bf49c4ebc",
+      "validation_status": "passed",
+      "tasks": 8,
       "attempts_per_task": 1,
-      "pass_threshold_pct": 50.0,
+      "pass_threshold_pct": null,
       "verdict": "PASS",
       "agents": [
         "claude-code",
@@ -323,7 +323,7 @@
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "has_results": true,
-      "average_uplift_pct": 50.5
+      "average_uplift_pct": 33.9
     },
     {
       "skill": "cupynumeric-hdf5",
@@ -4849,15 +4849,15 @@
     },
     {
       "skill": "portfolio-optimization",
-      "evaluation_date": "2026-07-30",
+      "evaluation_date": "2026-08-27",
       "environment": "k8s-sandbox",
-      "evaluator_version": "0.9.2",
-      "dataset_digest": "sha256:93d7d58ac9dd6ef70bbdea737d6c97c7ff428b7568edfff7aa9028ec3966bc78",
-      "validation_status": null,
+      "evaluator_version": "1.3.2",
+      "dataset_digest": "sha256:97b53fc5f0fc9cbbb6e594394ff89d950c9b5b713c0f4a6594c968dade42869f",
+      "validation_status": "passed",
       "tasks": 4,
       "attempts_per_task": 1,
       "pass_threshold_pct": null,
-      "verdict": "PASS",
+      "verdict": "NEUTRAL",
       "agents": [
         "claude-code",
         "codex"
@@ -4865,7 +4865,7 @@
       "catalog_dir": "portfolio-optimization",
       "component": "Portfolio Optimization",
       "has_results": true,
-      "average_uplift_pct": 17.1
+      "average_uplift_pct": 2.2
     },
     {
       "skill": "rag-blueprint",
@@ -7898,7 +7898,7 @@
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 0.0
@@ -7907,52 +7907,34 @@
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Security",
-      "num": 1,
+      "num": null,
       "agent": "codex",
       "score_pct": 100.0,
-      "uplift_pct": 0.0
+      "uplift_pct": 31.0
     },
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
-      "uplift_pct": 70.0
+      "uplift_pct": 25.0
     },
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Correctness",
-      "num": 1,
+      "num": null,
       "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 35.0
+      "score_pct": 98.0,
+      "uplift_pct": 10.0
     },
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Discoverability",
-      "num": 1,
-      "agent": "claude-code",
-      "score_pct": 100.0,
-      "uplift_pct": 100.0
-    },
-    {
-      "catalog_dir": "cuopt-server-api-python",
-      "component": "cuOpt",
-      "dimension": "Discoverability",
-      "num": 1,
-      "agent": "codex",
-      "score_pct": 97.0,
-      "uplift_pct": 69.0
-    },
-    {
-      "catalog_dir": "cuopt-server-api-python",
-      "component": "cuOpt",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "num": null,
       "agent": "claude-code",
       "score_pct": 100.0,
       "uplift_pct": 56.0
@@ -7960,29 +7942,47 @@
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
-      "dimension": "Effectiveness",
-      "num": 1,
+      "dimension": "Discoverability",
+      "num": null,
       "agent": "codex",
-      "score_pct": 100.0,
-      "uplift_pct": 40.0
+      "score_pct": 93.0,
+      "uplift_pct": 48.0
     },
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
-      "dimension": "Efficiency",
-      "num": 1,
+      "dimension": "Effectiveness",
+      "num": null,
       "agent": "claude-code",
       "score_pct": 95.0,
-      "uplift_pct": 68.0
+      "uplift_pct": 38.0
+    },
+    {
+      "catalog_dir": "cuopt-server-api-python",
+      "component": "cuOpt",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 88.0,
+      "uplift_pct": 15.0
     },
     {
       "catalog_dir": "cuopt-server-api-python",
       "component": "cuOpt",
       "dimension": "Efficiency",
-      "num": 1,
+      "num": null,
+      "agent": "claude-code",
+      "score_pct": 97.0,
+      "uplift_pct": 53.0
+    },
+    {
+      "catalog_dir": "cuopt-server-api-python",
+      "component": "cuOpt",
+      "dimension": "Efficiency",
+      "num": null,
       "agent": "codex",
-      "score_pct": 95.0,
-      "uplift_pct": 67.0
+      "score_pct": 100.0,
+      "uplift_pct": 63.0
     },
     {
       "catalog_dir": "cupynumeric-hdf5",
@@ -27834,27 +27834,9 @@
       "component": "Portfolio Optimization",
       "dimension": "Security",
       "num": null,
-      "agent": "claude-code",
+      "agent": "codex",
       "score_pct": 100.0,
-      "uplift_pct": 25.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Security",
-      "num": null,
-      "agent": "codex",
-      "score_pct": 75.0,
-      "uplift_pct": 0.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Correctness",
-      "num": null,
-      "agent": "claude-code",
-      "score_pct": 85.0,
-      "uplift_pct": 25.0
+      "uplift_pct": 12.0
     },
     {
       "catalog_dir": "portfolio-optimization",
@@ -27862,62 +27844,35 @@
       "dimension": "Correctness",
       "num": null,
       "agent": "codex",
-      "score_pct": 70.0,
-      "uplift_pct": 10.0
+      "score_pct": 50.0,
+      "uplift_pct": -30.0
     },
     {
       "catalog_dir": "portfolio-optimization",
       "component": "Portfolio Optimization",
       "dimension": "Discoverability",
-      "num": null,
-      "agent": "claude-code",
-      "score_pct": 88.0,
-      "uplift_pct": 19.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Discoverability",
-      "num": null,
-      "agent": "codex",
-      "score_pct": 88.0,
-      "uplift_pct": 23.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Effectiveness",
-      "num": null,
-      "agent": "claude-code",
-      "score_pct": 52.0,
-      "uplift_pct": 2.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Effectiveness",
-      "num": null,
-      "agent": "codex",
-      "score_pct": 41.0,
-      "uplift_pct": 8.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Efficiency",
-      "num": null,
-      "agent": "claude-code",
-      "score_pct": 96.0,
-      "uplift_pct": 30.0
-    },
-    {
-      "catalog_dir": "portfolio-optimization",
-      "component": "Portfolio Optimization",
-      "dimension": "Efficiency",
       "num": null,
       "agent": "codex",
       "score_pct": 89.0,
-      "uplift_pct": 29.0
+      "uplift_pct": 16.0
+    },
+    {
+      "catalog_dir": "portfolio-optimization",
+      "component": "Portfolio Optimization",
+      "dimension": "Effectiveness",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 37.0,
+      "uplift_pct": -5.0
+    },
+    {
+      "catalog_dir": "portfolio-optimization",
+      "component": "Portfolio Optimization",
+      "dimension": "Efficiency",
+      "num": null,
+      "agent": "codex",
+      "score_pct": 94.0,
+      "uplift_pct": 18.0
     },
     {
       "catalog_dir": "rtvi-cv-customize-model",


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## What this fixes

`Generate Skill Metadata` has been failing since 2026-08-28, filing into #489 every few hours and leaving `benchmarks.json` stale.

```
Refusing to write benchmarks.json: fields lost values.
  pass_threshold_pct: 100 -> 101 nulls
```

`pass_threshold_pct` is parsed from the `- Pass threshold: N%` line that v1/v2 cards carry and v3 cards dropped. Scraping the v3 glossary sentence instead is not an option — it is byte-identical across skills with 4, 5 and 18 tasks, so it would stamp a fabricated value on every v3 skill. The existing `NO_FABRICATION` comment covers this.

So the field is knowingly drifting to null, one skill at a time, as teams re-run CI. That makes the guard fire on an expected transition rather than a parser break. It tripped on `cuopt-server-api-python` (synced in #488, now on evaluator 1.3.2) and would trip again on each of the ~100 skills still carrying a v1/v2 value.

## Approach

Add `MIGRATING_FIELDS` and filter at the call site, so `null_rate_regressions` stays a faithful reporter and the drift is still printed — just not treated as blocking.

Deliberately **not** `--allow-null-regressions`: that switches the guard off entirely, and the guard is what caught the `profile` regression in #485. Deliberately **not** retiring the field: ~100 skills still carry a real v1/v2 value and those keep being read. Only the increase in nulls stops blocking.

Remove the exemption once SkillEvaluator emits the threshold as a real per-run field.

## Verification

Run locally against a clean checkout of `main`:

| Check | Result |
| --- | --- |
| Reproduces the CI failure before the change | yes, identical message |
| Writes after the change | 343 skills |
| Guard still blocks a real regression (`environment`) | exit 1 |
| Exemption does not mask a co-occurring regression | `environment` still blocks while the threshold drifts in the same run |
| Drift stays visible | `note:` prints on both the success and the blocking path |
| `--check` before / after regeneration | fails stale, passes fresh |
| Test suite | 20 pass, was 16 |

The CLI guard tests probed with `pass_threshold_pct`, which would have made them pass for the wrong reason after this change. Repointed to `environment` and added four tests: that the exemption does not block, does not mask a co-occurring regression, that the drift is still reported, and that the field is listed.

No `benchmarks.json` in this PR — generated files come from the bot. The next successful run will regenerate it and auto-close #489.

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).