### PR TITLE
feat(medical-ai): register evidence export skill

### DIFF
--- a/components.d/medical-ai-skills.yml
+++ b/components.d/medical-ai-skills.yml
@@ -14,6 +14,8 @@ skills:
     catalog_dir: dicom-series-preflight
   - path: skills/dicom-series-to-volume/
     catalog_dir: dicom-series-to-volume
+  - path: skills/medtech-model-evidence-export/
+    catalog_dir: medtech-model-evidence-export
   - path: skills/nv-generate-ct-rflow/
     catalog_dir: nv-generate-ct-rflow
   - path: skills/nv-generate-mr/


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** by the owning team, with all required approvals in place
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0 
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency introduced

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

Registers the signed `medtech-model-evidence-export` skill from
`NVIDIA-Medtech/medical-AI-skills:dev` in the existing Medical AI component.
This was the only source skill missing from the catalog configuration; the
updated component now maps all 13 source skills to 13 unique flat catalog
directories.

Validation:

- focused source tests: 8 passed
- source completeness and reproducibility audits: 22/22 passed
- component inventory comparison: 13/13, with no missing paths
- global catalog validation: 337 unique `catalog_dir` values
- managed benchmark: PASS and recommended for publication, with no negative dimension change
- signature bundle structure and signed resource digests match the selected source revision
- all NVIDIA/skills pull-request checks pass

Mirrored skill content and generated catalog indexes remain owned by the
repository sync workflow. Strict certificate verification was unavailable
locally; the catalog trust workflow remains authoritative.

AI-assisted: Created with Codex/GPT at the user's request.
