### PR TITLE
feat: add PAIDF curation and retrieval component

### DIFF
--- a/components.d/physical-ai-curation-and-retrieval.yml
+++ b/components.d/physical-ai-curation-and-retrieval.yml
@@ -1,0 +1,8 @@
+name: Physical AI Curation and Retrieval
+repo: NVIDIA/paidf-curation-and-retrieval
+description: Author, validate, and run Physical AI Data Factory curation and retrieval pipelines.
+skills:
+  - path: skills/paidf-curation-and-retrieval
+    catalog_dir: paidf-curation-and-retrieval
+links:
+  discussions: false


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** by the owning team, with all required approvals in place
- [x] **License selected:**  Dual (Apache 2.0 + CC-BY 4.0). 
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries