### PR TITLE
fix(versions): let a deregistered skill leave versions.json

### DIFF
--- a/.github/scripts/generate_versions.py
+++ b/.github/scripts/generate_versions.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import jsonschema
 
+import aggregate_benchmarks as ab
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_DIR = REPO_ROOT / "skills"
 OUTPUT = REPO_ROOT / "versions.json"
@@ -112,6 +114,24 @@ def removed_skills(new: dict, old: dict) -> list[str]:
                   - {s["name"] for s in new["skills"]})
 
 
+def blocking_removals(gone: list[str], registered: set[str]) -> list[str]:
+    """Removals that must stop the write, given the registered skill set.
+
+    A skill whose components.d entry was dropped is *expected* to leave the
+    output: the sync prunes its directory and versions.json follows. The case
+    this guard exists for is the opposite one -- a skill still registered that
+    vanished anyway, which is how cuopt-multi-objective-exploration
+    disappeared on 2026-08-03. Registration is what separates them.
+
+    An empty ``registered`` means the parse failed rather than that nothing is
+    registered, so nothing is exempt; otherwise a bad parse would silently
+    switch the guard off.
+    """
+    if not registered:
+        return list(gone)
+    return [name for name in gone if name in registered]
+
+
 def serialize(doc: dict) -> str:
     return json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
 
@@ -133,13 +153,19 @@ def main() -> int:
     # rather than a wall — but it must be deliberate.
     if OUTPUT.is_file():
         gone = removed_skills(doc, json.loads(OUTPUT.read_text()))
-        if gone and not args.allow_removals:
-            print(f"Refusing to write versions.json: {len(gone)} skill(s) "
-                  f"disappeared from the output.", file=sys.stderr)
-            for name in gone:
+        blocking = blocking_removals(gone, ab.registered_catalog_dirs(REPO_ROOT))
+        expected = [name for name in gone if name not in blocking]
+        if expected:
+            print(f"note: {len(expected)} deregistered skill(s) removed from "
+                  f"versions.json: {', '.join(expected)}", file=sys.stderr)
+        if blocking and not args.allow_removals:
+            print(f"Refusing to write versions.json: {len(blocking)} skill(s) "
+                  f"disappeared while still registered in components.d.",
+                  file=sys.stderr)
+            for name in blocking:
                 print(f"  - {name}", file=sys.stderr)
-            print("\nIf these were deregistered in components.d, re-run with "
-                  "--allow-removals.", file=sys.stderr)
+            print("\nDrop their components.d entries if the removal is "
+                  "intended, or re-run with --allow-removals.", file=sys.stderr)
             return 1
 
     rendered = serialize(doc)

--- a/.github/scripts/generate_versions.py
+++ b/.github/scripts/generate_versions.py
@@ -156,8 +156,8 @@ def main() -> int:
         blocking = blocking_removals(gone, ab.registered_catalog_dirs(REPO_ROOT))
         expected = [name for name in gone if name not in blocking]
         if expected:
-            print(f"note: {len(expected)} deregistered skill(s) removed from "
-                  f"versions.json: {', '.join(expected)}", file=sys.stderr)
+            print(f"note: detected {len(expected)} deregistered skill(s) absent "
+                  f"from generated output: {', '.join(expected)}", file=sys.stderr)
         if blocking and not args.allow_removals:
             print(f"Refusing to write versions.json: {len(blocking)} skill(s) "
                   f"disappeared while still registered in components.d.",

--- a/.github/scripts/tests/test_generate_versions.py
+++ b/.github/scripts/tests/test_generate_versions.py
@@ -15,6 +15,10 @@ The properties that matter to a consumer, and what breaks if they fail:
   removal detection     A generated file stays schema-valid with one fewer
                         entry, which is how a skill silently vanished from
                         metadata.json on 2026-08-03.
+  removal intent        A team that deregisters a skill in components.d
+                        expects it to leave versions.json; blocking that made
+                        every post-deregistration regeneration fail, so the
+                        guard keys on registration rather than on absence.
 """
 
 import base64
@@ -120,6 +124,34 @@ class TestRemovedSkills(unittest.TestCase):
         old = {"skills": [{"name": "c"}, {"name": "a"}, {"name": "b"}]}
         new = {"skills": []}
         self.assertEqual(gv.removed_skills(new, old), ["a", "b", "c"])
+
+
+class TestBlockingRemovals(unittest.TestCase):
+    """Which removals stop the write.
+
+    Both directions matter. Blocking a deregistered skill wedges the hourly
+    regeneration permanently, because the guard compares against a checked-in
+    file that can then never be updated. Exempting a registered one restores
+    the 2026-08-03 silent-loss bug.
+    """
+
+    def test_deregistered_skill_is_not_blocking(self):
+        self.assertEqual(gv.blocking_removals(["retired"], {"kept"}), [])
+
+    def test_still_registered_skill_is_blocking(self):
+        self.assertEqual(gv.blocking_removals(["kept"], {"kept"}), ["kept"])
+
+    def test_mixed_removals_block_only_the_registered_one(self):
+        self.assertEqual(
+            gv.blocking_removals(["retired", "kept"], {"kept"}), ["kept"])
+
+    def test_empty_registry_blocks_everything(self):
+        """A failed components.d parse must not disable the guard."""
+        self.assertEqual(
+            gv.blocking_removals(["a", "b"], set()), ["a", "b"])
+
+    def test_no_removals_is_never_blocking(self):
+        self.assertEqual(gv.blocking_removals([], {"kept"}), [])
 
 
 class TestValidate(unittest.TestCase):

--- a/.github/scripts/tests/test_generate_versions.py
+++ b/.github/scripts/tests/test_generate_versions.py
@@ -22,10 +22,14 @@ The properties that matter to a consumer, and what breaks if they fail:
 """
 
 import base64
+import contextlib
+import io
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -152,6 +156,30 @@ class TestBlockingRemovals(unittest.TestCase):
 
     def test_no_removals_is_never_blocking(self):
         self.assertEqual(gv.blocking_removals([], {"kept"}), [])
+
+
+class TestRemovalDiagnostics(unittest.TestCase):
+    def test_check_does_not_claim_a_deregistration_was_written(self):
+        """--check reports intent without implying it changed versions.json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "versions.json"
+            output.write_text(json.dumps({"skills": [{"name": "retired"}]}))
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(gv, "OUTPUT", output),
+                mock.patch.object(gv, "build", return_value={"skills": []}),
+                mock.patch.object(gv, "validate"),
+                mock.patch.object(
+                    gv.ab, "registered_catalog_dirs", return_value={"kept"}
+                ),
+                mock.patch.object(sys, "argv", ["generate_versions.py", "--check"]),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(gv.main(), 1)
+
+            message = stderr.getvalue()
+            self.assertIn("detected 1 deregistered skill(s)", message)
+            self.assertNotIn("removed from versions.json", message)
 
 
 class TestValidate(unittest.TestCase):


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (CI / generator fix)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context

### The problem

`generate_versions.py` refuses to write when any skill present in the checked-in `versions.json` is missing from a regeneration. That guard is correct for the case it was written for — `cuopt-multi-objective-exploration` disappearing on 2026-08-03 while still registered — but it also fires on the routine case of a team retiring a skill.

It fired today. Isaac for Healthcare deregistered five catheter skills in c3168ca, the sync pruned them in #538, and the regeneration refused:

```
Refusing to write versions.json: 5 skill(s) disappeared from the output.
  - i4h-catheter-navigation
  ...
If these were deregistered in components.d, re-run with --allow-removals.
```

The workflow never passes `--allow-removals` and exposes no input to set it, so there is no way to record that a removal was intended.

Two knock-on effects worth naming:

1. **It strands the other three files.** This is the last generation step, so a non-zero exit skips "Create regeneration PR" — `metadata.json`, `skills.sh.json` and `benchmarks.json` were all generated correctly and then discarded.
2. **It cannot self-heal.** The comparison is against a checked-in file that only a successful regeneration can update, so every subsequent hourly run fails identically and re-comments on the tracking issue (#541).

### The change

Registration separates the two cases exactly:

- a skill absent from `components.d` was retired on purpose — allow it, and log which ones
- a skill still registered that disappears anyway — still blocks

This is the same distinction #522 drew in `aggregate_benchmarks.py` for the same class of false alarm, and it reuses `registered_catalog_dirs()` rather than restating the rule.

An empty registry is treated as a parse failure rather than as "nothing is registered", so a bad parse cannot silently switch the guard off. `--allow-removals` is unchanged as a manual override.

The decision is factored into `blocking_removals(gone, registered)` so it can be tested directly, matching how the rest of this module is covered.

### Verification

Against `main` at 0b26974:

| Case | Before | After |
|---|---|---|
| 5 deregistered skills removed (today's failure) | refuses, exit 1 | writes 346 skills, names the five, exit 0 |
| Still-registered skill vanishes (2026-08-03 shape) | refuses | **still refuses**, exit 1 |
| `components.d` parse returns empty | n/a | all removals block — guard not disabled |

Confirmed the corrected output keeps `-smoke`/`-e2e` (still registered, handled separately in #540) and includes the newly synced `i4h-workflow-train-rl`.

27 tests pass, including five new ones pinning both directions.

`versions.json` itself is deliberately not touched here — the bot regenerates it with AI enrichment, which is required for skill classification, once this lands.

## Test plan

- [ ] Post-merge regeneration completes and refreshes #539 with correct content
- [ ] A future deregistration (e.g. #540's `-smoke`/`-e2e`) no longer wedges the hourly run