### PR TITLE
Add nemo-retriever-mcp to nemo-retriever.yml

### DIFF
--- a/components.d/nemo-retriever.yml
+++ b/components.d/nemo-retriever.yml
@@ -6,3 +6,5 @@ description: NeMo Retriever - deploy NeMo Retriever Library locally, extract inf
 skills:
   - path: skills/nemo-retriever/
     catalog_dir: nemo-retriever
+  - path: skills/nemo-retriever-mcp/
+    catalog_dir: nemo-retriever-mcp


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 -->
<!-- Copyright (c) 2026 NVIDIA Corporation. All rights reserved. -->

## Onboarding type

- [ ] New product onboarding (new `components.d/<slug>.yml` file)
- [x] Other (catalog change, README fix, infrastructure, etc.)

## For new product onboarding — author affirmations

By submitting this PR, I confirm on behalf of my team:

- [x] **Skills cleared for open source release** by the owning team, with all required approvals in place
- [x] **License selected:** Apache 2.0 / CC-BY 4.0 / Dual (Apache 2.0 + CC-BY 4.0). Specify: _____
- [x] **No new license or new third-party component** introduced beyond what the source repo already carries
- [x] **Source repo is public and under an NVIDIA-owned GitHub org**
- [x] `.agents/skills/` or `skills/` path used for new entries (or existing path retained for legacy entries per `components.d/<slug>.yml`)

## Reviewer checklist (OSS Skills PIC)

- [ ] Author confirmations above are checked
- [ ] `components.d/<slug>.yml` entry valid (required fields, unique `catalog_dir`, path exists in source repo, filename slug matches name)
- [ ] `SKILL.md` frontmatter spec-compliant (at least one sampled)
- [ ] No new license or third-party dependency introduced

## All PRs

- [x] All commits signed off with DCO (`git commit -s`).
      If you forgot, run `git rebase --signoff origin/main && git push --force-with-lease` to retroactively sign all commits in your branch.

## Other context (for non-onboarding PRs)

Adds `nemo-retriever-mcp` as a second skill under the existing NeMo Retriever component. The signed source artifacts are available under `skills/nemo-retriever-mcp/` in NVIDIA/NeMo-Retriever.

<!-- Brief description of the change -->
