### PR TITLE
Update Isaac for Healthcare workflow skills

### DIFF
--- a/components.d/isaac-for-healthcare-workflows.yml
+++ b/components.d/isaac-for-healthcare-workflows.yml
@@ -27,22 +27,14 @@ skills:
     catalog_dir: i4h-workflow-dataset-convert
   - path: skills/i4h-workflow-finetune/
     catalog_dir: i4h-workflow-finetune
+  - path: skills/i4h-workflow-train-rl/
+    catalog_dir: i4h-workflow-train-rl
   - path: skills/i4h-workflow-validate/
     catalog_dir: i4h-workflow-validate
   - path: skills/i4h-workflow-e2e/
     catalog_dir: i4h-workflow-e2e
   - path: skills/i4h-lerobot-viz/
     catalog_dir: i4h-lerobot-viz
-  - path: skills/i4h-catheter-navigation/
-    catalog_dir: i4h-catheter-navigation
-  - path: skills/i4h-catheter-navigation-setup/
-    catalog_dir: i4h-catheter-navigation-setup
-  - path: skills/i4h-catheter-navigation-digital-twin/
-    catalog_dir: i4h-catheter-navigation-digital-twin
-  - path: skills/i4h-catheter-navigation-render-drr/
-    catalog_dir: i4h-catheter-navigation-render-drr
-  - path: skills/i4h-catheter-navigation-viewport/
-    catalog_dir: i4h-catheter-navigation-viewport
   - path: skills/i4h-catheter-navigation-smoke/
     catalog_dir: i4h-catheter-navigation-smoke
   - path: skills/i4h-catheter-navigation-e2e/


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change to an existing component)

## Source skill affirmations

- [x] Skills cleared for open source release by the owning team
- [x] License: Apache 2.0
- [x] No new license or third-party component introduced
- [x] Source repo is public under the `isaac-for-healthcare` GitHub organization
- [x] Skills use the existing `skills/` layout

## Summary

- register the newly graduated `i4h-workflow-train-rl` skill
- deregister five retired catheter-navigation skills
- leave `i4h-catheter-navigation-smoke` and `i4h-catheter-navigation-e2e` for a follow-up PR so each sync remains within the five-directory prune cap

The signed v0.8.0 skill payload was published in https://github.com/isaac-for-healthcare/i4h-workflows/pull/240.

## Validation

- source-onboarding verifier passes the new train-RL skill and all 13 retained active skills
- all catalog directories remain unique
- YAML and diff checks pass

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).