### PR TITLE
chore: ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ credentials.json
 # Local configuration
 *.local
 *.local.*
+
+# Python bytecode
+# generate_versions.py imports aggregate_benchmarks, so any script run writes
+# a __pycache__ next to the sources. The regeneration bot commits whatever is
+# in the tree, which is how a .pyc reached PR #539.
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (repo hygiene)

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).

## Other context

#542 made `generate_versions.py` import `aggregate_benchmarks` so both share one `registered_catalog_dirs()` helper. Python writes bytecode on import, and `.gitignore` covered editor files, `.env` and keys but not `__pycache__`.

The regeneration bot commits whatever is in the working tree, so the next run added a binary artifact to the metadata PR:

```
ADDED .github/scripts/__pycache__/aggregate_benchmarks.cpython-314.pyc
```

That is in #539 right now and should not be merged into the catalog.

Ignoring `__pycache__/` and `*.py[cod]` covers any future script import rather than just this file. Verified locally: creating the exact path the bot picked up now produces no untracked entry.

Sequence: merge this, re-dispatch the regeneration so #539 refreshes without the `.pyc`, then merge #539.

## Test plan

- [ ] Re-dispatched regeneration produces a #539 containing only the four generated JSON files