### PR TITLE
ci: verify source-repo skills on onboarding PRs

### DIFF
--- a/.github/scripts/tests/test_verify_source_onboarding.py
+++ b/.github/scripts/tests/test_verify_source_onboarding.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for verify_source_onboarding.py.
+
+The properties that matter, and what breaks if they fail:
+
+  drift detection     A skill whose content moved after signing is dropped by
+                      the sync with no notification. This is the whole point
+                      of the check; if it stops catching a stale BENCHMARK.md
+                      the gate is decorative. Modelled on the real 2026-08-31
+                      paidf-orchestration failure, where all four skills
+                      carried a signature covering an earlier BENCHMARK.md.
+
+  card name variants  Three spellings are in use across the catalog today
+                      (skill-card.md 343, SKILLCARD.yaml 47, card.yaml 18).
+                      Recognising only one would fail most valid onboardings.
+
+  new vs pre-existing Roughly 30 catalog skills already carry signature drift
+                      (tracked in #216/#357). Blocking on paths a PR did not
+                      add would hold authors hostage to drift they cannot fix,
+                      so only added paths are allowed to fail the build.
+
+  empty benchmarks    A report can say PASS while carrying no measurements at
+                      all. Accepting the verdict alone would wave through a
+                      skill with a template report and no evidence behind it.
+"""
+
+import base64
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import verify_source_onboarding as vso  # noqa: E402
+
+
+BENCHMARK_PASS = """# Evaluation Report
+
+## Evaluation Summary
+
+- Skill: `demo-skill`
+- Evaluation date: 2026-08-31
+- Dataset: 6 evaluation tasks
+- Attempts per task: 1
+- Pass threshold: 50%
+- Overall verdict: PASS
+
+## Results
+
+| Dimension | Claude Code | Codex |
+|---|---|---|
+| 1. Security | 100% (+10%) | 100% (+10%) |
+| 2. Correctness | 90% (+40%) | 95% (+45%) |
+"""
+
+# Same header, but the Results section carries no measurement rows.
+BENCHMARK_PASS_NO_RESULTS = BENCHMARK_PASS.split("## Results")[0] + "## Results\n\nNot yet run.\n"
+
+BENCHMARK_FAIL = BENCHMARK_PASS.replace("Overall verdict: PASS", "Overall verdict: FAIL")
+
+
+def sign(skill_dir: Path) -> None:
+    """Write a skill.oms.sig covering every file currently in skill_dir.
+
+    Mirrors the real bundle shape: a Sigstore envelope wrapping a DSSE
+    payload whose predicate.resources lists name + sha256 per file.
+    """
+    resources = []
+    for f in sorted(skill_dir.rglob("*")):
+        if not f.is_file() or f.name == vso.SIG_NAME:
+            continue
+        resources.append({
+            "name": str(f.relative_to(skill_dir)),
+            "digest": hashlib.sha256(f.read_bytes()).hexdigest(),
+        })
+    statement = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [{"name": skill_dir.name, "digest": {"sha256": "0" * 64}}],
+        "predicateType": "https://model_signing/signature/v1.0",
+        "predicate": {"resources": resources},
+    }
+    payload = base64.b64encode(json.dumps(statement).encode()).decode()
+    (skill_dir / vso.SIG_NAME).write_text(
+        json.dumps({"dsseEnvelope": {"payload": payload, "payloadType": "x"}})
+    )
+
+
+def make_skill(root: Path, name: str = "demo-skill", *, card: str = "skill-card.md",
+               benchmark: str = BENCHMARK_PASS, omit: tuple = ()) -> Path:
+    """A complete, correctly-signed skill directory."""
+    d = root / name
+    (d / "evals").mkdir(parents=True)
+    files = {
+        "SKILL.md": "---\nname: demo-skill\n---\n\nDo the thing.\n",
+        card: "# Skill Card\n",
+        "BENCHMARK.md": benchmark,
+        "evals/evals.json": '{"tasks": []}\n',
+    }
+    for rel, body in files.items():
+        if rel in omit:
+            continue
+        (d / rel).write_text(body)
+    sign(d)
+    return d
+
+
+class CheckSkillTests(unittest.TestCase):
+    """The per-skill verification, run against a directory on disk."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_correctly_signed_skill_passes(self):
+        self.assertEqual(vso.check_skill(make_skill(self.root)), [])
+
+    def test_file_modified_after_signing_is_reported_by_name(self):
+        """The 2026-08-31 defect: BENCHMARK.md regenerated after the signing run."""
+        d = make_skill(self.root)
+        with (d / "BENCHMARK.md").open("a") as fh:
+            fh.write("\n<!-- regenerated after signing -->\n")
+
+        problems = vso.check_skill(d)
+
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("BENCHMARK.md", problems[0])
+        self.assertIn("MISMATCH", problems[0])
+        # Nothing else drifted; a report naming extra files would send the
+        # author re-signing things that were never wrong.
+        self.assertNotIn("SKILL.md", problems[0])
+
+    def test_signed_file_deleted_after_signing_is_reported(self):
+        d = make_skill(self.root)
+        (d / "evals" / "evals.json").unlink()
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("evals/evals.json", problems)
+
+    def test_unparseable_signature_is_a_failure_not_a_pass(self):
+        """A corrupt bundle must not read as 'no problems found'."""
+        d = make_skill(self.root)
+        (d / vso.SIG_NAME).write_text("not json")
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn(vso.SIG_NAME, problems)
+
+    def test_missing_signature_is_reported(self):
+        d = make_skill(self.root)
+        (d / vso.SIG_NAME).unlink()
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn(vso.SIG_NAME, problems)
+
+
+class RequiredFileTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_each_skill_card_spelling_is_accepted(self):
+        for card in ("skill-card.md", "SKILLCARD.yaml", "card.yaml"):
+            with self.subTest(card=card):
+                d = make_skill(self.root, name=f"skill-{card}", card=card)
+                self.assertEqual(vso.check_skill(d), [])
+
+    def test_missing_skill_card_is_reported(self):
+        d = make_skill(self.root, omit=("skill-card.md",))
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("skill card", problems)
+
+    def test_missing_evals_is_reported(self):
+        d = make_skill(self.root, omit=("evals/evals.json",))
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("evals/evals.json", problems)
+
+    def test_missing_skill_md_is_reported(self):
+        d = make_skill(self.root, omit=("SKILL.md",))
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("SKILL.md", problems)
+
+
+class BenchmarkTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_failing_verdict_is_reported(self):
+        d = make_skill(self.root, benchmark=BENCHMARK_FAIL)
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("FAIL", problems)
+
+    def test_pass_verdict_without_measurements_is_reported(self):
+        """PASS on a report carrying no result rows is not evidence."""
+        d = make_skill(self.root, benchmark=BENCHMARK_PASS_NO_RESULTS)
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("no results", problems.lower())
+
+    def test_missing_benchmark_is_reported(self):
+        d = make_skill(self.root, omit=("BENCHMARK.md",))
+
+        problems = "\n".join(vso.check_skill(d))
+
+        self.assertIn("BENCHMARK.md", problems)
+
+
+class DeclaredPathTests(unittest.TestCase):
+    """Parsing components.d/<slug>.yml without a YAML dependency."""
+
+    COMPONENT = """name: Physical AI Orchestration
+repo: NVIDIA/paidf-orchestration
+description: Build, run and monitor pipelines.
+skills:
+  - path: skills/write-dag/
+    catalog_dir: paidf-orchestration-write-dag
+  - path: skills/orchestration-setup/
+    catalog_dir: paidf-orchestration-setup
+links:
+  discussions: false
+"""
+
+    def test_reads_repo_and_paths(self):
+        c = vso.parse_component(self.COMPONENT)
+
+        self.assertEqual(c["repo"], "NVIDIA/paidf-orchestration")
+        self.assertEqual(c["paths"], ["skills/write-dag", "skills/orchestration-setup"])
+
+    def test_ref_defaults_to_main(self):
+        self.assertEqual(vso.parse_component(self.COMPONENT)["ref"], "main")
+
+    def test_explicit_ref_is_honoured(self):
+        """AIQ tracks develop; defaulting to main would verify the wrong tree."""
+        c = vso.parse_component("repo: NVIDIA-AI-Blueprints/aiq\nref: develop\n"
+                                "skills:\n  - path: skills/aiq-research/\n")
+
+        self.assertEqual(c["ref"], "develop")
+
+
+class BlockingScopeTests(unittest.TestCase):
+    """Only paths the PR adds may fail the build."""
+
+    BASE = ("repo: NVIDIA/demo\nskills:\n"
+            "  - path: skills/existing/\n")
+    HEAD = ("repo: NVIDIA/demo\nskills:\n"
+            "  - path: skills/existing/\n"
+            "  - path: skills/added/\n")
+
+    def test_added_path_is_blocking(self):
+        self.assertEqual(vso.added_paths(self.BASE, self.HEAD), {"skills/added"})
+
+    def test_unchanged_path_is_not_blocking(self):
+        self.assertNotIn("skills/existing", vso.added_paths(self.BASE, self.HEAD))
+
+    def test_brand_new_component_blocks_on_every_path(self):
+        """A new file has no base version, so all of its skills are new."""
+        self.assertEqual(
+            vso.added_paths(None, self.HEAD),
+            {"skills/existing", "skills/added"},
+        )
+
+    def test_removing_a_path_adds_nothing(self):
+        self.assertEqual(vso.added_paths(self.HEAD, self.BASE), set())
+
+    def test_pre_existing_drift_does_not_fail_the_run(self):
+        """Drift on a path the PR did not touch is reported, never blocking."""
+        findings = [
+            vso.Finding("skills/existing", "BENCHMARK.md: MISMATCH", blocking=False),
+        ]
+        self.assertEqual(vso.exit_code(findings), 0)
+
+    def test_drift_on_an_added_path_fails_the_run(self):
+        findings = [
+            vso.Finding("skills/added", "BENCHMARK.md: MISMATCH", blocking=True),
+        ]
+        self.assertEqual(vso.exit_code(findings), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_verify_source_onboarding.py
+++ b/.github/scripts/tests/test_verify_source_onboarding.py
@@ -167,25 +167,46 @@ class RequiredFileTests(unittest.TestCase):
         self.root = Path(self._tmp.name)
         self.addCleanup(self._tmp.cleanup)
 
-    def test_each_skill_card_spelling_is_accepted(self):
-        for card in ("skill-card.md", "SKILLCARD.yaml", "card.yaml"):
+    def test_skill_card_md_is_accepted(self):
+        self.assertEqual(vso.check_skill(make_skill(self.root)), [])
+
+    def test_alternate_card_spelling_alone_is_rejected(self):
+        """The sync requires skill-card.md by name and drops anything else.
+
+        Accepting SKILLCARD.yaml or card.yaml here would pass a skill at
+        onboarding that the next hourly sync silently removes.
+        """
+        for card in ("SKILLCARD.yaml", "card.yaml"):
             with self.subTest(card=card):
                 d = make_skill(self.root, name=f"skill-{card}", card=card)
-                self.assertEqual(vso.check_skill(d), [])
+
+                problems = "\n".join(vso.check_skill(d))
+
+                self.assertIn("skill-card.md", problems)
 
     def test_missing_skill_card_is_reported(self):
         d = make_skill(self.root, omit=("skill-card.md",))
 
         problems = "\n".join(vso.check_skill(d))
 
-        self.assertIn("skill card", problems)
+        self.assertIn("skill-card.md", problems)
 
     def test_missing_evals_is_reported(self):
         d = make_skill(self.root, omit=("evals/evals.json",))
 
         problems = "\n".join(vso.check_skill(d))
 
-        self.assertIn("evals/evals.json", problems)
+        self.assertIn("eval dataset", problems)
+
+    def test_multi_profile_eval_dataset_is_accepted(self):
+        """rag-blueprint, rag-eval and rag-perf ship eval/*.json, not
+        evals/evals.json, and the sync carries them. The gate must too."""
+        d = make_skill(self.root, omit=("evals/evals.json",))
+        (d / "eval").mkdir()
+        (d / "eval" / "h100.json").write_text('{"tasks": []}\n')
+        sign(d)
+
+        self.assertEqual(vso.check_skill(d), [])
 
     def test_missing_skill_md_is_reported(self):
         d = make_skill(self.root, omit=("SKILL.md",))

--- a/.github/scripts/verify_source_onboarding.py
+++ b/.github/scripts/verify_source_onboarding.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+"""Verify source-repo skills before an onboarding PR is merged.
+
+An onboarding PR adds ``components.d/<slug>.yml`` pointing at skill
+directories in a product repo. Nothing on the PR looks at those directories:
+``verify_content_integrity.py`` checks *this* repository's tree, which is
+sound, while the content being onboarded lives somewhere else entirely. The
+PR therefore goes green on evidence that has nothing to do with what is
+being merged.
+
+The cost lands after the merge. The sync fetches the source directory,
+recomputes each signed file's digest, and refuses the skill on any mismatch:
+an existing skill reverts to its last good version, and a *new* skill is
+dropped outright, because there is no earlier version to fall back to. The PR
+is closed by then, so the failure has nowhere to surface. The catalog looks
+correct and the skill is simply absent.
+
+That happened twice on 2026-08-31. ``paidf-augmentation`` (#501) merged green
+and was dropped by the next sync; ``paidf-orchestration`` (#507) carried the
+same defect in all four declared skills and was caught only because someone
+verified the signatures by hand during review. In every case the offending
+file was ``BENCHMARK.md``, regenerated after the signing run so the signature
+covered an earlier copy — an easy sequencing mistake that is invisible until
+it is expensive.
+
+This script follows the pointer. For each skill directory a PR declares it
+fetches the source at the component's ``ref`` and checks that:
+
+  * every file listed in ``skill.oms.sig`` is present and still hashes to its
+    signed digest;
+  * ``SKILL.md``, ``skill.oms.sig``, a skill card and ``evals/evals.json``
+    exist;
+  * ``BENCHMARK.md`` reports an overall verdict of PASS backed by real
+    measurements.
+
+Blocking scope: only paths the PR *adds*. Around 30 catalog skills already
+carry signature drift (tracked in #216 / #357); failing a PR for drift its
+author neither caused nor can fix would make the gate an obstacle rather than
+a signal. Pre-existing paths are still checked, and reported, but never fail
+the build.
+
+Reads the source repository read-only over an anonymous clone. No signing
+credentials, and nothing here writes to the source repo.
+
+Exit code 0 = no blocking problems; 1 = a newly-added skill is not fit to
+merge.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import aggregate_benchmarks as ab  # noqa: E402
+import verify_content_integrity as vci  # noqa: E402
+
+COMPONENTS_DIR = Path("components.d")
+SIG_NAME = vci.SIG_NAME
+
+# Required alongside the signature. A skill card is required too, but its
+# filename is not settled: all three spellings below are in active use in the
+# catalog today (skill-card.md 343, SKILLCARD.yaml 47, card.yaml 18), so any
+# one of them satisfies the requirement.
+REQUIRED_FILES = ("SKILL.md", SIG_NAME, "BENCHMARK.md", "evals/evals.json")
+CARD_NAMES = ("skill-card.md", "SKILLCARD.yaml", "card.yaml")
+
+RE_REPO = re.compile(r"^repo:\s*(\S+)\s*$")
+RE_REF = re.compile(r"^ref:\s*(\S+)\s*$")
+RE_PATH = re.compile(r"^-?\s*path:\s*(\S+)\s*$")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One problem with one skill directory.
+
+    ``blocking`` records whether this path was added by the PR under review.
+    Only blocking findings affect the exit code; the rest are reported so a
+    reviewer can see them without the author being held responsible.
+    """
+
+    path: str
+    problem: str
+    blocking: bool
+
+
+# --------------------------------------------------------------------------
+# Component files
+# --------------------------------------------------------------------------
+
+def parse_component(text: str) -> dict:
+    """Read repo, ref and declared skill paths from a component file.
+
+    Deliberately line-based rather than PyYAML: every other script in this
+    directory parses these files the same way, and CI carries no third-party
+    Python dependencies. The schema is flat and fixed (components.d/README.md),
+    so a real parser buys nothing here.
+
+    Trailing slashes are stripped so a path compares equal however it was
+    written — ``skills/write-dag/`` and ``skills/write-dag`` are the same
+    directory, and treating them as different would report a path as newly
+    added when a PR only reformatted it.
+    """
+    repo = None
+    ref = None
+    paths: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if repo is None:
+            m = RE_REPO.match(stripped)
+            if m:
+                repo = m.group(1)
+                continue
+        if ref is None:
+            m = RE_REF.match(stripped)
+            if m:
+                ref = m.group(1)
+                continue
+        m = RE_PATH.match(stripped)
+        if m:
+            paths.append(m.group(1).rstrip("/"))
+    # An absent ref means the component tracks the default branch. Several
+    # components (AIQ, VSS) track develop instead; verifying those against
+    # main compares a tree the sync will never fetch.
+    return {"repo": repo, "ref": ref or "main", "paths": paths}
+
+
+def added_paths(base_text: str | None, head_text: str) -> set[str]:
+    """Skill paths this PR introduces.
+
+    ``base_text`` is None when the component file itself is new, in which case
+    every path in it is new — the common onboarding case, and the one where a
+    bad signature causes the skill to be dropped rather than reverted.
+    """
+    head = set(parse_component(head_text)["paths"])
+    if base_text is None:
+        return head
+    return head - set(parse_component(base_text)["paths"])
+
+
+# --------------------------------------------------------------------------
+# Per-skill verification (pure — operates on a directory on disk)
+# --------------------------------------------------------------------------
+
+def check_signature(skill_dir: Path) -> list[str]:
+    """Content-vs-signature check, reusing the catalog's integrity logic.
+
+    ``vci.verify_skill`` recomputes each signed file's sha256 and compares it
+    to the digest in the DSSE payload. It takes a directory and does not care
+    whose repository that directory came from, so pointing it at a clone of
+    the source is the entire check — a second implementation here would be a
+    copy that could drift from the one the sync effectively enforces.
+
+    One behaviour is deliberately overridden: verify_skill treats a missing
+    signature as out of scope and returns no problems, because a separate gate
+    covers presence for already-published skills. On an onboarding PR there is
+    no such gate upstream, and silently passing an unsigned skill is exactly
+    the outcome this script exists to prevent.
+    """
+    if not (skill_dir / SIG_NAME).is_file():
+        return [f"{SIG_NAME}: MISSING — the skill is not signed"]
+    # verify_skill prefixes each problem with the directory it was given,
+    # which here is a temporary clone path. Strip it so the reader sees the
+    # file to re-sign rather than /tmp/source-onboarding-xyz/skills/....
+    prefix = f"{skill_dir}/"
+    return [p[len(prefix):] if p.startswith(prefix) else p
+            for p in vci.verify_skill(skill_dir)]
+
+
+def check_required_files(skill_dir: Path) -> list[str]:
+    problems = []
+    for rel in REQUIRED_FILES:
+        if not (skill_dir / rel).is_file():
+            problems.append(f"{rel}: MISSING — required for onboarding")
+    if not any((skill_dir / c).is_file() for c in CARD_NAMES):
+        problems.append(
+            "skill card: MISSING — expected one of " + ", ".join(CARD_NAMES)
+        )
+    return problems
+
+
+def check_benchmark(skill_dir: Path) -> list[str]:
+    """Require a PASS verdict backed by actual measurements.
+
+    ``ab.parse_benchmark`` handles the v1, v2 and v3 report layouts, which
+    state the verdict in different places; matching the string by hand would
+    read v2's methodology bullet ("Overall verdict: PASS only when every
+    configured dimension...") as a passing verdict on every v2 report.
+
+    A verdict alone is not enough. A report can carry PASS in its header while
+    its results table is an unfilled template, which is a claim with no
+    evidence under it — the same has_results:false condition that left
+    rag-blueprint and rag-eval reporting a verdict no run ever produced.
+    """
+    bm = skill_dir / "BENCHMARK.md"
+    if not bm.is_file():
+        return []  # already reported by check_required_files
+
+    try:
+        entry = ab.parse_benchmark(bm)
+    except Exception as exc:
+        return [f"BENCHMARK.md: could not be parsed: {exc}"]
+
+    problems = []
+    verdict = entry.get("verdict")
+    if verdict != "PASS":
+        problems.append(
+            f"BENCHMARK.md: overall verdict is {verdict or 'absent'}, expected PASS"
+        )
+    if not entry.get("results"):
+        problems.append(
+            "BENCHMARK.md: reports no results — the verdict is not backed by "
+            "any measurements"
+        )
+    return problems
+
+
+def check_skill(skill_dir: Path) -> list[str]:
+    """All problems with one skill directory (empty == fit to merge)."""
+    if not skill_dir.is_dir():
+        return ["directory does not exist in the source repository at this ref"]
+    return (
+        check_required_files(skill_dir)
+        + check_signature(skill_dir)
+        + check_benchmark(skill_dir)
+    )
+
+
+# --------------------------------------------------------------------------
+# Fetching the source
+# --------------------------------------------------------------------------
+
+def fetch_source(repo: str, ref: str, paths: list[str], dest: Path) -> Path | None:
+    """Sparse-clone the declared skill directories at the component's ref.
+
+    Mirrors the sync's own fetch (shallow, blobless, sparse) so this check
+    sees the same tree the sync will. Anonymous over HTTPS: the source repos
+    are public, and the check must not need credentials to run on a fork PR.
+
+    Returns None when the clone fails — an unreachable repo or a ref that does
+    not exist is itself a finding, not a reason to crash.
+    """
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1", "--filter=blob:none", "--sparse",
+             "-b", ref, f"https://github.com/{repo}.git", str(dest)],
+            capture_output=True, text=True, check=True, timeout=300,
+        )
+        if paths:
+            subprocess.run(
+                ["git", "sparse-checkout", "set", *paths],
+                cwd=dest, capture_output=True, text=True, check=True, timeout=120,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return dest
+
+
+# --------------------------------------------------------------------------
+# Orchestration
+# --------------------------------------------------------------------------
+
+def changed_component_files(base_sha: str, head_sha: str) -> list[str]:
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    return sorted(
+        p for p in diff
+        if p.startswith(f"{COMPONENTS_DIR}/") and p.endswith(".yml")
+    )
+
+
+def file_at(sha: str, path: str) -> str | None:
+    """A file's contents at a commit, or None when it did not exist there."""
+    result = subprocess.run(
+        ["git", "show", f"{sha}:{path}"], capture_output=True, text=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def exit_code(findings: list[Finding]) -> int:
+    return 1 if any(f.blocking for f in findings) else 0
+
+
+def main() -> int:
+    base_sha = os.environ.get("BASE_SHA")
+    head_sha = os.environ.get("HEAD_SHA")
+    if not base_sha or not head_sha:
+        print("BASE_SHA and HEAD_SHA are required; nothing to check.")
+        return 0
+
+    component_files = changed_component_files(base_sha, head_sha)
+    print(f"Source-onboarding check — {len(component_files)} changed component file(s)")
+    if not component_files:
+        print("No components.d changes in scope; nothing to verify.")
+        return 0
+
+    findings: list[Finding] = []
+    workdir = Path(tempfile.mkdtemp(prefix="source-onboarding-"))
+    try:
+        for rel in component_files:
+            head_text = file_at(head_sha, rel)
+            if head_text is None:
+                # Deleted by this PR — there is no source left to verify.
+                print(f"\n── {rel} (removed) ──")
+                continue
+            component = parse_component(head_text)
+            repo, ref = component["repo"], component["ref"]
+            new = added_paths(file_at(base_sha, rel), head_text)
+
+            print(f"\n── {rel} → {repo}@{ref} ──")
+            if not repo:
+                findings.append(Finding(rel, "no repo: declared", blocking=True))
+                print("  FAIL  no repo: declared")
+                continue
+
+            clone = fetch_source(
+                repo, ref, component["paths"],
+                workdir / rel.replace("/", "-"),
+            )
+            if clone is None:
+                findings.append(Finding(
+                    rel, f"could not clone {repo} at ref {ref}", blocking=True,
+                ))
+                print(f"  FAIL  could not clone {repo} at ref {ref}")
+                continue
+
+            for path in component["paths"]:
+                blocking = path in new
+                problems = check_skill(clone / path)
+                label = "new" if blocking else "existing"
+                if not problems:
+                    print(f"  ok    {path} ({label})")
+                    continue
+                print(f"  {'FAIL' if blocking else 'warn'}  {path} ({label})")
+                for p in problems:
+                    print(f"          {p}")
+                    findings.append(Finding(path, p, blocking))
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    blocking = [f for f in findings if f.blocking]
+    advisory = [f for f in findings if not f.blocking]
+
+    if advisory:
+        print(f"\n{len(advisory)} problem(s) on skills this PR did not add. "
+              "Reported for visibility; not blocking this merge. "
+              "Catalog-wide drift is tracked in #216 and #357.")
+
+    if not blocking:
+        print("\nOK — every skill this PR adds is fit to merge.")
+        return 0
+
+    print(f"\nFAILED — {len(blocking)} problem(s) on skills this PR adds:")
+    for f in blocking:
+        print(f"  - {f.path}: {f.problem}")
+
+    # Only explain re-signing when something actually drifted. Printing it
+    # under a missing directory or an absent evals file sends the author to
+    # re-run signing over a problem signing does not fix.
+    if any("MISMATCH" in f.problem for f in blocking):
+        print(
+            "\nA MISMATCH means the file changed after the signing run, so the "
+            "signature covers an earlier copy. This is most often BENCHMARK.md, "
+            "which is easy to regenerate after signing. The sync applies the "
+            "same check and will drop the skill rather than publish it, so "
+            "fixing it here is the difference between a red check and a skill "
+            "that silently never appears.\n"
+            "\nTo fix: re-run signing in the source repository so the signature "
+            "covers the current content, and do not modify skill files "
+            "afterward."
+        )
+    print("\nSee CONTRIBUTING.md for the onboarding requirements, or ask a CODEOWNER.")
+    return exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/verify_source_onboarding.py
+++ b/.github/scripts/verify_source_onboarding.py
@@ -30,8 +30,8 @@ fetches the source at the component's ``ref`` and checks that:
 
   * every file listed in ``skill.oms.sig`` is present and still hashes to its
     signed digest;
-  * ``SKILL.md``, ``skill.oms.sig``, a skill card and ``evals/evals.json``
-    exist;
+  * ``SKILL.md``, ``skill.oms.sig``, ``skill-card.md`` and an eval dataset
+    exist, applying the same filename rules the hourly sync applies;
   * ``BENCHMARK.md`` reports an overall verdict of PASS backed by real
     measurements.
 
@@ -66,12 +66,13 @@ import verify_content_integrity as vci  # noqa: E402
 COMPONENTS_DIR = Path("components.d")
 SIG_NAME = vci.SIG_NAME
 
-# Required alongside the signature. A skill card is required too, but its
-# filename is not settled: all three spellings below are in active use in the
-# catalog today (skill-card.md 343, SKILLCARD.yaml 47, card.yaml 18), so any
-# one of them satisfies the requirement.
-REQUIRED_FILES = ("SKILL.md", SIG_NAME, "BENCHMARK.md", "evals/evals.json")
-CARD_NAMES = ("skill-card.md", "SKILLCARD.yaml", "card.yaml")
+# Required alongside the signature. The card name is exactly skill-card.md:
+# the hourly sync drops a skill that lacks that file (sync-skills.yml), so
+# accepting SKILLCARD.yaml or card.yaml here would pass a skill at onboarding
+# that the next sync silently removes. Both spellings do appear in the catalog
+# (SKILLCARD.yaml 47, card.yaml 18) but always *alongside* skill-card.md,
+# which all 350 published skills carry — no skill relies on an alternate.
+REQUIRED_FILES = ("SKILL.md", SIG_NAME, "BENCHMARK.md", "skill-card.md")
 
 RE_REPO = re.compile(r"^repo:\s*(\S+)\s*$")
 RE_REF = re.compile(r"^ref:\s*(\S+)\s*$")
@@ -175,14 +176,32 @@ def check_signature(skill_dir: Path) -> list[str]:
             for p in vci.verify_skill(skill_dir)]
 
 
+def has_eval_dataset(skill_dir: Path) -> bool:
+    """Mirror the eval-dataset rule the hourly sync applies.
+
+    The sync accepts an ``evals.json`` at any depth, or any ``*.json`` under
+    ``evals/`` or ``eval/``, which is what lets multi-profile datasets through
+    (rag-blueprint, rag-eval and rag-perf ship ``eval/*.json`` rather than the
+    canonical single file). Requiring ``evals/evals.json`` exactly would fail
+    an onboarding PR the sync would carry happily.
+    """
+    if any(skill_dir.rglob("evals.json")):
+        return True
+    return any(
+        (skill_dir / sub).is_dir() and any((skill_dir / sub).glob("*.json"))
+        for sub in ("evals", "eval")
+    )
+
+
 def check_required_files(skill_dir: Path) -> list[str]:
     problems = []
     for rel in REQUIRED_FILES:
         if not (skill_dir / rel).is_file():
             problems.append(f"{rel}: MISSING — required for onboarding")
-    if not any((skill_dir / c).is_file() for c in CARD_NAMES):
+    if not has_eval_dataset(skill_dir):
         problems.append(
-            "skill card: MISSING — expected one of " + ", ".join(CARD_NAMES)
+            "eval dataset: MISSING — expected evals/evals.json, or any "
+            "*.json under evals/ or eval/"
         )
     return problems
 

--- a/.github/workflows/verify-source-onboarding.yml
+++ b/.github/workflows/verify-source-onboarding.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+#
+# Verify the source-repo skills an onboarding PR declares, before it merges.
+#
+# An onboarding PR adds components.d/<slug>.yml pointing at skill directories
+# in a product repo. The other checks on such a PR inspect this repository's
+# tree, which is sound — the content being onboarded lives elsewhere and goes
+# unexamined. The PR therefore goes green on evidence unrelated to what is
+# being merged.
+#
+# The sync applies the real check an hour later, and refuses any skill whose
+# files no longer match skill.oms.sig: an existing skill reverts, a new skill
+# is dropped outright. By then the PR is closed, so the failure surfaces
+# nowhere — the catalog looks correct and the skill is simply absent. That is
+# how paidf-augmentation (#501) merged green and vanished on 2026-08-31, and
+# how paidf-orchestration (#507) carried the same defect in all four skills.
+#
+# This job follows the pointer and reports the offending filename while the
+# author is still looking at the PR. See .github/scripts/verify_source_onboarding.py.
+
+name: Verify Source Onboarding
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "components.d/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-source-onboarding-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  source-onboarding:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so base...head and `git show <base>:<file>` resolve.
+          # The check needs the component file's *previous* contents to tell
+          # which declared paths this PR actually adds.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify declared source skills
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/verify_source_onboarding.py


### PR DESCRIPTION
Closes #508.

## The gap

An onboarding PR adds `components.d/<slug>.yml` pointing at skill directories in a product repo. Nothing on the PR looks at them. `verify-content-integrity` checks *this* repository's tree, which is sound — the content being onboarded lives somewhere else and goes unexamined. The PR goes green on evidence unrelated to what is being merged.

The cost lands after the merge. The sync recomputes each signed file's digest and refuses the skill on any mismatch: an existing skill reverts to its last good version, and a **new** skill is dropped outright, having no earlier version to fall back to. The PR is closed by then, so the failure surfaces nowhere. The catalog looks correct and the skill is simply absent.

Both happened on 2026-08-31. `paidf-augmentation` (#501) merged green and was dropped by the next sync. `paidf-orchestration` (#507) carried the same defect in all four declared skills and was caught only because the signatures were verified by hand during review. In every case the file was `BENCHMARK.md`, regenerated after the signing run so the signature covered an earlier copy.

## What this adds

A `Verify Source Onboarding` check on PRs touching `components.d/**`. For each declared path it fetches the source at the component's `ref` and verifies:

- every file listed in `skill.oms.sig` is present and still hashes to its signed digest
- `SKILL.md`, `skill.oms.sig`, a skill card and `evals/evals.json` exist
- `BENCHMARK.md` reports an overall verdict of PASS backed by real measurements

**Blocking scope is limited to paths the PR adds.** Around 30 catalog skills already carry drift (#216, #357); failing a PR for drift its author neither caused nor can fix would make the gate an obstacle rather than a signal. Pre-existing paths are still checked and reported, never fatal.

Read-only, anonymous clone, no signing credentials — so it runs on fork PRs.

## Reuse

The content check calls `verify_content_integrity.verify_skill` rather than reimplementing digest comparison; it takes a directory and does not care whose repository that directory came from. The benchmark check calls `aggregate_benchmarks.parse_benchmark`, which already handles the v1/v2/v3 report layouts — matching the verdict string by hand reads v2's methodology bullet ("Overall verdict: PASS only when every configured dimension...") as a passing verdict on every v2 report.

Stdlib only, matching the other scripts in `.github/scripts/`.

## Verification

Replaying `paidf-orchestration` at `5e4fd6b` — its state while #507 was under review — flags `BENCHMARK.md` on all four skills and nothing else, reproducing the table in #508:

```
FAIL  event-video-generation-workflow         BENCHMARK.md: HASH MISMATCH
FAIL  image-attribute-augmentation-workflow   BENCHMARK.md: HASH MISMATCH
FAIL  orchestration-setup                     BENCHMARK.md: HASH MISMATCH
FAIL  write-dag                               BENCHMARK.md: HASH MISMATCH
```

Also exercised end-to-end against live repositories: a new component with a clean source passes; a declared path absent at the ref fails; an unresolvable `ref` fails; a new path pointing at a source with real drift (`NVIDIA/NeMo-Retriever`) fails with 8 named files; and an edit to an existing component whose source is drifted warns and exits 0 rather than blocking.

21 unit tests cover the per-skill checks and the added-vs-pre-existing classification, against fixture directories — no network.

## Known limits

- The source is checked at the moment CI runs. A team that re-signs, goes green, then pushes a commit touching a signed file can still land the defect; the sync remains the backstop. This moves the common case left, it does not make the class impossible.
- On fork PRs the check waits for a maintainer to click "Approve and run" under the current Actions policy, so feedback is on first reviewer touch rather than instant.

## Test plan

- [ ] Check runs and passes on a PR touching `components.d/**` with a correctly-signed source
- [ ] Check is skipped on PRs that touch no component files
