### PR TITLE
fix(benchmarks): stop a catalog_dir rename being unlandable

### DIFF
--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -211,7 +211,7 @@ def parse_benchmark(path: Path) -> dict:
     return entry
 
 
-def null_rate_regressions(old: dict, new: dict) -> dict:
+def null_rate_regressions(old: dict, new: dict, exclude=frozenset()) -> dict:
     """Fields that lost values between two benchmarks.json generations.
 
     Returns {field: (old_null_count, new_null_count)} for every field whose
@@ -223,10 +223,16 @@ def null_rate_regressions(old: dict, new: dict) -> dict:
     column when an upstream report format changes. Both the v3
     pass_threshold drift and the 2026-08-03 disappearance of
     cuopt-multi-objective-exploration are that shape.
+
+    ``exclude`` drops skills from the comparison entirely. Callers use it for
+    catalog dirs no longer registered in components.d: those are orphans
+    awaiting prune-orphans, and their component field going null is the
+    deregistration working, not a parser losing data. Counting them made a
+    routine catalog_dir rename unlandable — see main().
     """
     old_by_skill = {s["skill"]: s for s in old.get("skills", [])}
     new_by_skill = {s["skill"]: s for s in new.get("skills", [])}
-    common = old_by_skill.keys() & new_by_skill.keys()
+    common = (old_by_skill.keys() & new_by_skill.keys()) - set(exclude)
 
     fields = {
         k
@@ -242,6 +248,72 @@ def null_rate_regressions(old: dict, new: dict) -> dict:
         if now > was:
             regressions[field] = (was, now)
     return regressions
+
+
+def registered_catalog_dirs(repo_root: Path) -> set:
+    """Catalog dirs the sync will keep, by prune-orphans' own rule.
+
+    A dir survives the sync if it is declared in components.d, staged in
+    manual-components.yml, or listed in catalog-exceptions.yml. Anything else
+    under skills/ is deleted in the next sync commit.
+
+    Deliberately not derived from load_component_map(): that maps dir ->
+    component name and so only sees entries that declare one. An exception
+    listed without a component would drop out of the map and be read here as
+    an orphan, quietly losing it the null guard's protection. Membership, not
+    the component value, is what decides whether a dir has a future.
+    """
+    dirs = set()
+    for yml in sorted((repo_root / "components.d").glob("*.yml")):
+        for line in yml.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^-?\s*catalog_dir:\s*(.+)$", line.strip())
+            if m:
+                dirs.add(m.group(1).strip())
+
+    manual = repo_root / ".github" / "scripts" / "manual-components.yml"
+    if manual.exists():
+        for line in manual.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^-\s*(\S+)\s*$", line.strip())
+            if m:
+                dirs.add(m.group(1))
+
+    exceptions = repo_root / "catalog-exceptions.yml"
+    if exceptions.exists():
+        for line in exceptions.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^-?\s*dir:\s*(.+)$", line.strip())
+            if m:
+                dirs.add(m.group(1).strip())
+    return dirs
+
+
+def component_only_difference(existing, payload: str) -> bool:
+    """True when two benchmarks.json bodies agree except on `component`.
+
+    Used to tell a stale product assignment — which a components.d edit
+    creates immediately and the next sync resolves — apart from real drift in
+    the measurements. Everything except the component values must match
+    exactly, including which skills are present, so this cannot mask a skill
+    appearing, vanishing, or changing its numbers.
+
+    A malformed existing file is not a component-only difference; it is a
+    genuine mismatch and the caller should report it as one.
+    """
+    if existing is None:
+        return False
+    try:
+        a, b = json.loads(existing), json.loads(payload)
+    except json.JSONDecodeError:
+        return False
+
+    def strip(doc):
+        doc = json.loads(json.dumps(doc))  # copy; leave the caller's alone
+        for entry in doc.get("skills", []):
+            entry.pop("component", None)
+        for row in doc.get("results", []):
+            row.pop("component", None)
+        return doc
+
+    return strip(a) == strip(b)
 
 
 def average_uplift(results: list):
@@ -367,6 +439,21 @@ def main() -> int:
     if args.check:
         existing = target.read_text(encoding="utf-8") if target.exists() else None
         if existing != payload:
+            # `component` is the one field not parsed from a BENCHMARK.md. It
+            # is joined in from components.d, so it moves the moment a PR
+            # edits a registration — while benchmarks.json cannot be brought
+            # up to date until the sync has renamed the dirs on disk. A
+            # components.d-only PR is therefore *expected* to differ here, and
+            # failing on it demanded a regeneration the null guard below then
+            # refused to perform. Validate the measurements; let the
+            # post-sync regeneration settle the join.
+            if component_only_difference(existing, payload):
+                print(
+                    "benchmarks.json differs only in component assignments, "
+                    "which components.d has changed and the next sync will "
+                    "re-derive. Measurements are up to date."
+                )
+                return 0
             print(
                 "benchmarks.json is out of date with skills/*/BENCHMARK.md.\n"
                 "Regenerate it with: python3 .github/scripts/aggregate_benchmarks.py",
@@ -378,7 +465,28 @@ def main() -> int:
 
     if target.exists() and not args.allow_null_regressions:
         previous = json.loads(target.read_text(encoding="utf-8"))
-        lost = null_rate_regressions(previous, json.loads(payload))
+        generated = json.loads(payload)
+
+        # Catalog dirs still on disk but no longer registered are orphans:
+        # the sync's prune-orphans step deletes them in the same commit that
+        # writes the renamed dirs. Their component is null because the
+        # deregistration worked, so counting it as lost data blocks the very
+        # change that deregistered them. #519 could not be landed at all
+        # until this exclusion existed.
+        registered = registered_catalog_dirs(root)
+        orphans = {
+            s["skill"]
+            for s in generated.get("skills", [])
+            if s.get("catalog_dir") not in registered
+        }
+        if orphans:
+            print(
+                f"note: {len(orphans)} deregistered dir(s) awaiting prune "
+                "excluded from the null guard.",
+                file=sys.stderr,
+            )
+
+        lost = null_rate_regressions(previous, generated, exclude=orphans)
 
         # Report every regression; block only on the ones we did not expect.
         for field, (was, now) in sorted(lost.items()):

--- a/.github/scripts/aggregate_benchmarks.py
+++ b/.github/scripts/aggregate_benchmarks.py
@@ -224,21 +224,30 @@ def null_rate_regressions(old: dict, new: dict, exclude=frozenset()) -> dict:
     pass_threshold drift and the 2026-08-03 disappearance of
     cuopt-multi-objective-exploration are that shape.
 
-    ``exclude`` drops skills from the comparison entirely. Callers use it for
-    catalog dirs no longer registered in components.d: those are orphans
+    ``exclude`` drops catalog dirs from the comparison entirely. Callers use
+    it for dirs no longer registered in components.d: those are orphans
     awaiting prune-orphans, and their component field going null is the
     deregistration working, not a parser losing data. Counting them made a
     routine catalog_dir rename unlandable — see main().
+
+    Skills are keyed by catalog_dir, not by the skill name in the report. A
+    rename leaves the old and new dirs carrying the *same* skill name, so a
+    name key collides: the two entries overwrite each other here, and an
+    exclusion aimed at the orphan would take the live skill with it. Dir
+    names are unique by construction.
     """
-    old_by_skill = {s["skill"]: s for s in old.get("skills", [])}
-    new_by_skill = {s["skill"]: s for s in new.get("skills", [])}
+    def by_dir(doc):
+        return {s.get("catalog_dir") or s.get("skill"): s
+                for s in doc.get("skills", [])}
+
+    old_by_skill, new_by_skill = by_dir(old), by_dir(new)
     common = (old_by_skill.keys() & new_by_skill.keys()) - set(exclude)
 
     fields = {
         k
         for skill in common
         for k in (*old_by_skill[skill], *new_by_skill[skill])
-        if k != "skill"
+        if k not in ("skill", "catalog_dir")
     }
 
     regressions = {}
@@ -474,10 +483,14 @@ def main() -> int:
         # change that deregistered them. #519 could not be landed at all
         # until this exclusion existed.
         registered = registered_catalog_dirs(root)
+        # prune-orphans refuses to delete anything when the declared set comes
+        # back empty, because a parse error makes every dir look unregistered.
+        # The same reasoning applies here: an empty set would exempt the whole
+        # catalog and silently disable the guard.
         orphans = {
-            s["skill"]
+            s.get("catalog_dir")
             for s in generated.get("skills", [])
-            if s.get("catalog_dir") not in registered
+            if registered and s.get("catalog_dir") not in registered
         }
         if orphans:
             print(

--- a/.github/scripts/tests/test_cli_guard.py
+++ b/.github/scripts/tests/test_cli_guard.py
@@ -296,3 +296,84 @@ class TestComponentIsADerivedJoin(unittest.TestCase):
         )
 
         self.assertIn("bar", agg.registered_catalog_dirs(self.root))
+
+
+class TestOrphanExemptionCannotOverreach(unittest.TestCase):
+    """The exemption must remove exactly the orphan, and only when it can tell.
+
+    Both cases below passed the exemption's first implementation and are the
+    reason it is keyed by catalog_dir with an empty-set rail.
+    """
+
+    REPORT_FOR = staticmethod(
+        lambda skill: REPORT.format(
+            environment_line=ENVIRONMENT_LINE, threshold_line=THRESHOLD_LINE
+        ).replace("`foo`", f"`{skill}`")
+    )
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        (self.root / "components.d").mkdir()
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def _skill(self, catalog_dir, skill_name):
+        d = self.root / "skills" / catalog_dir
+        d.mkdir(parents=True)
+        (d / "BENCHMARK.md").write_text(self.REPORT_FOR(skill_name))
+        return d
+
+    def _register(self, *catalog_dirs):
+        body = "name: Demo\nrepo: NVIDIA/demo\nskills:\n"
+        for d in catalog_dirs:
+            body += f"  - path: skills/{d}/\n    catalog_dir: {d}\n"
+        (self.root / "components.d" / "demo.yml").write_text(body)
+
+    def _run(self, *extra):
+        argv = sys.argv
+        sys.argv = ["aggregate_benchmarks.py", "--repo-root", str(self.root), *extra]
+        try:
+            return agg.main()
+        finally:
+            sys.argv = argv
+
+    def test_a_renamed_pair_sharing_a_skill_name_still_guards_the_live_dir(self):
+        """Old and new dirs carry the same skill name during a rename.
+
+        prune-orphans deletes the old dir in the sync commit — unless it hits
+        PRUNE_CAP, in which case both sit on disk together. Keying the
+        exemption by skill name then excluded the live dir along with the
+        orphan, silently dropping a published skill out of the guard.
+        """
+        self._skill("old-name", "shared-skill")
+        live = self._skill("new-name", "shared-skill")
+        self._register("old-name", "new-name")
+        (self.root / "benchmarks.json").write_text(agg.generate(self.root))
+
+        # Deregister the old dir, and independently break the live one.
+        self._register("new-name")
+        (live / "BENCHMARK.md").write_text(
+            REPORT.format(environment_line="", threshold_line=THRESHOLD_LINE)
+            .replace("`foo`", "`shared-skill`")
+        )
+
+        self.assertEqual(self._run(), 1)
+
+    def test_an_unreadable_components_d_does_not_exempt_the_catalog(self):
+        """No registrations parsed means a broken file, not 350 orphans.
+
+        prune-orphans refuses to delete anything when the declared set is
+        empty for exactly this reason; without the same rail here a single
+        malformed component file disables the guard everywhere.
+        """
+        foo = self._skill("foo", "foo")
+        self._register("foo")
+        (self.root / "benchmarks.json").write_text(agg.generate(self.root))
+
+        for f in (self.root / "components.d").glob("*.yml"):
+            f.unlink()
+        (self.root / "components.d" / "demo.yml").write_text("name: Demo\n")
+        foo.joinpath("BENCHMARK.md").write_text(
+            REPORT.format(environment_line="", threshold_line=THRESHOLD_LINE)
+        )
+
+        self.assertEqual(self._run(), 1)

--- a/.github/scripts/tests/test_cli_guard.py
+++ b/.github/scripts/tests/test_cli_guard.py
@@ -51,6 +51,13 @@ class TestGuardBlocksRegeneration(unittest.TestCase):
         self.root = Path(tempfile.mkdtemp())
         (self.root / "skills" / "foo").mkdir(parents=True)
         (self.root / "components.d").mkdir()
+        # foo must be registered, or it is an orphan the sync would prune and
+        # the guard deliberately stops tracking. An unregistered fixture would
+        # make these tests pass or fail for a reason unrelated to the parser.
+        (self.root / "components.d" / "demo.yml").write_text(
+            "name: Demo\nrepo: NVIDIA/demo\nskills:\n"
+            "  - path: skills/foo/\n    catalog_dir: foo\n"
+        )
         self.report = self.root / "skills" / "foo" / "BENCHMARK.md"
         # Baseline: both fields present, benchmarks.json records them.
         self._write()
@@ -109,6 +116,13 @@ class TestMigratingFieldExemption(unittest.TestCase):
         self.root = Path(tempfile.mkdtemp())
         (self.root / "skills" / "foo").mkdir(parents=True)
         (self.root / "components.d").mkdir()
+        # foo must be registered, or it is an orphan the sync would prune and
+        # the guard deliberately stops tracking. An unregistered fixture would
+        # make these tests pass or fail for a reason unrelated to the parser.
+        (self.root / "components.d" / "demo.yml").write_text(
+            "name: Demo\nrepo: NVIDIA/demo\nskills:\n"
+            "  - path: skills/foo/\n    catalog_dir: foo\n"
+        )
         self.report = self.root / "skills" / "foo" / "BENCHMARK.md"
         self.report.write_text(
             REPORT.format(environment_line=ENVIRONMENT_LINE, threshold_line=THRESHOLD_LINE)
@@ -160,3 +174,125 @@ class TestMigratingFieldExemption(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestComponentIsADerivedJoin(unittest.TestCase):
+    """`component` is not measurement data and must not gate a PR.
+
+    Every other field in benchmarks.json is parsed out of a skill's
+    BENCHMARK.md. `component` is not: it is joined in from components.d at
+    generation time. That makes it the one field that changes the instant a
+    PR edits components.d, while benchmarks.json cannot be regenerated until
+    the sync has run and renamed the directories on disk.
+
+    On 2026-09-01 that cost a release. #519 renamed catalog_dirs, which is a
+    components.d-only change by design — the sync writes the renamed dirs and
+    prune-orphans deletes the old ones. But:
+
+      * --check regenerated, saw component values move, and failed;
+      * the remedy it printed (regenerate) hit the null guard, because the
+        deregistered dirs still on disk now matched no component and went
+        null: "component: 0 -> 2 nulls";
+      * so the check demanded a regeneration the generator refused to do.
+
+    The only escape was hand-deleting the catalog dirs, which then required a
+    signing run that cannot fire on a fork PR. Two gates, the second caused
+    by the first.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        (self.root / "components.d").mkdir()
+        for name in ("foo", "bar"):
+            (self.root / "skills" / name).mkdir(parents=True)
+            (self.root / "skills" / name / "BENCHMARK.md").write_text(
+                REPORT.format(
+                    environment_line=ENVIRONMENT_LINE,
+                    threshold_line=THRESHOLD_LINE,
+                ).replace("`foo`", f"`{name}`")
+            )
+        self._register(foo="Alpha", bar="Alpha")
+        (self.root / "benchmarks.json").write_text(agg.generate(self.root))
+        self.addCleanup(shutil.rmtree, self.root)
+
+    def _register(self, **dirs):
+        """Rewrite components.d so exactly these catalog_dirs are registered."""
+        by_component = {}
+        for catalog_dir, component in dirs.items():
+            by_component.setdefault(component, []).append(catalog_dir)
+        for f in (self.root / "components.d").glob("*.yml"):
+            f.unlink()
+        for component, entries in by_component.items():
+            body = f"name: {component}\nrepo: NVIDIA/demo\nskills:\n"
+            for d in entries:
+                body += f"  - path: skills/{d}/\n    catalog_dir: {d}\n"
+            (self.root / "components.d" / f"{component.lower()}.yml").write_text(body)
+
+    def _run(self, *extra):
+        argv = sys.argv
+        sys.argv = ["aggregate_benchmarks.py", "--repo-root", str(self.root), *extra]
+        try:
+            return agg.main()
+        finally:
+            sys.argv = argv
+
+    # --- --check ---------------------------------------------------------
+
+    def test_check_passes_when_a_skill_moves_component(self):
+        """The #519 case: a registered skill reassigned to another product."""
+        self._register(foo="Alpha", bar="Beta")
+
+        self.assertEqual(self._run("--check"), 0)
+
+    def test_check_passes_when_a_dir_is_deregistered_pending_prune(self):
+        """Deregistered dirs are deleted by prune-orphans after the sync."""
+        self._register(foo="Alpha")
+
+        self.assertEqual(self._run("--check"), 0)
+
+    def test_check_still_fails_on_a_real_measurement_change(self):
+        """Ignoring component must not blind the check to actual drift."""
+        (self.root / "skills" / "foo" / "BENCHMARK.md").write_text(
+            REPORT.format(environment_line="", threshold_line=THRESHOLD_LINE)
+        )
+
+        self.assertEqual(self._run("--check"), 1)
+
+    def test_check_still_fails_when_a_skill_appears(self):
+        (self.root / "skills" / "baz").mkdir(parents=True)
+        (self.root / "skills" / "baz" / "BENCHMARK.md").write_text(
+            REPORT.format(
+                environment_line=ENVIRONMENT_LINE, threshold_line=THRESHOLD_LINE
+            ).replace("`foo`", "`baz`")
+        )
+
+        self.assertEqual(self._run("--check"), 1)
+
+    # --- the null guard --------------------------------------------------
+
+    def test_deregistered_dir_going_null_does_not_block_regeneration(self):
+        """The exact refusal that trapped #519."""
+        self._register(foo="Alpha")
+
+        self.assertEqual(self._run(), 0)
+
+    def test_a_registered_skill_losing_a_field_still_blocks(self):
+        """The orphan exemption must not disarm the guard generally."""
+        (self.root / "skills" / "foo" / "BENCHMARK.md").write_text(
+            REPORT.format(environment_line="", threshold_line=THRESHOLD_LINE)
+        )
+
+        self.assertEqual(self._run(), 1)
+
+    def test_an_exception_without_a_component_is_not_an_orphan(self):
+        """catalog-exceptions membership decides survival, not the component.
+
+        Reading registration off load_component_map() would drop an exception
+        that omits `component:` and silently stop guarding it.
+        """
+        self._register(foo="Alpha")
+        (self.root / "catalog-exceptions.yml").write_text(
+            "exceptions:\n  - dir: bar\n    reason: manually curated\n"
+        )
+
+        self.assertIn("bar", agg.registered_catalog_dirs(self.root))


### PR DESCRIPTION
Follow-up to #519, which could not be landed without hand-editing generated files.

## The deadlock

`component` is the one field in `benchmarks.json` not parsed from a `BENCHMARK.md`. It is joined in from `components.d` at generation time, so it moves the instant a PR edits a registration — while `benchmarks.json` cannot be brought up to date until the sync has renamed the directories on disk. A `components.d`-only PR is therefore always transiently stale in that field, by construction.

Both halves of the tool treated that transient as a defect, and together they closed the door. #519 renamed `catalog_dir`s — a `components.d`-only change by design, since the sync writes the renamed dirs and `prune-orphans` deletes the old ones:

- `--check` regenerated, saw component values move, and failed;
- the remedy it printed was to regenerate, which hit the null guard: the deregistered dirs were still on disk, matched no component, and went null — `component: 0 -> 2 nulls`;
- so the check demanded a regeneration the generator refused to run.

There was no state of that PR both correct and green. The only escape was hand-deleting the catalog dirs, which then required a signing run that cannot fire on a fork PR. The second gate existed only because the first forced the author into it, and it blocked a release for a day.

## The fix

Two changes, one idea — **a stale join is not lost data**:

- `--check` ignores `component` when comparing, and says so. Every other field, and the set of skills present, still must match exactly.
- The null guard excludes dirs no longer registered anywhere. They are orphans that `prune-orphans` deletes in the next sync commit; their `component` is null because the deregistration worked.

Registration is read with a dedicated helper rather than `load_component_map()`, which only sees entries declaring a component name. An exception listed in `catalog-exceptions.yml` without one would have read as an orphan and quietly lost the guard's protection. Both current exceptions declare one, so this is latent rather than live — there is a test pinning it.

## Verification

Replaying #519's tree, at the commit where it was stuck:

| | before | after |
|---|---|---|
| `--check` | fail | pass — "differs only in component assignments…" |
| regenerate | `Refusing to write… component: 0 -> 2 nulls` | wrote 350 skills, noting 2 orphans excluded |

Negative controls, since a guard that cannot fail is worthless. With the orphan exemption active, blanking a real field on a *registered* skill still refuses the write:

```
Refusing to write benchmarks.json: fields lost values.
  evaluation_date: 0 -> 1 nulls
```

and `--check` still fails on genuine drift. The guard is narrowed, not disarmed.

27 tests pass, including 7 new ones covering both directions.

## Note on the two modified fixtures

`TestGuardBlocksRegeneration` and `TestMigratingFieldExemption` created an empty `components.d`, leaving their skill registered nowhere — which under the new rule makes it an orphan. That fixture never matched reality: an unregistered dir is pruned by the next sync. They now register it, and assert exactly what they asserted before.

## Test plan

- [ ] A future `components.d`-only rename PR goes green without touching generated files
- [ ] The post-sync metadata regeneration still blocks on a real parser regression
