### PR TITLE
Register NVIDIA FLARE skills

### DIFF
--- a/components.d/nvflare.yml
+++ b/components.d/nvflare.yml
@@ -8,8 +8,7 @@ description: >-
   Agent skills for converting training code to federated workflows,
   diagnosing jobs, collecting federated statistics, and running Auto-FL
   with NVIDIA FLARE. Install the complete NVFlare skill set together so
-  each workflow has its required shared references. Run
-  `npx skills add nvidia/skills` to install.
+  each workflow has its required shared references.
 links:
   security: false
 skills:

--- a/components.d/nvflare.yml
+++ b/components.d/nvflare.yml
@@ -7,7 +7,10 @@ ref: 2.9
 description: >-
   Agent skills for converting training code to federated workflows,
   diagnosing jobs, collecting federated statistics, and running Auto-FL
-  with NVIDIA FLARE.
+  with NVIDIA FLARE. Install the complete NVFlare skill set together so
+  each workflow has its required shared references.
+links:
+  security: false
 skills:
   - path: skills/nvflare-autofl
     catalog_dir: nvflare-autofl

--- a/components.d/nvflare.yml
+++ b/components.d/nvflare.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
+# Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+
+name: NVIDIA FLARE
+repo: NVIDIA/NVFlare
+ref: main
+description: >-
+  Agent skills for converting training code to federated workflows,
+  diagnosing jobs, collecting federated statistics, and running Auto-FL
+  with NVIDIA FLARE.
+skills:
+  - path: skills/nvflare-autofl
+    catalog_dir: nvflare-autofl
+  - path: skills/nvflare-autofl-report
+    catalog_dir: nvflare-autofl-report
+  - path: skills/nvflare-convert-huggingface
+    catalog_dir: nvflare-convert-huggingface
+  - path: skills/nvflare-convert-lightning
+    catalog_dir: nvflare-convert-lightning
+  - path: skills/nvflare-convert-pytorch
+    catalog_dir: nvflare-convert-pytorch
+  - path: skills/nvflare-diagnose-job
+    catalog_dir: nvflare-diagnose-job
+  - path: skills/nvflare-fed-stats
+    catalog_dir: nvflare-fed-stats
+  - path: skills/nvflare-orient
+    catalog_dir: nvflare-orient
+  - path: skills/nvflare-shared
+    catalog_dir: nvflare-shared

--- a/components.d/nvflare.yml
+++ b/components.d/nvflare.yml
@@ -3,7 +3,7 @@
 
 name: NVIDIA FLARE
 repo: NVIDIA/NVFlare
-ref: main
+ref: 2.9
 description: >-
   Agent skills for converting training code to federated workflows,
   diagnosing jobs, collecting federated statistics, and running Auto-FL

--- a/components.d/nvflare.yml
+++ b/components.d/nvflare.yml
@@ -8,7 +8,8 @@ description: >-
   Agent skills for converting training code to federated workflows,
   diagnosing jobs, collecting federated statistics, and running Auto-FL
   with NVIDIA FLARE. Install the complete NVFlare skill set together so
-  each workflow has its required shared references.
+  each workflow has its required shared references. Run
+  `npx skills add nvidia/skills` to install.
 links:
   security: false
 skills:


### PR DESCRIPTION
## Onboarding type

- [x] New product onboarding (new `components.d/<slug>.yml` file)
- [ ] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** by the owning team, with all required approvals in place
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: Apache 2.0
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency introduced

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context (for non-onboarding PRs)

Registers all nine NVIDIA FLARE skills from the stable `NVIDIA/NVFlare:2.9` branch. The skills are intended to be installed as a complete set so shared references resolve through `nvflare-shared`.

Draft dependency: NVIDIA/NVFlare#5260 must merge with fresh, hash-valid artifacts for all nine skills before this PR is ready for review.
